### PR TITLE
Add new AF players packet struct for online RFSB

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -104,6 +104,7 @@ Version 1.3.0 (Bakeapple): Not yet released
 - Add `Gas_Region_State`, `Modify_Gas_Region`, `Resize_Gas_Region` events
 - Add `require_d3d11` to dedicated server config
 - Add `$Stock Alpha Test` to `af_level_quirks.tbl` and use to restore stock alpha test only on known affected levels
+- Serve player type, team, and score in `players_request` packet response (for online RFSB)
 
 [@is-this-c](https://github.com/is-this-c)
 - Use 64-bit integers for time deltas

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -104,7 +104,7 @@ Version 1.3.0 (Bakeapple): Not yet released
 - Add `Gas_Region_State`, `Modify_Gas_Region`, `Resize_Gas_Region` events
 - Add `require_d3d11` to dedicated server config
 - Add `$Stock Alpha Test` to `af_level_quirks.tbl` and use to restore stock alpha test only on known affected levels
-- Serve player type, team, and score in `players_request` packet response (for online RFSB)
+- Serve detailed player and server info in `players_request` packet response (for online FF RFSB)
 - Support 8-bit greyscale TGA textures (types 3 and 11) in editor and game
 
 [@is-this-c](https://github.com/is-this-c)

--- a/game_patch/multi/alpine_packets.cpp
+++ b/game_patch/multi/alpine_packets.cpp
@@ -9,6 +9,7 @@
 #include <common/rfproto.h>
 #include <xlog/xlog.h>
 #include "../rf/multi.h"
+#include "../rf/level.h"
 #include "../rf/player/player.h"
 #include "../rf/weapon.h"
 #include "multi.h"
@@ -2258,6 +2259,36 @@ void af_send_player_info_response(const rf::NetAddr& addr)
     static uint8_t next_response_id = 0;
     uint8_t response_id = next_response_id++;
 
+    uint32_t time_left_seconds = 0;
+    if (rf::multi_time_limit > 0.0f) {
+        float remaining = rf::multi_time_limit - rf::level.time;
+        if (remaining > 0.0f) {
+            time_left_seconds = static_cast<uint32_t>(remaining);
+        }
+    }
+
+    uint16_t red_score = 0;
+    uint16_t blue_score = 0;
+    if (multi_is_team_game_type()) {
+        switch (rf::netgame.type) {
+            case rf::NetGameType::NG_TYPE_CTF:
+                red_score = static_cast<uint16_t>(rf::multi_ctf_get_red_team_score());
+                blue_score = static_cast<uint16_t>(rf::multi_ctf_get_blue_team_score());
+                break;
+            case rf::NetGameType::NG_TYPE_TEAMDM:
+                red_score = static_cast<uint16_t>(rf::multi_tdm_get_red_team_score());
+                blue_score = static_cast<uint16_t>(rf::multi_tdm_get_blue_team_score());
+                break;
+            case rf::NetGameType::NG_TYPE_KOTH:
+            case rf::NetGameType::NG_TYPE_DC:
+                red_score = static_cast<uint16_t>(multi_koth_get_red_team_score());
+                blue_score = static_cast<uint16_t>(multi_koth_get_blue_team_score());
+                break;
+            default:
+                break;
+        }
+    }
+
     // Serialize all player entries into a flat buffer.
     // Per player: flags (1) + score (2) + name (len+1)
     // Name cannot realistically be longer than 20 characters,
@@ -2347,6 +2378,9 @@ void af_send_player_info_response(const rf::NetAddr& addr)
         hdr.response_id = response_id;
         hdr.sequence = static_cast<uint8_t>(seg);
         hdr.total_segments = static_cast<uint8_t>(total_segments);
+        hdr.red_score = red_score;
+        hdr.blue_score = blue_score;
+        hdr.time_left_seconds = time_left_seconds;
 
         std::memcpy(packet_buf, &hdr, header_size);
         if (payload_len > 0) {

--- a/game_patch/multi/alpine_packets.cpp
+++ b/game_patch/multi/alpine_packets.cpp
@@ -2290,17 +2290,31 @@ void af_send_player_info_response(const rf::NetAddr& addr)
         }
     }
 
-    // Serialize all player entries into a flat buffer.
+    // Serialize the logical payload into a flat buffer:
+    //   [payload_header][player entry 0][player entry 1]...
+    // which is then sliced into segments. The receiver reassembles by
+    // response_id and parses the header + entries.
     // Per player: flags (1) + score (2) + name (len+1)
     // Name cannot realistically be longer than 20 characters,
     // but wire protocol allows 31, so account for it
-    constexpr size_t max_players_data = 32 * (1 + 2 + 32);
+    constexpr size_t preamble_size = sizeof(af_player_info_payload_header);
+    constexpr size_t max_players_data = preamble_size + 32 * (1 + 2 + 32);
     std::byte players_data[max_players_data];
     int players_data_len = 0;
 
-    // Track where each player entry starts so we can chunk without splitting entries
-    int entry_offsets[33]; // max 32 players + sentinel
-    int entry_count = 0;
+    // Chunk 0 is the payload header; chunks 1..entry_count are player entries.
+    // The chunker keeps chunks intact per segment, so the preamble always lands
+    // entirely in segment 0.
+    int entry_offsets[34]; // preamble + max 32 players + sentinel
+    entry_offsets[0] = 0;
+    int entry_count = 1;
+
+    af_player_info_payload_header preamble{};
+    preamble.red_score = red_score;
+    preamble.blue_score = blue_score;
+    preamble.time_left_seconds = time_left_seconds;
+    std::memcpy(players_data, &preamble, preamble_size);
+    players_data_len = static_cast<int>(preamble_size);
 
     constexpr int max_players = 32;
     auto player_list = SinglyLinkedList(rf::player_list);
@@ -2308,7 +2322,7 @@ void af_send_player_info_response(const rf::NetAddr& addr)
         int name_len = player.name.size();
         int entry_size = 1 + 2 + name_len + 1; // flags + score + name + null
 
-        if (entry_count >= max_players ||
+        if (entry_count - 1 >= max_players ||
             players_data_len + entry_size > static_cast<int>(sizeof(players_data))) {
                 break;
         }
@@ -2334,7 +2348,7 @@ void af_send_player_info_response(const rf::NetAddr& addr)
     constexpr int header_size = static_cast<int>(sizeof(af_player_info_packet));
     constexpr int max_payload = static_cast<int>(rf::max_packet_size) - header_size;
 
-    int seg_boundaries[max_players + 1]; // start index of each segment + sentinel
+    int seg_boundaries[max_players + 2]; // preamble + entries + sentinel
     int total_segments = 0;
     {
         int seg_start = 0;
@@ -2346,18 +2360,13 @@ void af_send_player_info_response(const rf::NetAddr& addr)
                 ++seg_end;
             }
             if (seg_end == seg_start) {
-                // Single entry too large (should never happen)
+                // Single chunk too large (should never happen)
                 ++seg_end;
             }
             seg_start = seg_end;
         }
     }
     seg_boundaries[total_segments] = entry_count; // sentinel
