### PR TITLE
Optimize mesh shadows

### DIFF
--- a/game_patch/graphics/d3d11/gr_d3d11_entity_shadow.cpp
+++ b/game_patch/graphics/d3d11/gr_d3d11_entity_shadow.cpp
@@ -378,9 +378,78 @@ namespace df::gr::d3d11
         // Check if quality changed (e.g. via console command)
         if (quality != current_quality_) {
             apply_quality(quality);
+            last_shadow_render_frame_ = -1; // force re-render after texture recreation
         }
 
         current_camera_pos_ = camera_pos;
+
+        // Quick pre-scan: skip entire shadow pass if no casters are in range.
+        // Mirrors the same filters used by the actual render functions to avoid
+        // false positives (e.g. local player entity is always at distance 0).
+        {
+            int dp = std::clamp(g_alpine_game_config.shadow_distance, 0, num_shadow_distance_presets - 1);
+            float fade_end = shadow_distance_presets[dp].fade_end;
+            float fade_end_sq = fade_end * fade_end;
+            bool found_caster = false;
+
+            // Determine which entities to skip (matches render_entity_shadow)
+            int local_entity_handle = -1;
+            if (rf::local_player) {
+                local_entity_handle = rf::local_player->entity_handle;
+            }
+            int spectate_entity_handle = -1;
+            if (multi_spectate_is_first_person()) {
+                rf::Player* spectate_target = multi_spectate_get_target_player();
+                if (spectate_target) {
+                    spectate_entity_handle = spectate_target->entity_handle;
+                }
+            }
+
+            for (auto& entity : DoublyLinkedList{rf::entity_list}) {
+                if (entity.handle == local_entity_handle) continue;
+                if (entity.handle == spectate_entity_handle) continue;
+                if (entity.entity_flags2 & rf::EF2_NO_SHADOW) continue;
+                if (entity.obj_flags & (OF_DELAYED_DELETE | OF_HIDDEN)) continue;
+                if (!entity.vmesh) continue;
+                float dx = entity.pos.x - camera_pos.x;
+                float dy = entity.pos.y - camera_pos.y;
+                float dz = entity.pos.z - camera_pos.z;
+                if (dx * dx + dy * dy + dz * dz <= fade_end_sq) { found_caster = true; break; }
+            }
+
+            if (!found_caster && g_alpine_game_config.shadow_corpses) {
+                for (auto& corpse : DoublyLinkedList{rf::corpse_list}) {
+                    if (corpse.obj_flags & (OF_DELAYED_DELETE | OF_HIDDEN)) continue;
+                    if (!corpse.vmesh) continue;
+                    float dx = corpse.pos.x - camera_pos.x;
+                    float dy = corpse.pos.y - camera_pos.y;
+                    float dz = corpse.pos.z - camera_pos.z;
+                    if (dx * dx + dy * dy + dz * dz <= fade_end_sq) { found_caster = true; break; }
+                }
+            }
+
+            if (!found_caster && g_alpine_game_config.shadow_items) {
+                for (auto& item : DoublyLinkedList{rf::item_list}) {
+                    if (item.obj_flags & (OF_DELAYED_DELETE | OF_HIDDEN)) continue;
+                    if (!item.vmesh) continue;
+                    float dx = item.pos.x - camera_pos.x;
+                    float dy = item.pos.y - camera_pos.y;
+                    float dz = item.pos.z - camera_pos.z;
+                    if (dx * dx + dy * dy + dz * dz <= fade_end_sq) { found_caster = true; break; }
+                }
+            }
+
+            last_frame_had_casters_ = found_caster;
+            if (!found_caster) return;
+        }
+
+        // Frame lag: reuse the cached shadow map (and its VP matrix) if rendered recently enough
+        int frame_lag = std::clamp(g_alpine_game_config.shadow_frame_lag, 1, 30);
+        if (last_shadow_render_frame_ >= 0 &&
+            (rf::frame_count - last_shadow_render_frame_) < frame_lag) {
+            return;
+        }
+        last_shadow_render_frame_ = rf::frame_count;
 
         build_shadow_view_proj(context, camera_pos);
 
@@ -706,6 +775,11 @@ namespace df::gr::d3d11
 
         // Respect the stock game's ShowShadows toggle
         if (rf::local_player && !rf::local_player->settings.shadows_enabled) {
+            shadows_active = false;
+        }
+
+        // No casters were found in the pre-scan — disable shadow sampling
+        if (!last_frame_had_casters_) {
             shadows_active = false;
         }
 

--- a/game_patch/graphics/d3d11/gr_d3d11_entity_shadow.h
+++ b/game_patch/graphics/d3d11/gr_d3d11_entity_shadow.h
@@ -123,6 +123,8 @@ namespace df::gr::d3d11
         int current_quality_ = 2;
         int current_resolution_ = 1024;
         int last_frame_ = -1;
