### PR TITLE
Make semi automatic weapon fire rate in RF work like other games

### DIFF
--- a/common/include/common/config/GameConfig.h
+++ b/common/include/common/config/GameConfig.h
@@ -117,6 +117,7 @@ struct GameConfig
     CfgVar<bool> reduced_speed_in_background = false;
     CfgVar<bool> player_join_beep = false;
     CfgVar<bool> autosave = true;
+    CfgVar<bool> unlimited_semi_auto = false;
 
     // Internal
     CfgVar<std::string> alpine_faction_version{""};

--- a/common/src/config/GameConfig.cpp
+++ b/common/src/config/GameConfig.cpp
@@ -215,6 +215,7 @@ bool GameConfig::visit_vars(T&& visitor, bool is_save)
     result &= visitor(dash_faction_key, "FFLink Token", fflink_token);
     result &= visitor(dash_faction_key, "FFLink Username", fflink_username);
     result &= visitor(dash_faction_key, "Multi Ricochet", multi_ricochet);
+    result &= visitor(dash_faction_key, "Unlimited Semi Auto", unlimited_semi_auto);
 
     return result;
 }

--- a/game_patch/multi/multi.h
+++ b/game_patch/multi/multi.h
@@ -84,11 +84,13 @@ struct DashFactionServerInfo
     uint8_t version_minor = 0;
     bool saving_enabled = false;
     std::optional<float> max_fov;
-    bool allow_fb_mesh = true;
-    bool allow_lmap = true;
-    bool allow_no_ss = true;
+    bool allow_fb_mesh = false;
+    bool allow_lmap = false;
+    bool allow_no_ss = false;
     bool no_player_collide = false;
-    bool allow_no_mf = true;
+    bool allow_no_mf = false;
+    bool click_limit = false;
+    std::optional<int> semi_auto_cooldown;
 };
 
 void multi_level_download_update();

--- a/game_patch/multi/multi.h
+++ b/game_patch/multi/multi.h
@@ -105,3 +105,4 @@ void multi_ban_apply_patch();
 void server_set_player_weapon(rf::Player* pp, rf::Entity* ep, int weapon_type);
 void start_level_in_multi(std::string filename);
 std::optional<std::string> multi_ban_unban_last();