-    if (total_segments == 0) {
-        total_segments = 1; // send one empty segment
-        seg_boundaries[0] = 0;
-        seg_boundaries[1] = 0;
-    }
 
     // Build and send each segment
     std::byte packet_buf[rf::max_packet_size];
@@ -2379,9 +2388,6 @@ void af_send_player_info_response(const rf::NetAddr& addr)
         hdr.response_id = response_id;
         hdr.sequence = static_cast<uint8_t>(seg);
         hdr.total_segments = static_cast<uint8_t>(total_segments);
-        hdr.red_score = red_score;
-        hdr.blue_score = blue_score;
-        hdr.time_left_seconds = time_left_seconds;
 
         std::memcpy(packet_buf, &hdr, header_size);
         if (payload_len > 0) {

--- a/game_patch/multi/alpine_packets.cpp
+++ b/game_patch/multi/alpine_packets.cpp
@@ -2330,9 +2330,10 @@ void af_send_player_info_response(const rf::NetAddr& addr)
     players_data[players_data_len++] = std::byte{0};
 
     constexpr int max_players = 32;
+    constexpr int max_name_len = 31; // wire protocol cap
     auto player_list = SinglyLinkedList(rf::player_list);
     for (auto& player : player_list) {
-        int name_len = player.name.size();
+        int name_len = std::min<int>(player.name.size(), max_name_len);
         int entry_size = 1 + 2 + 2 + 2 + 2 + name_len + 1; // flags + score + kills + deaths + caps + name + null
 
         if (entry_count - 1 >= max_players ||
@@ -2368,9 +2369,10 @@ void af_send_player_info_response(const rf::NetAddr& addr)
         std::memcpy(players_data + players_data_len, &caps, sizeof(caps));
         players_data_len += sizeof(caps);
 
-        // name (null-terminated)
-        std::memcpy(players_data + players_data_len, player.name.c_str(), name_len + 1);
-        players_data_len += name_len + 1;
+        // name (null-terminated; clamped to max_name_len)
+        std::memcpy(players_data + players_data_len, player.name.c_str(), name_len);
+        players_data_len += name_len;
+        players_data[players_data_len++] = std::byte{0};
     }
     entry_offsets[entry_count] = players_data_len; // sentinel
 
@@ -2398,6 +2400,19 @@ void af_send_player_info_response(const rf::NetAddr& addr)
     }
     seg_boundaries[total_segments] = entry_count; // sentinel
 
+    // Verify all segments fit before sending anything. Chunk-size invariants
+    // (preamble+filename <= ~269 B, per-entry <= 41 B, max_payload ~= 505 B)
+    // guarantee this in practice, but a silent partial send would leave the
+    // receiver waiting on a missing segment forever.
+    for (int seg = 0; seg < total_segments; ++seg) {
+        int payload_len = entry_offsets[seg_boundaries[seg + 1]] - entry_offsets[seg_boundaries[seg]];
+        if (payload_len > max_payload) {
+            xlog::error("af_send_player_info_response: segment {} payload {} > max {}; aborting response",
+                seg, payload_len, max_payload);
+            return;
+        }
+    }
+
     // Build and send each segment
     std::byte packet_buf[rf::max_packet_size];
     for (int seg = 0; seg < total_segments; ++seg) {
@@ -2406,10 +2421,6 @@ void af_send_player_info_response(const rf::NetAddr& addr)
 
         int payload_offset = entry_offsets[first_entry];
         int payload_len = entry_offsets[end_entry] - payload_offset;
-
-        if (payload_len > max_payload) {
-            continue;
-        }
 
         af_player_info_packet hdr{};
         hdr.hdr.type = static_cast<uint8_t>(pf_packet_type::players);

--- a/game_patch/multi/alpine_packets.cpp
+++ b/game_patch/multi/alpine_packets.cpp
@@ -2353,6 +2353,8 @@ void af_send_player_info_response(const rf::NetAddr& addr)
             std::memcpy(packet_buf + header_size, players_data + payload_offset, payload_len);
         }
 
+        // cannot use af_send_packet because packet is sent to
+        // online rfsb, not a connected client
         rf::net_send(addr, packet_buf, header_size + payload_len);
     }
 