+        bool last_frame_had_casters_ = false;
+        int last_shadow_render_frame_ = -1;
 
         // Dynamic vertex buffer for VFX (MESH_TYPE_ANIM_FX) shadow geometry
         ComPtr<ID3D11Buffer> vfx_shadow_vb_;

--- a/game_patch/misc/alpine_settings.cpp
+++ b/game_patch/misc/alpine_settings.cpp
@@ -566,6 +566,10 @@ bool alpine_player_settings_load(rf::Player* player)
         g_alpine_game_config.set_shadow_quality(std::stoi(settings["ShadowQuality"]));
         processed_keys.insert("ShadowQuality");
     }
+    if (settings.count("ShadowFrameLag")) {
+        g_alpine_game_config.set_shadow_frame_lag(std::stoi(settings["ShadowFrameLag"]));
+        processed_keys.insert("ShadowFrameLag");
+    }
     if (settings.count("Outlines")) {
         g_alpine_game_config.try_outlines = std::stoi(settings["Outlines"]);
         processed_keys.insert("Outlines");
@@ -1341,6 +1345,7 @@ void alpine_player_settings_save(rf::Player* player)
     file << "ShadowItems=" << g_alpine_game_config.shadow_items << "\n";
     file << "ShadowDistance=" << g_alpine_game_config.shadow_distance << "\n";
     file << "ShadowQuality=" << g_alpine_game_config.shadow_quality << "\n";
+    file << "ShadowFrameLag=" << g_alpine_game_config.shadow_frame_lag << "\n";
     file << "Outlines=" << g_alpine_game_config.try_outlines << "\n";
     file << "OutlinesSpectator=" << g_alpine_game_config.outlines_spectator << "\n";
     file << "OutlinesTeamXray=" << g_alpine_game_config.try_outlines_team_xray << "\n";
@@ -1741,6 +1746,21 @@ ConsoleCommand2 shadow_quality_cmd{
     "r_shadowquality <0-5>",
 };
 
+ConsoleCommand2 shadow_frame_lag_cmd{
+    "r_shadowupdateinterval",
+    [](std::optional<int> value_opt) {
+        if (value_opt) {
+            g_alpine_game_config.set_shadow_frame_lag(value_opt.value());
+        }
+        rf::console::print("Shadow update interval: {} (shadow map refreshes every {} frame{})",
+            g_alpine_game_config.shadow_frame_lag,
+            g_alpine_game_config.shadow_frame_lag,
+            g_alpine_game_config.shadow_frame_lag == 1 ? "" : "s");
+    },
+    "Set shadow map update interval in frames (1=every frame, 2-30=reuse cached shadow map)",
+    "r_shadowupdateinterval <1-30>",
+};
+
 ConsoleCommand2 load_settings_cmd{
     "dbg_loadsettings",
     []() {
@@ -1779,6 +1799,7 @@ void alpine_settings_apply_patch()
     shadow_items_cmd.register_cmd();
     shadow_distance_cmd.register_cmd();
     shadow_quality_cmd.register_cmd();
+    shadow_frame_lag_cmd.register_cmd();
     dbg_shadows_cmd.register_cmd();
 
     // Init cmd line

--- a/game_patch/misc/alpine_settings.h
+++ b/game_patch/misc/alpine_settings.h
@@ -397,6 +397,11 @@ struct AlpineGameSettings
     {
         shadow_quality = std::clamp(value, 0, 5);
     }
+    int shadow_frame_lag = 1; // 1=every frame (default), 2-30=refresh every N frames
+    void set_shadow_frame_lag(int value)
+    {
+        shadow_frame_lag = std::clamp(value, 1, 30);
+    }
 };
 
 struct FpsCounterState

--- a/resources/shaders/standard_ps.hlsl
+++ b/resources/shaders/standard_ps.hlsl
@@ -269,82 +269,85 @@ float4 main(VsOutput input) : SV_TARGET
     target.rgb *= light_color;
 
     if (shadow_enabled > 0.5f) {
-        float3 world_pos = input.world_pos_and_depth.xyz;
-        float3 normal = normalize(input.norm);
+        // Early-out: skip all shadow work for fragments beyond the fade distance
+        float cam_dist = input.world_pos_and_depth.w;
+        float fade = 1.0f - saturate((cam_dist - shadow_fade_start) / (shadow_fade_end - shadow_fade_start));
 
-        // NdotL: how much the surface faces the light (light_dir points FROM light)
-        float NdotL = dot(normal, -shadow_light_dir);
+        if (fade > 0.0f) {
+            float3 world_pos = input.world_pos_and_depth.xyz;
+            float3 normal = normalize(input.norm);
 
-        // Smooth NdotL fade instead of hard cutoff
-        float ndotl_fade = saturate(NdotL * 5.0f);
+            // NdotL: how much the surface faces the light (light_dir points FROM light)
+            float NdotL = dot(normal, -shadow_light_dir);
 
-        if (ndotl_fade > 0.0f) {
-            // Normal offset bias scaled by angle to reduce self-shadowing
-            float bias_scale = saturate(1.0f - NdotL);
-            float3 biased_pos = world_pos + normal * shadow_normal_offset * (1.0f + bias_scale);
+            // Smooth NdotL fade instead of hard cutoff
+            float ndotl_fade = saturate(NdotL * 5.0f);
 
-            float4 shadow_pos = mul(float4(biased_pos, 1.0f), shadow_vp_mat);
-            float3 shadow_ndc = shadow_pos.xyz / shadow_pos.w;
-            float2 shadow_uv = shadow_ndc.xy * 0.5f + 0.5f;
-            shadow_uv.y = 1.0f - shadow_uv.y;
+            if (ndotl_fade > 0.0f) {
+                // Normal offset bias scaled by angle to reduce self-shadowing
+                float bias_scale = saturate(1.0f - NdotL);
+                float3 biased_pos = world_pos + normal * shadow_normal_offset * (1.0f + bias_scale);
 
-            float shadow_value = 1.0f;
-            float debug_proj_fade = 1.0f;
-            if (shadow_uv.x >= 0.0f && shadow_uv.x <= 1.0f && shadow_uv.y >= 0.0f && shadow_uv.y <= 1.0f) {
-                float spread = shadow_texel_size * 2.5f;
-                int extra_taps = (int)shadow_pcf_taps - 1;
+                float4 shadow_pos = mul(float4(biased_pos, 1.0f), shadow_vp_mat);
+                float3 shadow_ndc = shadow_pos.xyz / shadow_pos.w;
+                float2 shadow_uv = shadow_ndc.xy * 0.5f + 0.5f;
+                shadow_uv.y = 1.0f - shadow_uv.y;
 
-                // Receiver-side comparison bias
-                float z_compensation = shadow_normal_offset * (1.0f + bias_scale) * NdotL / shadow_depth_range;
-                float compare_depth = shadow_ndc.z + z_compensation;
+                float shadow_value = 1.0f;
+                float debug_proj_fade = 1.0f;
+                if (shadow_uv.x >= 0.0f && shadow_uv.x <= 1.0f && shadow_uv.y >= 0.0f && shadow_uv.y <= 1.0f) {
+                    float spread = shadow_texel_size * 2.5f;
+                    int extra_taps = (int)shadow_pcf_taps - 1;
 
-                // Per-pixel rotation angle to break up PCF banding on small shadows
-                float pcf_angle = frac(sin(dot(input.pos.xy * 0.5f, float2(12.9898f, 78.233f))) * 43758.5453f) * 6.28318530718f;
-                float pcf_cos = cos(pcf_angle);
-                float pcf_sin = sin(pcf_angle);
+                    // Receiver-side comparison bias
+                    float z_compensation = shadow_normal_offset * (1.0f + bias_scale) * NdotL / shadow_depth_range;
+                    float compare_depth = shadow_ndc.z + z_compensation;
 
-                float proj_fade_range = shadow_projection_fade_end - shadow_projection_fade_start;
+                    // Per-pixel rotation angle to break up PCF banding on small shadows
+                    float pcf_angle = frac(sin(dot(input.pos.xy * 0.5f, float2(12.9898f, 78.233f))) * 43758.5453f) * 6.28318530718f;
+                    float pcf_cos = cos(pcf_angle);
+                    float pcf_sin = sin(pcf_angle);
 
-                // Center tap
-                float center_depth = shadow_map.SampleLevel(shadow_depth_sampler, shadow_uv, 0).r;
-                float center_pd = saturate(shadow_ndc.z - center_depth) * shadow_depth_range;
-                float center_pf = 1.0f - saturate((center_pd - shadow_projection_fade_start) / proj_fade_range);
-                debug_proj_fade = center_pf;
-                float center_cmp = shadow_map.SampleCmpLevelZero(shadow_sampler, shadow_uv, compare_depth);
-                float shadow_sum = lerp(1.0f, lerp(shadow_strength, 1.0f, center_cmp), center_pf);
+                    float proj_fade_range = shadow_projection_fade_end - shadow_projection_fade_start;
 
-                // Early-out: skip extra taps if center is fully lit (no shadow nearby)
-                // Disabled when soft_edges is on (quality 5) for softer shadow boundaries
-                if (center_cmp >= 1.0f && extra_taps > 0 && shadow_soft_edges < 0.5f) {
-                    shadow_value = 1.0f;
-                } else {
-                    // Extra taps (PCF with Poisson disk + per-tap projection fade)
-                    for (int t = 0; t < extra_taps && t < 15; ++t) {
-                        float2 ofs = float2(pcf_offsets[t].x * pcf_cos - pcf_offsets[t].y * pcf_sin,
-                                            pcf_offsets[t].x * pcf_sin + pcf_offsets[t].y * pcf_cos);
-                        float2 tap_uv = shadow_uv + ofs * spread;
-                        float tap_depth = shadow_map.SampleLevel(shadow_depth_sampler, tap_uv, 0).r;
-                        float tap_pd = saturate(shadow_ndc.z - tap_depth) * shadow_depth_range;
-                        float tap_pf = 1.0f - saturate((tap_pd - shadow_projection_fade_start) / proj_fade_range);
-                        float tap_cmp = shadow_map.SampleCmpLevelZero(shadow_sampler, tap_uv, compare_depth);
-                        shadow_sum += lerp(1.0f, lerp(shadow_strength, 1.0f, tap_cmp), tap_pf);
+                    // Center tap
+                    float center_depth = shadow_map.SampleLevel(shadow_depth_sampler, shadow_uv, 0).r;
+                    float center_pd = saturate(shadow_ndc.z - center_depth) * shadow_depth_range;
+                    float center_pf = 1.0f - saturate((center_pd - shadow_projection_fade_start) / proj_fade_range);
+                    debug_proj_fade = center_pf;
+                    float center_cmp = shadow_map.SampleCmpLevelZero(shadow_sampler, shadow_uv, compare_depth);
+                    float shadow_sum = lerp(1.0f, lerp(shadow_strength, 1.0f, center_cmp), center_pf);
+
+                    // Early-out: skip extra taps if center is fully lit (no shadow nearby)
+                    // Disabled when soft_edges is on (quality 5) for softer shadow boundaries
+                    if (center_cmp >= 1.0f && extra_taps > 0 && shadow_soft_edges < 0.5f) {
+                        shadow_value = 1.0f;
+                    } else {
+                        // Extra taps (PCF with Poisson disk + per-tap projection fade)
+                        for (int t = 0; t < extra_taps && t < 15; ++t) {
+                            float2 ofs = float2(pcf_offsets[t].x * pcf_cos - pcf_offsets[t].y * pcf_sin,
+                                                pcf_offsets[t].x * pcf_sin + pcf_offsets[t].y * pcf_cos);
+                            float2 tap_uv = shadow_uv + ofs * spread;
+                            float tap_depth = shadow_map.SampleLevel(shadow_depth_sampler, tap_uv, 0).r;
+                            float tap_pd = saturate(shadow_ndc.z - tap_depth) * shadow_depth_range;
+                            float tap_pf = 1.0f - saturate((tap_pd - shadow_projection_fade_start) / proj_fade_range);
+                            float tap_cmp = shadow_map.SampleCmpLevelZero(shadow_sampler, tap_uv, compare_depth);
+                            shadow_sum += lerp(1.0f, lerp(shadow_strength, 1.0f, tap_cmp), tap_pf);
+                        }
+                        shadow_value = shadow_sum / shadow_pcf_taps;
                     }
-                    shadow_value = shadow_sum / shadow_pcf_taps;
                 }
-            }
 
-            float cam_dist = input.world_pos_and_depth.w;
-            float fade = 1.0f - saturate((cam_dist - shadow_fade_start) / (shadow_fade_end - shadow_fade_start));
-
-            if (shadow_debug > 0.5f) {
-                // Debug: Red = shadow darkening, Green = projection fade suppression (center tap)
-                float darken = (1.0f - shadow_value) * fade * ndotl_fade;
-                float proj_suppress = (1.0f - debug_proj_fade) * fade * ndotl_fade;
-                target.rgb *= 0.3f;
-                target.rgb += float3(darken * 1.5f, proj_suppress * 1.0f, 0.0f);
-            } else {
-                float final_shadow = lerp(1.0f, shadow_value, fade * ndotl_fade);
-                target.rgb *= final_shadow;
+                if (shadow_debug > 0.5f) {
+                    // Debug: Red = shadow darkening, Green = projection fade suppression (center tap)
+                    float darken = (1.0f - shadow_value) * fade * ndotl_fade;
+                    float proj_suppress = (1.0f - debug_proj_fade) * fade * ndotl_fade;
+                    target.rgb *= 0.3f;
+                    target.rgb += float3(darken * 1.5f, proj_suppress * 1.0f, 0.0f);
+                } else {
+                    float final_shadow = lerp(1.0f, shadow_value, fade * ndotl_fade);
+                    target.rgb *= final_shadow;
+                }
             }
         }
     }


### PR DESCRIPTION
- Early out GPU shadow mapping when no shadow sources are in range
- Skip projection and PCF sampling work when no shadow sources are in range
- Add `r_shadowupdateinterval` to hold cached shadow mapping across multiple frames and avoid per-frame calculations