### PR TITLE
Make solo trigger activations use non-reliable packets

### DIFF
--- a/game_patch/object/trigger.cpp
+++ b/game_patch/object/trigger.cpp
@@ -23,7 +23,7 @@ void send_trigger_activate_packet(rf::Player* player, int trigger_uid, int32_t e
     packet.header.size = sizeof(packet) - sizeof(packet.header);
     packet.uid = trigger_uid;
     packet.entity_handle = entity_handle;
-    rf::multi_io_send_reliable(player, &packet, sizeof(packet), 0);
+    rf::multi_io_send(player, &packet, sizeof(packet));
 }
 
 FunHook<void(int, int)> send_trigger_activate_packet_to_all_players_hook{


### PR DESCRIPTION
Normal trigger activations are non-reliable. Reliable causes extreme network load and eventually DCs in MP servers with high server FPS and player standing in solo trigger with reset of 0.0s.

Not sure why this originally used reliable. My understanding (unconfirmed) is that PF did not do this. This change will need to be thoroughly tested before potential merge.