### PR TITLE
Render movers and meshes in skyboxes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ Version 1.3.0 (Bakeapple): Not yet released
   - Add GPU accelerated per-pixel lighting for meshes (Direct3D 11 renderer only)
   - Add full mesh shadows for entities, corpses, and items
   - Support `Alpha` field in `Decal` objects placed in version >= 304 levels
+  - Support movers, meshes, and mesh pixel lighting in skyboxes
 - Expanded destruction capabilities available to developers
   - `Brush-based geomod` switch added to level properties; if true, use level hardness for geoable brushes (RF2-style)
   - Geo regions allow traditional world-based geomod to be used even when brush-based switch is true

--- a/game_patch/graphics/d3d11/gr_d3d11.cpp
+++ b/game_patch/graphics/d3d11/gr_d3d11.cpp
@@ -520,10 +520,10 @@ namespace df::gr::d3d11
         solid_renderer_->render_alpha_detail(room, solid);
     }
 
-    void Renderer::render_sky_room(rf::GRoom *room)
+    void Renderer::render_sky_room(rf::GRoom *room, rf::Vector3& out_sky_transform_pos, rf::Matrix3& out_sky_transform_orient)
     {
         dyn_geo_renderer_->flush();
-        solid_renderer_->render_sky_room(room);
+        solid_renderer_->render_sky_room(room, out_sky_transform_pos, out_sky_transform_orient);
     }
 
     void Renderer::render_room_liquid_surface(rf::GSolid* solid, rf::GRoom* room)

--- a/game_patch/graphics/d3d11/gr_d3d11.h
+++ b/game_patch/graphics/d3d11/gr_d3d11.h
@@ -70,7 +70,7 @@ namespace df::gr::d3d11
         void render_solid(rf::GSolid* solid, rf::GRoom** rooms, int num_rooms);
         void render_movable_solid(rf::GSolid* solid, const rf::Vector3& pos, const rf::Matrix3& orient);
         void render_alpha_detail_room(rf::GRoom *room, rf::GSolid *solid);
-        void render_sky_room(rf::GRoom *room);
+        void render_sky_room(rf::GRoom *room, rf::Vector3& out_sky_transform_pos, rf::Matrix3& out_sky_transform_orient);
         void render_room_liquid_surface(rf::GSolid* solid, rf::GRoom* room);
         void clear_solid_cache();
         void reset_solid_cache_after_boolean();

--- a/game_patch/graphics/d3d11/gr_d3d11_hooks.cpp
+++ b/game_patch/graphics/d3d11/gr_d3d11_hooks.cpp
@@ -15,6 +15,8 @@
 #include "../../rf/level.h"
 #include "../../rf/geometry.h"
 #include "../../rf/mover.h"
+#include "../../rf/object.h"
+#include "../../rf/vmesh.h"
 #include "../../bmpman/bmpman.h"
 #include "../../main/main.h"
 #include "../../misc/misc.h"
@@ -42,6 +44,10 @@ namespace df::gr::d3d11
     // Local working buffer for gathered lights. Preserves dynamic-light results
     // while running the static-light pass, then overwrites the globals for GPU upload.
     static rf::gr::Light* gathered_lights[rf::gr::max_relevant_lights];