--- a/game_patch/multi/alpine_packets.cpp
+++ b/game_patch/multi/alpine_packets.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <array>
 #include <ranges>
+#include <unordered_map>
 #include <common/utils/bool-utils.h>
 #include <common/utils/list-utils.h>
 #include <common/rfproto.h>
@@ -25,6 +26,8 @@
 #include "bots/bot_state.h"
 #include "../object/object_private.h"
 #include "../misc/misc.h"
+#include "../purefaction/pf_packets.h"
+#include "../os/os.h"
 
 void af_send_packet(rf::Player* player, const void* data, int len, bool is_reliable)
 {
@@ -2213,4 +2216,145 @@ void af_process_bot_control_packet(const void* data, size_t len, const rf::NetAd
             xlog::debug("af_process_bot_control_packet: unknown subtype {}", static_cast<int>(subtype));
             break;
     }
+}
+
+static uint8_t build_player_info_flags(const rf::Player& player)
+{
+    uint8_t flags = 0;
+    if (player.is_bot)
+        flags |= AF_PLAYER_FLAG_BOT;
+    if (player.is_browser)
+        flags |= AF_PLAYER_FLAG_BROWSER;
+    if (player.is_spectator)
+        flags |= AF_PLAYER_FLAG_SPECTATOR;
+    if (player_is_idle(&player))
+        flags |= AF_PLAYER_FLAG_IDLE;
+    if (player.team == rf::TEAM_BLUE)
+        flags |= AF_PLAYER_FLAG_TEAM_BLUE;
+    return flags;
+}
+
+void af_send_player_info_response(const rf::NetAddr& addr)
+{
+    if (!rf::is_server) {
+        return;
+    }
+
+    // Rate limit: one response per IP per second to reduce UDP amplification exposure
+    static std::unordered_map<uint32_t, HighResTimer> recent_responses;
+
+    // Sweep expired entries
+    std::erase_if(recent_responses, [](const auto& entry) {
+        return entry.second.elapsed();
+    });
+
+    auto [it, inserted] = recent_responses.try_emplace(addr.ip_addr);
+    if (!inserted) {
+        // Already responded to this IP within the last second
+        return;
+    }
+    it->second.set(std::chrono::seconds(1));
+
+    static uint8_t next_response_id = 0;
+    uint8_t response_id = next_response_id++;
+
+    // Serialize all player entries into a flat buffer.
+    // Per player: flags (1) + score (2) + name (len+1)
+    // Name cannot realistically be longer than 20 characters,
+    // but wire protocol allows 31, so account for it
+    constexpr size_t max_players_data = 32 * (1 + 2 + 32);
+    std::byte players_data[max_players_data];
+    int players_data_len = 0;
+
+    // Track where each player entry starts so we can chunk without splitting entries
+    int entry_offsets[33]; // max 32 players + sentinel
+    int entry_count = 0;
+
+    constexpr int max_players = 32;
+    auto player_list = SinglyLinkedList(rf::player_list);
+    for (auto& player : player_list) {
+        int name_len = player.name.size();
+        int entry_size = 1 + 2 + name_len + 1; // flags + score + name + null
+
+        if (entry_count >= max_players ||
+            players_data_len + entry_size > static_cast<int>(sizeof(players_data))) {
+                break;
+        }
+
+        entry_offsets[entry_count++] = players_data_len;
+
+        // flags
+        players_data[players_data_len] = static_cast<std::byte>(build_player_info_flags(player));
+        players_data_len += 1;
+
+        // score
+        int16_t score = player.stats ? player.stats->score : 0;
+        std::memcpy(players_data + players_data_len, &score, sizeof(score));
+        players_data_len += sizeof(score);
+
+        // name (null-terminated)
+        std::memcpy(players_data + players_data_len, player.name.c_str(), name_len + 1);
+        players_data_len += name_len + 1;
+    }
+    entry_offsets[entry_count] = players_data_len; // sentinel
+
+    // Compute segment boundaries (each segment fits within max_packet_size)
+    constexpr int header_size = static_cast<int>(sizeof(af_player_info_packet));
+    constexpr int max_payload = static_cast<int>(rf::max_packet_size) - header_size;
+
+    int seg_boundaries[max_players + 1]; // start index of each segment + sentinel
+    int total_segments = 0;
+    {
+        int seg_start = 0;
+        while (seg_start < entry_count) {
+            seg_boundaries[total_segments++] = seg_start;
+            int seg_end = seg_start;
+            while (seg_end < entry_count &&
+                   entry_offsets[seg_end + 1] - entry_offsets[seg_start] <= max_payload) {
+                ++seg_end;
+            }
+            if (seg_end == seg_start) {
+                // Single entry too large (should never happen)
+                ++seg_end;
+            }
+            seg_start = seg_end;
+        }
+    }
+    seg_boundaries[total_segments] = entry_count; // sentinel
+    if (total_segments == 0) {
+        total_segments = 1; // send one empty segment
+        seg_boundaries[0] = 0;
+        seg_boundaries[1] = 0;
+    }
+
+    // Build and send each segment
+    std::byte packet_buf[rf::max_packet_size];
+    for (int seg = 0; seg < total_segments; ++seg) {
+        int first_entry = seg_boundaries[seg];
+        int end_entry = seg_boundaries[seg + 1];
+
+        int payload_offset = entry_offsets[first_entry];
+        int payload_len = entry_offsets[end_entry] - payload_offset;
+
+        if (payload_len > max_payload) {
+            continue;
+        }
+
+        af_player_info_packet hdr{};
+        hdr.hdr.type = static_cast<uint8_t>(pf_packet_type::players);
+        hdr.hdr.size = static_cast<uint16_t>(payload_len + header_size - sizeof(hdr.hdr));
+        hdr.version = af_player_info_packet_version;
+        hdr.response_id = response_id;
+        hdr.sequence = static_cast<uint8_t>(seg);
+        hdr.total_segments = static_cast<uint8_t>(total_segments);
+
+        std::memcpy(packet_buf, &hdr, header_size);
+        if (payload_len > 0) {
+            std::memcpy(packet_buf + header_size, players_data + payload_offset, payload_len);
+        }
+
+        rf::net_send(addr, packet_buf, header_size + payload_len);
+    }
+
+    //xlog::trace("af_send_player_info_response: sent {} segments, {} players", total_segments, entry_count);
 }

