### PR TITLE
Add `wait_for`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@ Version 1.3.0 (Bakeapple): Not yet released
 - Add `/coinflip` chat command
 
 [@is-this-c](https://github.com/is-this-c)
+- Replace `os_sleep` in `frametime_calculate` with `wait_for`
 - Add `Server version:` to a server's printed config
 - Default gore level to 1
 - Default `gibbing` to disabled for dedicated servers

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -23,7 +23,6 @@
 #include "alpine_packets.h"
 #include "multi.h"
 #include "../os/console.h"
-#include "../os/os.h"
 #include "../hud/hud.h"
 #include "../misc/player.h"
 #include "../misc/alpine_options.h"
@@ -227,7 +226,6 @@ void set_server_window_title() {
 void on_dedicated_server_launch_post() {
     initialize_game_info_server_flags(); // build global flags var used in game_info packets
     set_server_window_title();
-    set_dedicated_server_timer_frequency();
 }
 
 // should weapons drop on player death?

--- a/game_patch/os/frametime.cpp
+++ b/game_patch/os/frametime.cpp
@@ -232,10 +232,11 @@ ConsoleCommand2 speed_display_cmd{
 
 CallHook<void(int)> frametime_calculate_sleep_hook{
     0x005095B4,
-    [](int ms) {
+    [] (int ms) {
         --ms;
         if (ms > 0) {
-            frametime_calculate_sleep_hook.call_target(ms);
+            // `wait_for` is higher resolution than `Sleep`.
+            wait_for(static_cast<float>(ms));
         }
     },
 };

--- a/game_patch/os/os.h
+++ b/game_patch/os/os.h
@@ -8,7 +8,7 @@ void os_apply_patch();
 void frametime_render_ui();
 float get_maximum_fps();
 void apply_maximum_fps();
-void set_dedicated_server_timer_frequency();
+void wait_for(float ms);
 
 class HighResTimer {
     using clock = std::chrono::high_resolution_clock;

--- a/game_patch/os/timer.cpp
+++ b/game_patch/os/timer.cpp
@@ -6,6 +6,10 @@
 #include "../rf/os/timer.h"
 
 void wait_for(const float ms) {
+    if (ms <= .0f) {
+        return;
+    }
+
     // Should be a resolution of 500 us.
     thread_local const HANDLE timer = CreateWaitableTimerExA(
         nullptr,

--- a/game_patch/os/timer.cpp
+++ b/game_patch/os/timer.cpp
@@ -16,6 +16,7 @@ void wait_for(const float ms) {
 
     if (!timer) {
         ERR_ONCE("CreateWaitableTimerExA in wait_for failed ({})", GetLastError());
+    SLEEP:
         static const MMRESULT res = timeBeginPeriod(1);
         if (res != TIMERR_NOERROR) {
             ERR_ONCE(
@@ -23,7 +24,6 @@ void wait_for(const float ms) {
                 res
             );
         }
-    SLEEP:
         Sleep(static_cast<DWORD>(ms));
     } else {
         // `SetWaitableTimer` requires 100-nanosecond intervals.
@@ -39,6 +39,7 @@ void wait_for(const float ms) {
 
         if (WaitForSingleObject(timer, INFINITE) != WAIT_OBJECT_0) {
             ERR_ONCE("WaitForSingleObject in wait_for failed ({})", GetLastError());
+            goto SLEEP;
         }
     }
 }

--- a/game_patch/os/timer.cpp
+++ b/game_patch/os/timer.cpp
@@ -7,7 +7,7 @@
 
 void wait_for(const float ms) {
     // Should be a resolution of 500 us.
-    static thread_local HANDLE timer = CreateWaitableTimerExA(
+    thread_local const HANDLE timer = CreateWaitableTimerExA(
         nullptr,
         nullptr,
         CREATE_WAITABLE_TIMER_HIGH_RESOLUTION,
@@ -16,7 +16,7 @@ void wait_for(const float ms) {
 
     if (!timer) {
         ERR_ONCE("CreateWaitableTimerExA in wait_for failed ({})", GetLastError());
-        static MMRESULT res = timeBeginPeriod(1);
+        static const MMRESULT res = timeBeginPeriod(1);
         if (res != TIMERR_NOERROR) {
             ERR_ONCE(
                 "The frame rate may be unstable, because timeBeginPeriod failed ({})",

--- a/game_patch/os/timer.cpp
+++ b/game_patch/os/timer.cpp
@@ -19,7 +19,7 @@ void wait_for(const float ms) {
         static MMRESULT res = timeBeginPeriod(1);
         if (res != TIMERR_NOERROR) {
             ERR_ONCE(
-                "The server frame rate may be unstable, because timeBeginPeriod failed ({})",
+                "The frame rate may be unstable, because timeBeginPeriod failed ({})",
                 res
             );
         }


### PR DESCRIPTION
No need to change timer resolution.

@nickalreadyinuse BTW

> Starting with Windows 11, if a window-owning process becomes fully occluded, minimized, or otherwise invisible or inaudible to the end user, Windows does not guarantee a higher resolution than the default system resolution. See [SetProcessInformation](https://learn.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-setprocessinformation) for more information on this behavior.