### PR TITLE
allow maps and af_game.tbl to override player headlamp settings

### DIFF
--- a/game_patch/main/main.cpp
+++ b/game_patch/main/main.cpp
@@ -31,6 +31,7 @@
 #include "../misc/alpine_options.h"
 #include "../misc/vpackfile.h"
 #include "../misc/high_fps.h"
+#include "../misc/player.h"
 #include "../input/input.h"
 #include "../rf/gr/gr.h"
 #include "../rf/multi.h"
@@ -175,6 +176,7 @@ FunHook<void(bool)> level_init_post_hook{
 
         process_queued_spawn_points_from_items();
         evaluate_fullbright_meshes();
+        update_player_flashlight();
         if (g_game_config.try_lightmaps_only) {
             evaluate_lightmaps_only();
         }

--- a/game_patch/misc/alpine_options.h
+++ b/game_patch/misc/alpine_options.h
@@ -18,6 +18,7 @@ void load_af_options_config();
 void load_level_info_config(const std::string& level_filename);
 std::string trim(const std::string& str); // unused?
 std::tuple<int, int, int, int> extract_color_components(uint32_t color);
+std::tuple<float, float, float, float> extract_normalized_color_components(uint32_t color);
 
 // ======= Alpine options =======
 enum class AlpineOptionID
@@ -53,6 +54,9 @@ enum class AlpineOptionID
     MultiplayerWalkSpeed,
     MultiplayerCrouchWalkSpeed,
     WalkableSlopeThreshold,
+    PlayerHeadlampColor,
+    PlayerHeadlampRange,
+    PlayerHeadlampRadius,
     _optioncount // dummy for total count
 };
 

--- a/game_patch/misc/player.h
+++ b/game_patch/misc/player.h
@@ -33,3 +33,4 @@ struct PlayerAdditionalData
 
 void find_player(const StringMatcher& query, std::function<void(rf::Player*)> consumer);
 PlayerAdditionalData& get_player_additional_data(rf::Player* player);
+void update_player_flashlight();

--- a/game_patch/rf/player/player.h
+++ b/game_patch/rf/player/player.h
@@ -17,7 +17,18 @@ namespace rf
     struct AiInfo;
     struct Camera;
 
-    /* Settings */   
+    /* Settings */
+
+    struct PlayerHeadlampSettings
+    {
+        float r;
+        float g;
+        float b;
+        float intensity;
+        float base_radius;
+        float max_range;
+        int attenuation_algorithm;
+    };
 
     struct PlayerSettings
     {


### PR DESCRIPTION
Allows 

`$Player Headlamp Color: 
$Player Headlamp Radius: 
$Player Headlamp Range: `

to be loaded from MAPNAME_info.tbl and af_game.tbl. Headlamp settings are used in the following order:
- If MAPNAME_info.tbl specifies it, use that.
- else if af_game.tbl specifies it, use that.
- else use the default values that I've set in code.

Fixes #43 