--- a/game_patch/multi/alpine_packets.cpp
+++ b/game_patch/multi/alpine_packets.cpp
@@ -2259,12 +2259,13 @@ void af_send_player_info_response(const rf::NetAddr& addr)
     static uint8_t next_response_id = 0;
     uint8_t response_id = next_response_id++;
 
-    uint32_t time_left_seconds = 0;
-    if (rf::multi_time_limit > 0.0f) {
+    uint32_t time_left_seconds;
+    if (rf::multi_time_limit <= 0.0f) {
+        time_left_seconds = UINT32_MAX; // no time limit
+    }
+    else {
         float remaining = rf::multi_time_limit - rf::level.time;
-        if (remaining > 0.0f) {
-            time_left_seconds = static_cast<uint32_t>(remaining);
-        }
+        time_left_seconds = remaining > 0.0f ? static_cast<uint32_t>(remaining) : 0;
     }
 
     uint16_t red_score = 0;

--- a/game_patch/multi/alpine_packets.cpp
+++ b/game_patch/multi/alpine_packets.cpp
@@ -2241,13 +2241,21 @@ void af_send_player_info_response(const rf::NetAddr& addr)
         return;
     }
 
+    // Placeholder filename used when no level is loaded
+    static constexpr const char* kNoLevelFilename = "No level loaded";
+
     // Rate limit: one response per IP per second to reduce UDP amplification exposure
