### PR TITLE
Add toggle for visual bullet ricochets in multiplayer

### DIFF
--- a/common/include/common/config/GameConfig.h
+++ b/common/include/common/config/GameConfig.h
@@ -90,6 +90,7 @@ struct GameConfig
     static const char default_rf_tracker[];
     CfgVar<std::string> tracker{default_rf_tracker};
     CfgVar<unsigned> server_netfps = 30;
+    CfgVar<bool> multi_ricochet = false;
 
     static constexpr unsigned default_update_rate = 200000; // T1/LAN in stock launcher
     CfgVar<unsigned> update_rate = default_update_rate;

--- a/common/src/config/GameConfig.cpp
+++ b/common/src/config/GameConfig.cpp
@@ -197,6 +197,7 @@ bool GameConfig::visit_vars(T&& visitor, bool is_save)
     result &= visitor(dash_faction_key, "Alpine Branding", af_branding);
     result &= visitor(dash_faction_key, "FFLink Token", fflink_token);
     result &= visitor(dash_faction_key, "FFLink Username", fflink_username);
+    result &= visitor(dash_faction_key, "Multi Ricochet", multi_ricochet);
 
     return result;
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -128,6 +128,7 @@ Version 1.0.0 (Maple)
 - Add `$Flag Dropping` svar to control whether flags can be dropped
 - Fixed shotgun (and potentially other weapons) dealing no damage in multiplayer if fired immediately after reloading
 - Add `mp_notifyonjoin` command
+- Add `mp_ricochet` command
 
 [@natarii](https://github.com/natarii)
 - Fix music desyncing when entering menus in multiplayer


### PR DESCRIPTION
Adds `mp_ricochet` setting (defaults false)

If true, bullet ricochets are enabled in multiplayer. Strictly visual, they deal no damage regardless

Fixes #61