+int get_semi_auto_fire_wait_override();

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -305,7 +305,7 @@ void parse_miscellaneous_options(rf::Parser& parser) {
     parse_boolean_option(parser, "$No Player Collide:", g_additional_server_config.no_player_collide, "No Player Collide");
     parse_boolean_option(parser, "$Dynamic Rotation:", g_additional_server_config.dynamic_rotation, "Dynamic Rotation");
     parse_boolean_option(parser, "$Require Client Mod:", g_additional_server_config.require_client_mod, "Clients Require Mod");
-    parse_int_option(parser, "$Semi Auto Minimum Fire Wait:", g_additional_server_config.click_limiter_fire_wait, "Semi Auto Minimum Fire Wait");
+    //parse_int_option(parser, "$Semi Auto Minimum Fire Wait:", g_additional_server_config.click_limiter_fire_wait, "Semi Auto Minimum Fire Wait");
     parse_float_option(parser, "$Player Damage Modifier:", g_additional_server_config.player_damage_modifier, "Player Damage Modifier");
     parse_boolean_option(parser, "$UPnP Enabled:", g_additional_server_config.upnp_enabled, "UPnP Enabled");
     parse_boolean_option(parser, "$Send Player Stats Message:", g_additional_server_config.stats_message_enabled, "Send Player Stats Message");
@@ -316,6 +316,7 @@ void parse_miscellaneous_options(rf::Parser& parser) {
     parse_boolean_option(parser, "$Allow Lightmaps Only Mode:", g_additional_server_config.allow_lightmaps_only, "Allow Lightmaps Only Mode");
     parse_boolean_option(parser, "$Allow Disable Screenshake:", g_additional_server_config.allow_disable_screenshake, "Allow Disable Screenshake");
     parse_boolean_option(parser, "$Allow Disable Muzzle Flash Lights:", g_additional_server_config.allow_disable_muzzle_flash, "Allow Disable Muzzle Flash Lights");
+    //parse_boolean_option(parser, "$Enforce Semi Auto Fire Rate Limit:", g_additional_server_config.apply_click_limiter, "Semi Auto Fire Rate Limit");
 
     if (parser.parse_optional("$Welcome Message:")) {
         rf::String welcome_message;
@@ -377,8 +378,21 @@ void load_additional_server_config(rf::Parser& parser) {
         float max_fov = parser.parse_float();
         if (max_fov > 0.0f) {
             g_additional_server_config.max_fov = {max_fov};
+            rf::console::print("Max FOV: {}", g_additional_server_config.max_fov.value_or(180));
         }
     }
+
+    if (parser.parse_optional("$Enforce Semi Auto Fire Rate Limit:")) {
+        g_additional_server_config.apply_click_limiter = parser.parse_bool();
+        rf::console::print("Enforce Semi Auto Fire Rate Limit: {}",
+                            g_additional_server_config.overtime.enabled ? "true" : "false");
+        if (parser.parse_optional("+Cooldown:")) {
+            int fire_wait = parser.parse_int();
+            g_additional_server_config.semi_auto_cooldown = {fire_wait};
+            rf::console::print("+Cooldown: {}", g_additional_server_config.semi_auto_cooldown.value_or(0));
+        }
+    }
+
 
     // Repeatable config
     parse_item_respawn_time_override(parser);
@@ -2223,6 +2237,11 @@ bool server_no_player_collide()
 bool server_allow_disable_muzzle_flash()
 {
     return g_additional_server_config.allow_disable_muzzle_flash;
+}
+
+bool server_apply_click_limiter()
+{
+    return g_additional_server_config.apply_click_limiter;
 }
 
 bool server_weapon_items_give_full_ammo()

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -305,7 +305,6 @@ void parse_miscellaneous_options(rf::Parser& parser) {
     parse_boolean_option(parser, "$No Player Collide:", g_additional_server_config.no_player_collide, "No Player Collide");
     parse_boolean_option(parser, "$Dynamic Rotation:", g_additional_server_config.dynamic_rotation, "Dynamic Rotation");
     parse_boolean_option(parser, "$Require Client Mod:", g_additional_server_config.require_client_mod, "Clients Require Mod");
-    //parse_int_option(parser, "$Semi Auto Minimum Fire Wait:", g_additional_server_config.click_limiter_fire_wait, "Semi Auto Minimum Fire Wait");
     parse_float_option(parser, "$Player Damage Modifier:", g_additional_server_config.player_damage_modifier, "Player Damage Modifier");
     parse_boolean_option(parser, "$UPnP Enabled:", g_additional_server_config.upnp_enabled, "UPnP Enabled");
     parse_boolean_option(parser, "$Send Player Stats Message:", g_additional_server_config.stats_message_enabled, "Send Player Stats Message");
@@ -316,7 +315,6 @@ void parse_miscellaneous_options(rf::Parser& parser) {
     parse_boolean_option(parser, "$Allow Lightmaps Only Mode:", g_additional_server_config.allow_lightmaps_only, "Allow Lightmaps Only Mode");
     parse_boolean_option(parser, "$Allow Disable Screenshake:", g_additional_server_config.allow_disable_screenshake, "Allow Disable Screenshake");
     parse_boolean_option(parser, "$Allow Disable Muzzle Flash Lights:", g_additional_server_config.allow_disable_muzzle_flash, "Allow Disable Muzzle Flash Lights");
-    //parse_boolean_option(parser, "$Enforce Semi Auto Fire Rate Limit:", g_additional_server_config.apply_click_limiter, "Semi Auto Fire Rate Limit");
 
     if (parser.parse_optional("$Welcome Message:")) {
         rf::String welcome_message;
@@ -373,7 +371,7 @@ void load_additional_server_config(rf::Parser& parser) {
     // Misc config
     parse_miscellaneous_options(parser);
 
-    // separate for now because it needs to use std::optional<float>
+    // separate for now because they need to use std::optional
     if (parser.parse_optional("$Max FOV:")) {
         float max_fov = parser.parse_float();
         if (max_fov > 0.0f) {

--- a/game_patch/multi/server.h
+++ b/game_patch/multi/server.h
@@ -16,6 +16,7 @@ bool server_allow_lightmaps_only();
 bool server_allow_disable_screenshake();
 bool server_no_player_collide();
 bool server_allow_disable_muzzle_flash();
+bool server_apply_click_limiter();
 void server_reliable_socket_ready(rf::Player* player);
 bool server_weapon_items_give_full_ammo();
 bool server_weapon_infinite_magazines();

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -137,6 +137,8 @@ struct ServerAdditionalConfig
     bool allow_lightmaps_only = true;
     bool allow_disable_screenshake = true;
     bool allow_disable_muzzle_flash = true;
+    bool apply_click_limiter = true;
+    std::optional<int> semi_auto_cooldown = 90;
     int anticheat_level = 0;
     int click_limiter_fire_wait = 50;
     bool stats_message_enabled = true;

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -140,7 +140,6 @@ struct ServerAdditionalConfig
     bool apply_click_limiter = true;
     std::optional<int> semi_auto_cooldown = 90;
     int anticheat_level = 0;
-    int click_limiter_fire_wait = 50;
     bool stats_message_enabled = true;
     bool drop_amps = false;
     bool dynamic_rotation = false;

--- a/game_patch/object/weapon.cpp
+++ b/game_patch/object/weapon.cpp
@@ -149,7 +149,7 @@ FunHook<bool(rf::Weapon*)> weapon_possibly_richochet {
     },
 };
 
-ConsoleCommand2 single_semi_auto_limit_cmd{
+ConsoleCommand2 unlimited_semi_auto_cmd{
     "sp_unlimitedsemiauto",
     []() {
         g_game_config.unlimited_semi_auto = !g_game_config.unlimited_semi_auto;
@@ -246,4 +246,5 @@ void apply_weapon_patches()
     // commands
     multi_ricochet_cmd.register_cmd();
     show_enemy_bullets_cmd.register_cmd();
+    unlimited_semi_auto_cmd.register_cmd();
 }


### PR DESCRIPTION
This PR modernizes semi automatic weapon fire behaviour. If enabled, the player is prevented from firing semi automatic weapons faster than the specified fire rate threshold. This does not cancel shots like previous attempts at click limiting functionality, it simply stops you from firing in the first place, meaning no ammo is wasted and you have immediate visual/auditory feedback as to what is happening (ie. the gun doesn't shoot). In multiplayer, whether this functionality is enforced at all, and if so, the specific threshold, are both configurable by the server. In single player, the player can turn it off (to restore legacy behaviour) if they choose.

Key elements:
1. Implement throttling to fire rate for semi automatic weapons. On by default in both SP and multi, with a default fire wait of 90ms (~11.1cps). Note in MP, the server you are in can control the specific maximum fire rate (or turn throttling off entirely). No throttling is applied if you join a server that either has turned throttling off or is running an older patch that doesn't have throttling to begin with.
2. Add `sp_unlimitedsemiauto` command to disable rate throttling (ie. restore legacy behaviour) in SP.
3. Add `$Enforce Semi Auto Fire Rate Limit` with configurable `+Cooldown` to dedicated server config. Defaults are true and 90ms.
4. Shifted previous server-side fire rate limit functionality (the one that prints chat messages when shots are cancelled) to instead be a sort of light anticheat measure designed to help prevent rapid fire cheats. A jitter threshold has also been implemented to help prevent shots being cancelled when they should not have been, especially in the event of extreme ping fluctuation.
5. Because the stock fire wait numbers for pistol/PR are so weird (500ms each), hacked a way to have the game use the custom defined value of 90ms instead of the stock values. If mod developers configure custom fire wait values for their semi automatic weapons, their configured values will be used instead.

Lastly, this does _not_ apply to enemy entities in single player. Their fire rate with semi automatic weapons is still determined using the stock game's logic.