+    static constexpr size_t kMaxRecentResponses = 16384;
     static std::unordered_map<uint32_t, HighResTimer> recent_responses;
 
-    // Sweep expired entries
+    // Sweep expired entries first
     std::erase_if(recent_responses, [](const auto& entry) {
         return entry.second.elapsed();
     });
+
+    if (recent_responses.size() >= kMaxRecentResponses) {
+        return;
+    }
 
     auto [it, inserted] = recent_responses.try_emplace(addr.ip_addr);
     if (!inserted) {
@@ -2265,7 +2273,9 @@ void af_send_player_info_response(const rf::NetAddr& addr)
     }
     else {
         float remaining = rf::multi_time_limit - rf::level.time;
-        time_left_seconds = remaining > 0.0f ? static_cast<uint32_t>(remaining) : 0;
+        time_left_seconds = remaining > 0.0f
+            ? static_cast<uint32_t>(std::min(remaining, static_cast<float>(UINT32_MAX)))
+            : 0;
     }
 
     uint16_t red_score = 0;
@@ -2298,7 +2308,7 @@ void af_send_player_info_response(const rf::NetAddr& addr)
     // Name cannot realistically be longer than 20 characters,
     // but wire protocol allows 31, so account for it
     constexpr size_t preamble_size = sizeof(af_player_info_payload_header);
-    constexpr size_t max_filename_size = 256; // level.filename + null
+    constexpr size_t max_filename_size = RF_MAX_LEVEL_NAME_LEN + 1;
     constexpr size_t max_players_data = preamble_size + max_filename_size + 32 * (1 + 2 + 2 + 2 + 2 + 32);
     std::byte players_data[max_players_data];
     int players_data_len = 0;
@@ -2319,13 +2329,18 @@ void af_send_player_info_response(const rf::NetAddr& addr)
     std::memcpy(players_data, &preamble, preamble_size);
     players_data_len = static_cast<int>(preamble_size);
 
-    // level filename (null-terminated), clamped to max_filename_size - 1 bytes
+    // level filename (null-terminated), clamped to max_filename_size - 1 bytes.
+    // Falls back to a placeholder when no level has been loaded yet.
+    const char* filename_src = rf::level.filename.c_str();
     int filename_len = rf::level.filename.size();
-    if (filename_len < 0) filename_len = 0;
+    if (filename_len <= 0) {
+        filename_src = kNoLevelFilename;
+        filename_len = static_cast<int>(std::strlen(kNoLevelFilename));
+    }
     if (filename_len >= static_cast<int>(max_filename_size)) {
         filename_len = static_cast<int>(max_filename_size) - 1;
     }
-    std::memcpy(players_data + players_data_len, rf::level.filename.c_str(), filename_len);
+    std::memcpy(players_data + players_data_len, filename_src, filename_len);
     players_data_len += filename_len;
     players_data[players_data_len++] = std::byte{0};
 
@@ -2401,7 +2416,7 @@ void af_send_player_info_response(const rf::NetAddr& addr)
     seg_boundaries[total_segments] = entry_count; // sentinel
 
     // Verify all segments fit before sending anything. Chunk-size invariants
-    // (preamble+filename <= ~269 B, per-entry <= 41 B, max_payload ~= 505 B)
+    // (preamble+filename <= ~273 B, per-entry <= 41 B, max_payload ~= 505 B)
     // guarantee this in practice, but a silent partial send would leave the
     // receiver waiting on a missing segment forever.
     for (int seg = 0; seg < total_segments; ++seg) {

--- a/game_patch/multi/alpine_packets.cpp
+++ b/game_patch/multi/alpine_packets.cpp
@@ -2291,21 +2291,22 @@ void af_send_player_info_response(const rf::NetAddr& addr)
     }
 
     // Serialize the logical payload into a flat buffer:
-    //   [payload_header][player entry 0][player entry 1]...
+    //   [payload_header][level_filename\0][player entry 0][player entry 1]...
     // which is then sliced into segments. The receiver reassembles by
-    // response_id and parses the header + entries.
-    // Per player: flags (1) + score (2) + name (len+1)
+    // response_id and parses the header + filename + entries.
+    // Per player: flags (1) + score (2) + kills (2) + deaths (2) + caps (2) + name (len+1)
     // Name cannot realistically be longer than 20 characters,
     // but wire protocol allows 31, so account for it
     constexpr size_t preamble_size = sizeof(af_player_info_payload_header);
-    constexpr size_t max_players_data = preamble_size + 32 * (1 + 2 + 32);
+    constexpr size_t max_filename_size = 256; // level.filename + null
+    constexpr size_t max_players_data = preamble_size + max_filename_size + 32 * (1 + 2 + 2 + 2 + 2 + 32);
     std::byte players_data[max_players_data];
     int players_data_len = 0;
 
-    // Chunk 0 is the payload header; chunks 1..entry_count are player entries.
-    // The chunker keeps chunks intact per segment, so the preamble always lands
-    // entirely in segment 0.
-    int entry_offsets[34]; // preamble + max 32 players + sentinel
+    // Chunk 0 is the payload header + level filename; chunks 1..entry_count are
+    // player entries. The chunker keeps chunks intact per segment, so chunk 0
+    // always lands entirely in segment 0.
+    int entry_offsets[34]; // preamble+filename + max 32 players + sentinel
     entry_offsets[0] = 0;
     int entry_count = 1;
 
@@ -2313,14 +2314,26 @@ void af_send_player_info_response(const rf::NetAddr& addr)
     preamble.red_score = red_score;
     preamble.blue_score = blue_score;
     preamble.time_left_seconds = time_left_seconds;
+    preamble.af_flags = server_get_game_info_flags().game_info_flags_to_uint32();
+    preamble.game_type = static_cast<uint8_t>(rf::netgame.type);
     std::memcpy(players_data, &preamble, preamble_size);
     players_data_len = static_cast<int>(preamble_size);
+
+    // level filename (null-terminated), clamped to max_filename_size - 1 bytes
+    int filename_len = rf::level.filename.size();
+    if (filename_len < 0) filename_len = 0;
+    if (filename_len >= static_cast<int>(max_filename_size)) {
+        filename_len = static_cast<int>(max_filename_size) - 1;
+    }
+    std::memcpy(players_data + players_data_len, rf::level.filename.c_str(), filename_len);
+    players_data_len += filename_len;
+    players_data[players_data_len++] = std::byte{0};
 
     constexpr int max_players = 32;
     auto player_list = SinglyLinkedList(rf::player_list);
     for (auto& player : player_list) {
         int name_len = player.name.size();
-        int entry_size = 1 + 2 + name_len + 1; // flags + score + name + null
+        int entry_size = 1 + 2 + 2 + 2 + 2 + name_len + 1; // flags + score + kills + deaths + caps + name + null
 
         if (entry_count - 1 >= max_players ||
             players_data_len + entry_size > static_cast<int>(sizeof(players_data))) {
@@ -2329,14 +2342,31 @@ void af_send_player_info_response(const rf::NetAddr& addr)
 
         entry_offsets[entry_count++] = players_data_len;
 
+        const auto* stats = static_cast<const PlayerStatsNew*>(player.stats);
+
         // flags
         players_data[players_data_len] = static_cast<std::byte>(build_player_info_flags(player));
         players_data_len += 1;
 
         // score
-        int16_t score = player.stats ? player.stats->score : 0;
+        int16_t score = stats ? stats->score : 0;
         std::memcpy(players_data + players_data_len, &score, sizeof(score));
         players_data_len += sizeof(score);
+
+        // kills
+        uint16_t kills = stats ? stats->num_kills : 0;
+        std::memcpy(players_data + players_data_len, &kills, sizeof(kills));
+        players_data_len += sizeof(kills);
+
+        // deaths
+        uint16_t deaths = stats ? stats->num_deaths : 0;
+        std::memcpy(players_data + players_data_len, &deaths, sizeof(deaths));
+        players_data_len += sizeof(deaths);
+
+        // caps
+        uint16_t caps = stats ? static_cast<uint16_t>(std::max<int16_t>(stats->caps, 0)) : 0;
+        std::memcpy(players_data + players_data_len, &caps, sizeof(caps));
+        players_data_len += sizeof(caps);
 
         // name (null-terminated)
         std::memcpy(players_data + players_data_len, player.name.c_str(), name_len + 1);

--- a/game_patch/multi/alpine_packets.h
+++ b/game_patch/multi/alpine_packets.h
@@ -153,6 +153,9 @@ struct af_player_info_packet
     uint8_t response_id;
     uint8_t sequence;
     uint8_t total_segments;
+    uint16_t red_score;     // 0 in non-team game types
+    uint16_t blue_score;    // 0 in non-team game types
+    uint32_t time_left_seconds; // 0 if no time limit or time expired
     // player entries follow
 };
 

--- a/game_patch/multi/alpine_packets.h
+++ b/game_patch/multi/alpine_packets.h
@@ -132,6 +132,32 @@ struct af_just_spawned_info_packet
     uint8_t data[];     // type-specific payload
 };
 