+
+    // When true, render_v3d_vif/render_character_vif skip automatic light gathering.
+    // Used by sky room mesh rendering which pre-gathers lights at the untransformed position.
+    static bool skip_mesh_light_gather = false;
 
     static void gather_mesh_lights(const rf::Vector3& pos, float mesh_radius = 0.0f)
     {
@@ -365,14 +371,85 @@ namespace df::gr::d3d11
 
     void render_sky_room(rf::GRoom *room)
     {
-        renderer->render_sky_room(room);
+        if (!room) {
+            return;
+        }
+
+        // Render sky room geometry and movers; get the computed sky transform back
+        rf::Vector3 sky_transform_pos;
+        rf::Matrix3 sky_transform_orient;
+        renderer->render_sky_room(room, sky_transform_pos, sky_transform_orient);
+
+        // Gather lights once for the sky room and build transformed copies.
+        // Filter to only lights within the sky room's bounding box.
+        // All meshes in the same sky room share the same light set.
+        constexpr int max_sky_lights = 32;
+        rf::gr::Light sky_light_copies[max_sky_lights];
+        rf::gr::Light* sky_light_ptrs[max_sky_lights];
+        int sky_light_count = 0;
+
+        gather_mesh_lights(rf::Vector3{
+            (room->bbox_min.x + room->bbox_max.x) * 0.5f,
+            (room->bbox_min.y + room->bbox_max.y) * 0.5f,
+            (room->bbox_min.z + room->bbox_max.z) * 0.5f});
+
+        for (int i = 0; i < rf::gr::num_relevant_lights && sky_light_count < max_sky_lights; ++i) {
+            rf::gr::Light* light = rf::gr::relevant_lights[i];
+            if (light->vec.x < room->bbox_min.x || light->vec.x > room->bbox_max.x ||
+                light->vec.y < room->bbox_min.y || light->vec.y > room->bbox_max.y ||
+                light->vec.z < room->bbox_min.z || light->vec.z > room->bbox_max.z) {
+                continue;
+            }
+            sky_light_copies[sky_light_count] = *light;
+            sky_light_copies[sky_light_count].vec = sky_transform_orient.transform_vector(light->vec) + sky_transform_pos;
+            sky_light_copies[sky_light_count].vec2 = sky_transform_orient.transform_vector(light->vec2) + sky_transform_pos;
+            sky_light_copies[sky_light_count].spotlight_dir = sky_transform_orient.transform_vector(light->spotlight_dir);
+            sky_light_ptrs[sky_light_count] = &sky_light_copies[sky_light_count];
+            sky_light_count++;
+        }
+        rf::gr::light_filter_reset();
+
+        // Render meshes (entities, clutter, items, etc.) that are in the sky room
+        for (rf::Object* obj = rf::object_list.next_obj; obj != &rf::object_list; obj = obj->next_obj) {
+            if (!obj->vmesh || obj->room != room) {
+                continue;
+            }
+            if (obj->obj_flags & rf::OF_HIDDEN) {
+                continue;
+            }
+            if (obj->type == rf::OT_MOVER_BRUSH) {
+                continue;
+            }
+
+            // Set pre-built sky room lights for this mesh
+            std::memcpy(rf::gr::relevant_lights, sky_light_ptrs, sky_light_count * sizeof(rf::gr::Light*));
+            rf::gr::num_relevant_lights = sky_light_count;
+            skip_mesh_light_gather = true;
+
+            rf::MeshRenderParams render_params{};
+            render_params.init_defaults();
+            render_params.flags = rf::MRF_CLIP_VERTICES;
+            render_params.vertex_colors = reinterpret_cast<rf::ubyte*>(obj->mesh_lighting_data);
+            if (room->ambient_light_defined) {
+                render_params.flags |= rf::MRF_CUSTOM_AMBIENT_COLOR;
+                render_params.ambient_color = room->ambient_light;
+            }
+
+            rf::Vector3 transformed_pos = sky_transform_orient.transform_vector(obj->pos) + sky_transform_pos;
+            rf::Matrix3 transformed_orient = sky_transform_orient;
+            transformed_orient.mul(obj->orient);
+            rf::vmesh_render(obj->vmesh, &transformed_pos, &transformed_orient, &render_params);
+
+            skip_mesh_light_gather = false;
+            renderer->clear_mesh_lights();
+        }
     }
 
     void render_v3d_vif(rf::VifLodMesh *lod_mesh, [[maybe_unused]] rf::VifMesh *mesh, const rf::Vector3& pos, const rf::Matrix3& orient, int lod_index, const rf::MeshRenderParams& params)
     {
         if (lod_mesh && lod_index >= 0 && lod_index < lod_mesh->num_levels && !level_uses_vertex_lighting()) {
             bool lights_gathered = false;
-            if (rf::level.geometry) {
+            if (rf::level.geometry && !skip_mesh_light_gather) {
                 gather_mesh_lights(pos, lod_mesh->radius);
                 lights_gathered = true;
             }
@@ -429,7 +506,7 @@ namespace df::gr::d3d11
             // Skip when using vertex lighting — the old path doesn't need gathered lights.
             bool is_first_person = (params.flags & rf::MeshRenderFlags::MRF_FIRST_PERSON) != 0;
             bool lights_gathered = false;
-            if (!use_vertex_lighting && rf::level.geometry) {
+            if (!use_vertex_lighting && rf::level.geometry && !skip_mesh_light_gather) {
                 gather_mesh_lights(pos, lod_mesh->radius);
                 lights_gathered = true;
             }

--- a/game_patch/graphics/d3d11/gr_d3d11_solid.cpp
+++ b/game_patch/graphics/d3d11/gr_d3d11_solid.cpp
@@ -38,9 +38,6 @@ namespace df::gr::d3d11
     static auto& gr_solid_alpha_mode = addr_as_ref<gr::Mode>(0x0180832C);
     static auto& geo_cache_rooms = addr_as_ref<GRoom*[256]>(0x01375DB4);
     static auto& geo_cache_num_rooms = addr_as_ref<int>(0x013761B8);
-    static auto& sky_room_center = addr_as_ref<Vector3>(0x0088FB10);
-    static auto& sky_room_offset = addr_as_ref<Vector3>(0x0087BB00);
-    static auto& sky_room_orient = addr_as_ref<Matrix3*>(0x009BB56C);
 
     static auto& set_currently_rendered_room = addr_as_ref<void (GRoom *room)>(0x004D3350);
 
@@ -817,26 +814,24 @@ namespace df::gr::d3d11
         }
     }
 
-    void SolidRenderer::render_sky_room(GRoom *room)
+    void SolidRenderer::render_sky_room(GRoom *room, Vector3& out_sky_transform_pos, Matrix3& out_sky_transform_orient)
     {
         xlog::trace("Rendering sky room {} cache {}", room->room_index, room->geo_cache);
         render_context_.update_lights(true);
 
         // Compute sky room transform: maps world coords to camera-relative coords
-        Vector3 sky_transform_pos;
-        Matrix3 sky_transform_orient;
         if (const Matrix3* skybox_orient = sky_room_orient) {
-            sky_transform_orient = *skybox_orient;
-            sky_transform_orient.inverse();
-            const Vector3 rotated_center = sky_transform_orient.transform_vector(sky_room_center);
-            sky_transform_pos = sky_room_offset + sky_room_center - rotated_center;
+            out_sky_transform_orient = *skybox_orient;
+            out_sky_transform_orient.inverse();
+            const Vector3 rotated_center = out_sky_transform_orient.transform_vector(sky_room_center);
+            out_sky_transform_pos = sky_room_offset + sky_room_center - rotated_center;
         }
         else {
-            sky_transform_pos = sky_room_offset;
-            sky_transform_orient = rf::identity_matrix;
+            out_sky_transform_pos = sky_room_offset;
+            out_sky_transform_orient = rf::identity_matrix;
         }
 
-        before_render(sky_transform_pos, sky_transform_orient);
+        before_render(out_sky_transform_pos, out_sky_transform_orient);
         render_room_faces(rf::level.geometry, room, FaceRenderType::opaque);
         render_room_faces(rf::level.geometry, room, FaceRenderType::alpha);
 
@@ -849,8 +844,8 @@ namespace df::gr::d3d11
                 continue;
             }
             // Transform mover position and orientation by the sky room transform
-            Vector3 transformed_pos = sky_transform_orient.transform_vector(mb.pos) + sky_transform_pos;
-            Matrix3 transformed_orient = sky_transform_orient;
+            Vector3 transformed_pos = out_sky_transform_orient.transform_vector(mb.pos) + out_sky_transform_pos;
+            Matrix3 transformed_orient = out_sky_transform_orient;
             transformed_orient.mul(mb.orient);
 
             GRenderCache* cache = get_or_create_movable_solid_cache(mb.geometry);

--- a/game_patch/graphics/d3d11/gr_d3d11_solid.h
+++ b/game_patch/graphics/d3d11/gr_d3d11_solid.h
@@ -32,7 +32,7 @@ namespace df::gr::d3d11
         ~SolidRenderer();
         void render_solid(rf::GSolid* solid, rf::GRoom** rooms, int num_rooms);
         void render_movable_solid(rf::GSolid* solid, const rf::Vector3& pos, const rf::Matrix3& orient);
-        void render_sky_room(rf::GRoom *room);
+        void render_sky_room(rf::GRoom *room, rf::Vector3& out_sky_transform_pos, rf::Matrix3& out_sky_transform_orient);
         void render_alpha_detail(rf::GRoom *room, rf::GSolid *solid);
         void render_room_liquid_surface(rf::GSolid* solid, rf::GRoom* room);
         void clear_cache();

--- a/game_patch/rf/geometry.h
+++ b/game_patch/rf/geometry.h
@@ -527,6 +527,11 @@ namespace rf
     static auto& g_cache_clear = addr_as_ref<void()>(0x004F0B90);
     static auto& g_get_room_render_list = addr_as_ref<void(GRoom ***rooms, int *num_rooms)>(0x004D3330);
 
+    // Sky room rendering globals (set by stock engine before sky room render call)
+    static auto& sky_room_center = addr_as_ref<Vector3>(0x0088FB10);
+    static auto& sky_room_offset = addr_as_ref<Vector3>(0x0087BB00);
+    static auto& sky_room_orient = addr_as_ref<Matrix3*>(0x009BB56C);
+
     static auto& g_solid_load_v3d_embedded = addr_as_ref<GSolid*(const char*)>(0x00586E70);
     static auto& g_solid_load_v3d = addr_as_ref<GSolid*(const char*)>(0x00586F5C);
 

--- a/game_patch/rf/v3d.h
+++ b/game_patch/rf/v3d.h
@@ -138,6 +138,20 @@ namespace rf
         int powerup_bitmaps[2];
         gr::Color ambient_color;
         Matrix3 orient;
+
+        // Initialize to stock defaults (matches FUN_00500fb0)
+        void init_defaults()
+        {
+            flags = 0;
+            lod_level = -1;
+            alpha = 255;
+            alt_tex = nullptr;
+            field_14_unk_fire = -1.0f;
+            vertex_colors = nullptr;
+            powerup_bitmaps[0] = -1;
+            powerup_bitmaps[1] = -1;
+            orient.make_identity();
+        }
     };
 
     enum MeshRenderFlags

--- a/game_patch/rf/vmesh.h
+++ b/game_patch/rf/vmesh.h
@@ -6,6 +6,7 @@
 namespace rf
 {
     struct GRoom;
+    struct MeshRenderParams;
 
     enum VMeshType
     {
@@ -106,6 +107,7 @@ namespace rf
     static auto& vmesh_play_action_by_index = addr_as_ref<void(VMesh* vmesh, int action_index, float transition_time, int hold_last_frame)>(0x005033B0);
     static auto& vmesh_stop_all_actions = addr_as_ref<void(VMesh* vmesh)>(0x00503400);
     static auto& vmesh_get_materials_array = addr_as_ref<void(VMesh *vmesh, int *num_materials_out, MeshMaterial **materials_array_out)>(0x00503650);
+    static auto& vmesh_render = addr_as_ref<void(VMesh* vmesh, Vector3* pos, Matrix3* orient, MeshRenderParams* params)>(0x00503100);
     static auto& vmesh_process = addr_as_ref<void(VMesh* vmesh, float frametime, int increment_only, Vector3* pos, Matrix3* orient, int lod_level)>(0x00503360);
 
     // character_mesh_load_action: __thiscall on mesh_data (VMesh::mesh), loads .rfa animation file


### PR DESCRIPTION
- Support movers, meshes, and mesh pixel lighting in skyboxes

Partially implements #131 