+enum af_player_info_flags : uint8_t
+{
+    AF_PLAYER_FLAG_BOT       = 1 << 0,
+    AF_PLAYER_FLAG_BROWSER   = 1 << 1,
+    AF_PLAYER_FLAG_SPECTATOR = 1 << 2,
+    AF_PLAYER_FLAG_IDLE      = 1 << 3,
+    AF_PLAYER_FLAG_TEAM_BLUE = 1 << 4,
+};
+
+// Wire format per player entry (variable length):
+//   uint8_t flags
+//   int16_t score
+//   char name[] (null-terminated)
+
+struct af_player_info_packet
+{
+    RF_GamePacketHeader hdr; // type = pf_packet_type::players (0xA1)
+    uint8_t version;        // 2
+    uint8_t response_id;
+    uint8_t sequence;
+    uint8_t total_segments;
+    // player entries follow
+};
+
+constexpr uint8_t af_player_info_packet_version = 2;
+
 struct af_koth_hill_state_packet
 {
     RF_GamePacketHeader header;
@@ -370,3 +396,6 @@ void af_send_bot_control_update_identity(rf::Player* player, const std::string& 
 void af_send_bot_config(rf::Player* player, const ServerBotConfig& config,
                         const std::string& resolved_name, int32_t resolved_character);
 void af_process_bot_control_packet(const void* data, size_t len, const rf::NetAddr& addr);
+
+// player info response (sent to online server browsers)
+void af_send_player_info_response(const rf::NetAddr& addr);

--- a/game_patch/multi/alpine_packets.h
+++ b/game_patch/multi/alpine_packets.h
@@ -141,11 +141,9 @@ enum af_player_info_flags : uint8_t
     AF_PLAYER_FLAG_TEAM_BLUE = 1 << 4,
 };
 
-// Wire format per player entry (variable length):
-//   uint8_t flags
-//   int16_t score
-//   char name[] (null-terminated)
-
+// Per-segment framing. The payload bytes of each segment are concatenated in
+// `sequence` order (grouped by `response_id`) to form one logical payload
+// described by `af_player_info_payload_header` below.
 struct af_player_info_packet
 {
     RF_GamePacketHeader hdr; // type = pf_packet_type::players (0xA1)
@@ -153,10 +151,20 @@ struct af_player_info_packet
     uint8_t response_id;
     uint8_t sequence;
     uint8_t total_segments;
+    // segmented payload follows
+};
+
+// Reassembled payload layout:
+//   af_player_info_payload_header preamble
+//   player entries (variable length per entry):
+//     uint8_t flags
+//     int16_t score
+//     char name[] (null-terminated)
+struct af_player_info_payload_header
+{
     uint16_t red_score;     // 0 in non-team game types
     uint16_t blue_score;    // 0 in non-team game types
     uint32_t time_left_seconds; // UINT32_MAX if no time limit, 0 if time expired
-    // player entries follow
 };
 
 constexpr uint8_t af_player_info_packet_version = 2;

--- a/game_patch/multi/alpine_packets.h
+++ b/game_patch/multi/alpine_packets.h
@@ -156,15 +156,21 @@ struct af_player_info_packet
 
 // Reassembled payload layout:
 //   af_player_info_payload_header preamble
+//   char level_filename[] (null-terminated)
 //   player entries (variable length per entry):
-//     uint8_t flags
-//     int16_t score
-//     char name[] (null-terminated)
+//     uint8_t  flags
+//     int16_t  score
+//     uint16_t kills
+//     uint16_t deaths
+//     uint16_t caps
+//     char     name[] (null-terminated)
 struct af_player_info_payload_header
 {
     uint16_t red_score;     // 0 in non-team game types
     uint16_t blue_score;    // 0 in non-team game types
     uint32_t time_left_seconds; // UINT32_MAX if no time limit, 0 if time expired
+    uint32_t af_flags;      // af_server_info_flags bitfield
+    uint8_t  game_type;     // rf::NetGameType
 };
 
 constexpr uint8_t af_player_info_packet_version = 2;

--- a/game_patch/multi/alpine_packets.h
+++ b/game_patch/multi/alpine_packets.h
@@ -155,7 +155,7 @@ struct af_player_info_packet
     uint8_t total_segments;
     uint16_t red_score;     // 0 in non-team game types
     uint16_t blue_score;    // 0 in non-team game types
-    uint32_t time_left_seconds; // 0 if no time limit or time expired
+    uint32_t time_left_seconds; // UINT32_MAX if no time limit, 0 if time expired
     // player entries follow
 };
 

--- a/game_patch/purefaction/pf.cpp
+++ b/game_patch/purefaction/pf.cpp
@@ -12,6 +12,7 @@
 #include "pf_ac.h"
 #include "../misc/player.h"
 #include "../multi/server.h"
+#include "../multi/alpine_packets.h"
 
 void pf_send_reliable_packet(rf::Player* player, const void* data, int len)
 {
@@ -154,38 +155,6 @@ static void process_pf_player_stats_packet(const void* data, size_t len, [[ mayb
     }
 }
 
-static void process_pf_players_request_packet([[ maybe_unused ]] const void* data, [[ maybe_unused ]] size_t len, const rf::NetAddr& addr)
-{
-    xlog::trace("PF players_request packet");
-
-    // Receive: server <- client (can be non-joined)
-    if (!rf::is_server) {
-        return;
-    }
-
-    pf_players_packet players_packet{};
-    players_packet.hdr.type = static_cast<uint8_t>(pf_packet_type::players);
-    players_packet.version = 1;
-    players_packet.show_ip = 0;
-
-    std::byte packet_buf[rf::max_packet_size];
-    int packet_len = sizeof(players_packet);
-    auto player_list = SinglyLinkedList(rf::player_list);
-    for (auto& player : player_list) {
-        int name_len = player.name.size();
-        if (packet_len + name_len + 1 > static_cast<int>(sizeof(packet_buf))) {
-            xlog::warn("PF players packet is too big! Skipping some players...");
-            break;
-        }
-        std::memcpy(packet_buf + packet_len, player.name.c_str(), name_len + 1);
-        packet_len += name_len + 1;
-    }
-
-    players_packet.hdr.size = packet_len - sizeof(players_packet.hdr);
-    std::memcpy(packet_buf, &players_packet, sizeof(players_packet));
-    rf::net_send(addr, packet_buf, packet_len);
-}
-
 bool pf_process_packet(const void* data, int len, const rf::NetAddr& addr, rf::Player* player)
 {
     if (pf_ac_process_packet(data, len, addr, player)) {
@@ -223,10 +192,9 @@ bool pf_process_raw_unreliable_packet(const void* data, int len, const rf::NetAd
     std::memcpy(&header, data, sizeof(header));
     auto packet_type = static_cast<pf_packet_type>(header.type);
 
+    // sent by online rfsb, not connected clients
     if (packet_type == pf_packet_type::players_request) {
-        // Note: this packet can be sent by clients that do not join the server (e.g. online server browser)
-        // Because of that it must be handled here and not in pf_process_packet
-        process_pf_players_request_packet(data, len, addr);
+        af_send_player_info_response(addr);
         return true;
     }
     return false;

--- a/game_patch/purefaction/pf_packets.h
+++ b/game_patch/purefaction/pf_packets.h
@@ -73,25 +73,6 @@ struct pf_player_announce_packet
 
 constexpr uint8_t pf_announce_player_packet_version = 2;
 
-struct pf_players_packet
-{
-    rf_packet_header hdr; // players
-    uint8_t version; // current version is 1
-    uint8_t show_ip;
-#ifdef PSEUDOCODE
-    struct player_info
-    {
-        if (show_ip) {
-            uint32_t ip_addr;
-        }
-        char name[];
-    };
-    player_info players[];
-    uint8_t reserved[3]; // PF bug workaround (PF expects size field to include header size)
-#endif
-};
-
-constexpr uint8_t pf_players_packet_version = 1;
 
 constexpr uint32_t pf_game_info_signature = 0xEFBEADDE;
 constexpr uint16_t pf_game_info_version = 0x030DF;


### PR DESCRIPTION
- Serve player type, team, and score in `players_request` packet response (for online RFSB)