### PR TITLE
Add ATX, PNG, JPG texture support

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -19,6 +19,9 @@ set(SRCS
     include/common/utils/perf-utils.h
     include/common/utils/string-utils.h
     include/common/utils/bool-utils.h
+    include/common/bitmap/formats.h
+    include/common/atx/spec.h
+    include/common/atx/parse.h
     include/common/version/version.h
     src/HttpRequest.cpp
     src/config/GameConfig.cpp

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -46,7 +46,11 @@ target_include_directories(Common PRIVATE
 # Make sure Windows min/max macro don't conflict with std::min/std::max
 target_compile_definitions(Common PUBLIC NOMINMAX)
 
-target_include_directories(Common PUBLIC include)
+target_include_directories(Common PUBLIC
+    include
+    ${CMAKE_SOURCE_DIR}/vendor/dds
+    ${CMAKE_SOURCE_DIR}/vendor/toml++
+)
 
 target_link_libraries(Common
     shlwapi

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -48,8 +48,8 @@ target_compile_definitions(Common PUBLIC NOMINMAX)
 
 target_include_directories(Common PUBLIC
     include
+    ${CMAKE_SOURCE_DIR}/vendor
     ${CMAKE_SOURCE_DIR}/vendor/dds
-    ${CMAKE_SOURCE_DIR}/vendor/toml++
 )
 
 target_link_libraries(Common

--- a/common/include/common/atx/parse.h
+++ b/common/include/common/atx/parse.h
@@ -1,0 +1,115 @@
+#pragma once
+
+// Pure ATX parser — takes TOML bytes, returns a structurally-validated AtxSpec, or nullopt.
+//
+// What this DOES validate:
+//   - Valid TOML syntax (toml++ parses it)
+//   - At least one [[frame]]
+//   - Each frame has a non-empty `file` that doesn't end in .atx (no nesting)
+//   - animation_mode is in range (0–3); out-of-range warns and falls back to default
+//   - Numeric fields clamped to ATX_MIN_FRAME_TIME_MS
+//
+// What this does NOT do (caller's responsibility):
+//   - File IO (caller supplies the bytes)
+//   - Loading or decoding frame textures
+//   - Cross-frame validation (dimensions/format/mip-count must match)
+//   - Material name → engine material index lookup
+//   - Format string → engine format enum lookup
+//
+// Header-only and engine-agnostic. Each consumer just needs toml++ on the include path.
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include <toml++/toml.hpp>
+#include <xlog/xlog.h>
+#include <common/utils/string-utils.h>
+
+#include "spec.h"
+
+// Returns the parsed AtxSpec on success, or nullopt on TOML parse error or schema violation.
+// `source_name` is included in log messages to identify the file in question (typically
+// the .atx filename).
+inline std::optional<AtxSpec> parse_atx(std::string_view toml_bytes, std::string_view source_name = {})
+{
+    toml::table tbl;
+    try {
+        tbl = toml::parse(toml_bytes, source_name);
+    }
+    catch (const toml::parse_error& e) {
+        xlog::warn("ATX: parse error in '{}': {}", source_name, e.description());
+        return std::nullopt;
+    }
+    catch (...) {
+        xlog::warn("ATX: unexpected exception while parsing '{}'", source_name);
+        return std::nullopt;
+    }
+
+    AtxSpec spec;
+
+    // [header] is optional — defaults apply if absent.
+    if (const auto* hdr = tbl.get_as<toml::table>(ATX_TABLE_HEADER)) {
+        if (auto v = (*hdr)[ATX_KEY_FRAME_TIME].value<int64_t>()) {
+            spec.header.frame_time_ms = std::max<int>(ATX_MIN_FRAME_TIME_MS, static_cast<int>(*v));
+        }
+        if (auto v = (*hdr)[ATX_KEY_INITIALLY_ON].value<bool>()) {
+            spec.header.initially_on = *v;
+        }
+        if (auto v = (*hdr)[ATX_KEY_ANIMATION_MODE].value<int64_t>()) {
+            int mode = static_cast<int>(*v);
+            if (mode < 0 || mode > 3) {
+                xlog::warn("ATX '{}': animation_mode {} out of range, defaulting to static",
+                           source_name, mode);
+                mode = static_cast<int>(AtxSpec::AnimationMode::Static);
+            }
+            spec.header.animation_mode = static_cast<AtxSpec::AnimationMode>(mode);
+        }
+        if (auto v = (*hdr)[ATX_KEY_FORMAT].value<std::string>()) {
+            if (!v->empty()) spec.header.format = *v;
+        }
+        if (auto v = (*hdr)[ATX_KEY_ALPHA_MASK].value<std::string>()) {
+            if (!v->empty()) spec.header.alpha_mask = *v;
+        }
+        if (auto v = (*hdr)[ATX_KEY_MATERIAL].value<std::string>()) {
+            if (!v->empty()) spec.header.material = *v;
+        }
+    }
+
+    const auto* frames_arr = tbl.get_as<toml::array>(ATX_ARRAY_FRAME);
+    if (!frames_arr || frames_arr->empty()) {
+        xlog::warn("ATX '{}': no [[frame]] entries", source_name);
+        return std::nullopt;
+    }
+
+    spec.frames.reserve(frames_arr->size());
+    for (auto&& node : *frames_arr) {
+        const auto* frame_tbl = node.as_table();
+        if (!frame_tbl) {
+            xlog::warn("ATX '{}': non-table frame entry", source_name);
+            return std::nullopt;
+        }
+        AtxSpec::Frame f;
+        if (auto v = (*frame_tbl)[ATX_KEY_FRAME_FILE].value<std::string>()) {
+            f.filename = *v;
+        }
+        if (f.filename.empty()) {
+            xlog::warn("ATX '{}': frame missing 'file'", source_name);
+            return std::nullopt;
+        }
+        if (string_iends_with(f.filename, ".atx")) {
+            xlog::warn("ATX '{}': nested .atx is not allowed (frame '{}')",
+                       source_name, f.filename);
+            return std::nullopt;
+        }
+        if (auto v = (*frame_tbl)[ATX_KEY_FRAME_TIME_OVR].value<int64_t>()) {
+            f.frame_time_ms = std::max<int>(ATX_MIN_FRAME_TIME_MS, static_cast<int>(*v));
+        }
+        if (auto v = (*frame_tbl)[ATX_KEY_FRAME_MATERIAL].value<std::string>()) {
+            if (!v->empty()) f.material = *v;
+        }
+        spec.frames.push_back(std::move(f));
+    }
+
+    return spec;
+}

--- a/common/include/common/atx/parse.h
+++ b/common/include/common/atx/parse.h
@@ -18,14 +18,13 @@
 //
 // Header-only and engine-agnostic. Each consumer just needs toml++ on the include path.
 
+#include <algorithm>
 #include <optional>
 #include <string>
 #include <string_view>
-
 #include <toml++/toml.hpp>
 #include <xlog/xlog.h>
 #include <common/utils/string-utils.h>
-
 #include "spec.h"
 
 // Returns the parsed AtxSpec on success, or nullopt on TOML parse error or schema violation.

--- a/common/include/common/atx/spec.h
+++ b/common/include/common/atx/spec.h
@@ -1,0 +1,89 @@
+#pragma once
+
+// ATX format core types — describes what an .atx file declares, independent of use.
+// Runtime side (loading frames, dispatching locks, animating, etc.) lives per-consumer.
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <common/bitmap/formats.h>      // BM_FORMAT_*
+#include <common/utils/string-utils.h>  // string_to_lower
+
+// ─── TOML schema constants ────────────────────────────────────────────────────
+
+// [header] keys
+inline constexpr std::string_view ATX_KEY_FRAME_TIME     = "frame_time";
+inline constexpr std::string_view ATX_KEY_INITIALLY_ON   = "initially_on";
+inline constexpr std::string_view ATX_KEY_ANIMATION_MODE = "animation_mode";
+inline constexpr std::string_view ATX_KEY_FORMAT         = "format";
+inline constexpr std::string_view ATX_KEY_ALPHA_MASK     = "alpha_mask";
+inline constexpr std::string_view ATX_KEY_MATERIAL       = "material";
+
+// [[frame]] entry keys
+inline constexpr std::string_view ATX_KEY_FRAME_FILE     = "file";
+inline constexpr std::string_view ATX_KEY_FRAME_TIME_OVR = "frame_time"; // per-frame override
+inline constexpr std::string_view ATX_KEY_FRAME_MATERIAL = "material";   // per-frame override
+
+// TOML structure
+inline constexpr std::string_view ATX_TABLE_HEADER       = "header";
+inline constexpr std::string_view ATX_ARRAY_FRAME        = "frame";
+
+// ─── Default values & limits ──────────────────────────────────────────────────
+
+inline constexpr int  ATX_MIN_FRAME_TIME_MS     = 1;   // floor enforced by parser
+inline constexpr int  ATX_DEFAULT_FRAME_TIME_MS = 100;
+inline constexpr bool ATX_DEFAULT_INITIALLY_ON  = true;
+
+// ─── Parsed structures ────────────────────────────────────────────────────────
+
+// All ATX format types are nested under AtxSpec to keep the global namespace clean and
+// avoid collisions with other Frame/Header-named types in consumer code.
+struct AtxSpec
+{
+    enum class AnimationMode : int
+    {
+        Static   = 0, // No anim playback. Frames change only manually (default).
+        PingPong = 1, // Forward to last, then backward to first, repeating.
+        Loop     = 2, // Forward; wrap to 0 after last, repeating.
+        PlayOnce = 3, // Forward; stop and hold on the last frame.
+    };
+
+    struct Frame
+    {
+        std::string filename;                  // required; never empty after parse, never .atx
+        std::optional<int> frame_time_ms;      // per-frame override
+        std::optional<std::string> material;   // per-frame material override (string token)
+    };
+
+    struct Header
+    {
+        int frame_time_ms          = ATX_DEFAULT_FRAME_TIME_MS;
+        bool initially_on          = ATX_DEFAULT_INITIALLY_ON;
+        AnimationMode animation_mode = AnimationMode::Static;
+        std::optional<std::string> format;     // target format token, e.g. "8888_argb"
+        std::optional<std::string> alpha_mask; // alpha-mask filename
+        std::optional<std::string> material;   // ATX-wide material override token
+    };
+
+    Header header;
+    std::vector<Frame> frames; // always non-empty after a successful parse
+};
+
+// ─── ATX schema vocabulary parsers ────────────────────────────────────────────
+
+// Maps an ATX [header].format string token like "8888_argb" or "565" to a BM_FORMAT_*
+// integer, or std::nullopt if the token isn't a recognised ATX format name.
+// The accepted token set is part of the ATX format specification, hence its home here.
+inline std::optional<int> atx_parse_format_token(std::string_view token)
+{
+    std::string s = string_to_lower(token);
+    if (s == "565"  || s == "565_rgb")    return BM_FORMAT_565_RGB;
+    if (s == "4444" || s == "4444_argb")  return BM_FORMAT_4444_ARGB;
+    if (s == "1555" || s == "1555_argb")  return BM_FORMAT_1555_ARGB;
+    if (s == "888"  || s == "888_rgb")    return BM_FORMAT_888_RGB;
+    if (s == "8888" || s == "8888_argb")  return BM_FORMAT_8888_ARGB;
+    return std::nullopt;
+}

--- a/common/include/common/bitmap/formats.h
+++ b/common/include/common/bitmap/formats.h
@@ -1,0 +1,146 @@
+#pragma once
+
+// Shared bitmap format helpers used by both game_patch and editor_patch. These wrap the few
+// bits of logic that are genuinely identical across binaries (DDS pixel-format classification,
+// stb_image channel-count → bm format mapping, file-extension predicates). Engine-glue code
+// like file IO, hooks, and bm system calls intentionally stays per-binary because of address
+// and behavioural differences between RF.exe and RED.exe.
+//
+// Format constants are returned/expressed as plain `int`. Each binary's own enum
+// (rf::bm::Format on the game side, BitmapEntry::FORMAT_* on the editor side) uses the same
+// numeric values, so callers cast freely.
+
+#include <cstdint>
+#include <string_view>
+
+#include <dds.h>
+#include <common/utils/string-utils.h>
+
+// ─── Format constants ─────────────────────────────────────────────────────────
+// Match RED.exe's and RF.exe's bm enum values.
+
+inline constexpr int BM_FORMAT_NONE       = 0;
+inline constexpr int BM_FORMAT_8_PALETTED = 1;
+inline constexpr int BM_FORMAT_8_ALPHA    = 2;
+inline constexpr int BM_FORMAT_565_RGB    = 3;
+inline constexpr int BM_FORMAT_4444_ARGB  = 4;
+inline constexpr int BM_FORMAT_1555_ARGB  = 5;
+inline constexpr int BM_FORMAT_888_RGB    = 6;
+inline constexpr int BM_FORMAT_8888_ARGB  = 7;
+// Alpine extensions (game-only):
+inline constexpr int BM_FORMAT_DXT1       = 0x11;
+inline constexpr int BM_FORMAT_DXT2       = 0x12;
+inline constexpr int BM_FORMAT_DXT3       = 0x13;
+inline constexpr int BM_FORMAT_DXT4       = 0x14;
+inline constexpr int BM_FORMAT_DXT5       = 0x15;
+
+// ─── Format helpers ──────────────────────────────────────────────────────────
+
+// Returns the bm format integer for a DDS pixel format header, or BM_FORMAT_NONE if the
+// pixel format is unsupported.
+inline int bm_format_from_dds(const DDS_PIXELFORMAT& ddspf)
+{
+    if (ddspf.flags & DDS_RGB) {
+        switch (ddspf.RGBBitCount) {
+            case 32: return ddspf.ABitMask ? BM_FORMAT_8888_ARGB : BM_FORMAT_NONE;
+            case 24: return BM_FORMAT_888_RGB;
+            case 16:
+                if (ddspf.ABitMask == 0x8000) return BM_FORMAT_1555_ARGB;
+                if (ddspf.ABitMask)           return BM_FORMAT_4444_ARGB;
+                return BM_FORMAT_565_RGB;
+        }
+    }
+    else if (ddspf.flags & DDS_FOURCC) {
+        switch (ddspf.fourCC) {
+            case MAKEFOURCC('D','X','T','1'): return BM_FORMAT_DXT1;
+            case MAKEFOURCC('D','X','T','2'): return BM_FORMAT_DXT2;
+            case MAKEFOURCC('D','X','T','3'): return BM_FORMAT_DXT3;
+            case MAKEFOURCC('D','X','T','4'): return BM_FORMAT_DXT4;
+            case MAKEFOURCC('D','X','T','5'): return BM_FORMAT_DXT5;
+        }
+    }
+    return BM_FORMAT_NONE;
+}
+
+// Map stb_image's reported source channel count to the appropriate bm format.
+// 1 (greyscale) and 3 (RGB) → BM_FORMAT_888_RGB (no alpha).
+// 2 (gray+alpha) and 4 (RGBA) → BM_FORMAT_8888_ARGB.
+inline int bm_format_from_stb_channels(int channels)
+{
+    return (channels == 2 || channels == 4) ? BM_FORMAT_8888_ARGB : BM_FORMAT_888_RGB;
+}
+
+// ─── Filename extension predicates ────────────────────────────────────────────
+// Used by both game-side and editor-side bm hooks to decide which decode path applies.
+// Centralising these means a new format is added in exactly one place.
+
+inline bool is_stb_filename(std::string_view name)
+{
+    return string_iends_with(name, ".png")
+        || string_iends_with(name, ".jpg")
+        || string_iends_with(name, ".jpeg");
+}
+inline bool is_dds_filename(std::string_view name) { return string_iends_with(name, ".dds"); }
+inline bool is_atx_filename(std::string_view name) { return string_iends_with(name, ".atx"); }
+
+// ─── Format predicates / mappings ─────────────────────────────────────────────
+
+// True for the set of uncompressed direct-color formats: 565, 1555, 4444, 888, 8888.
+// Excludes paletted (indexed-color) and block-compressed (DXT*). Useful for any pipeline
+// that reads or writes pixel bytes directly.
+inline bool bm_format_is_uncompressed_rgb(int fmt)
+{
+    switch (fmt) {
+        case BM_FORMAT_565_RGB:
+        case BM_FORMAT_4444_ARGB:
+        case BM_FORMAT_1555_ARGB:
+        case BM_FORMAT_888_RGB:
+        case BM_FORMAT_8888_ARGB:
+            return true;
+        default:
+            return false;
+    }
+}
+
+// If `fmt` lacks an alpha channel, return an analogous format with one. Used to auto-promote
+// when an alpha mask is supplied without an explicit target format.
+inline int bm_promote_to_alpha(int fmt)
+{
+    switch (fmt) {
+        case BM_FORMAT_565_RGB: return BM_FORMAT_4444_ARGB;
+        case BM_FORMAT_888_RGB: return BM_FORMAT_8888_ARGB;
+        default:                return fmt;
+    }
+}
+
+// ─── Alpha mask overlay ───────────────────────────────────────────────────────
+// Overlay an 8-bit greyscale `mask` as the alpha channel of a destination buffer in
+// `dst_fmt`. Caller guarantees dst_fmt is one of the alpha-bearing supported formats
+// (8888_ARGB, 4444_ARGB, or 1555_ARGB). Buffer layout matches D3D's *_ARGB: the alpha
+// component lives in the highest-order bits of each pixel (memory: BGRA / RGBA-MSB-A).
+inline void bm_overlay_alpha_mask(uint8_t* dst, int dst_fmt, const uint8_t* mask, int num_pixels)
+{
+    switch (dst_fmt) {
+        case BM_FORMAT_8888_ARGB:
+            // Memory order is BGRA on little-endian; alpha is the 4th byte per pixel.
+            for (int i = 0; i < num_pixels; ++i) {
+                dst[i * 4 + 3] = mask[i];
+            }
+            break;
+        case BM_FORMAT_4444_ARGB:
+            // Two bytes per pixel little-endian; alpha lives in the high nibble of byte 1.
+            for (int i = 0; i < num_pixels; ++i) {
+                dst[i * 2 + 1] = static_cast<uint8_t>((dst[i * 2 + 1] & 0x0F) | (mask[i] & 0xF0));
+            }
+            break;
+        case BM_FORMAT_1555_ARGB:
+            // Single alpha bit at the top of byte 1; threshold the mask at 0x80.
+            for (int i = 0; i < num_pixels; ++i) {
+                if (mask[i] >= 128) dst[i * 2 + 1] |= 0x80;
+                else                dst[i * 2 + 1] &= 0x7F;
+            }
+            break;
+        default:
+            break;
+    }
+}

--- a/common/include/common/bitmap/formats.h
+++ b/common/include/common/bitmap/formats.h
@@ -70,8 +70,9 @@ inline int bm_format_from_stb_channels(int channels)
     return (channels == 2 || channels == 4) ? BM_FORMAT_8888_ARGB : BM_FORMAT_888_RGB;
 }
 
-// Hard upper bound for stb-decoded texture dimensions.
-inline constexpr int BM_STB_MAX_DIMENSION = 16384;
+// Hard upper bound for any externally-sourced texture dimension
+// 16384 matches D3D11's mandatory minimum
+inline constexpr int BM_MAX_DIMENSION = 16384;
 
 // ─── Filename extension predicates ────────────────────────────────────────────
 // Used by both game-side and editor-side bm hooks to decide which decode path applies.

--- a/common/include/common/bitmap/formats.h
+++ b/common/include/common/bitmap/formats.h
@@ -83,8 +83,6 @@ inline bool is_stb_filename(std::string_view name)
 inline bool is_dds_filename(std::string_view name) { return string_iends_with(name, ".dds"); }
 inline bool is_atx_filename(std::string_view name) { return string_iends_with(name, ".atx"); }
 
-// ─── Format predicates / mappings ─────────────────────────────────────────────
-
 // True for the set of uncompressed direct-color formats: 565, 1555, 4444, 888, 8888.
 // Excludes paletted (indexed-color) and block-compressed (DXT*). Useful for any pipeline
 // that reads or writes pixel bytes directly.

--- a/common/include/common/bitmap/formats.h
+++ b/common/include/common/bitmap/formats.h
@@ -70,6 +70,9 @@ inline int bm_format_from_stb_channels(int channels)
     return (channels == 2 || channels == 4) ? BM_FORMAT_8888_ARGB : BM_FORMAT_888_RGB;
 }
 
+// Hard upper bound for stb-decoded texture dimensions.
+inline constexpr int BM_STB_MAX_DIMENSION = 16384;
+
 // ─── Filename extension predicates ────────────────────────────────────────────
 // Used by both game-side and editor-side bm hooks to decide which decode path applies.
 // Centralising these means a new format is added in exactly one place.

--- a/common/include/common/version/version.h
+++ b/common/include/common/version/version.h
@@ -45,7 +45,8 @@
 // 302 = Alpine 1.2.0
 // 303 = Alpine 1.2.2
 // 304 = Alpine 1.3.0
-#define MAXIMUM_RFL_VERSION    304
+// 305 = Alpine 1.4.0
+#define MAXIMUM_RFL_VERSION    305
 
 // clang-format on
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,11 +6,17 @@ Version 1.4.0 (Lupin): Not yet released
 ### Major features
 
 ### Minor features, changes, and enhancements
+[@GooberRF](https://github.com/GooberRF)
+- Support Alpine Texture (ATX) declarative texture format
+  - Fine tuned texture animation without being subject to VBM format limitations
+  - Accessible to event system via handle for level-driven behaviour scripting
+- Support PNG and JPG texture formats in game and level editor
 
 ### Bug fixes
 [@GooberRF](https://github.com/GooberRF)
 - Fix team balance not properly randomizing the distribution order of equal-scoring human players
 - Fix incorrect clickable area size for launcher FFLink button
+- Add `ATX_Set_Frame`, `ATX_Play`, `ATX_Pause`, `ATX_Set_Frame_Time` events
 
 [@is-this-c](https://github.com/is-this-c)
 - For `Run` games, rename `Score` column to `Deaths`, and compare `Loads` in `std::ranges::sort`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,19 +4,22 @@
 Version 1.4.0 (Lupin): Not yet released
 --------------------------------
 ### Major features
-
-### Minor features, changes, and enhancements
 [@GooberRF](https://github.com/GooberRF)
-- Support Alpine Texture (ATX) declarative texture format
+- Support Alpine Texture (ATX) declarative texture format in game and level editor
   - Fine tuned texture animation without being subject to VBM format limitations
   - Accessible to event system via handle for level-driven behaviour scripting
 - Support PNG and JPG texture formats in game and level editor
+
+### Minor features, changes, and enhancements
+[@GooberRF](https://github.com/GooberRF)
+- Support DDS texture format in level editor
+- Add `ATX_Set_Frame`, `ATX_Play`, `ATX_Pause`, `ATX_Set_Frame_Time` events
 
 ### Bug fixes
 [@GooberRF](https://github.com/GooberRF)
 - Fix team balance not properly randomizing the distribution order of equal-scoring human players
 - Fix incorrect clickable area size for launcher FFLink button
-- Add `ATX_Set_Frame`, `ATX_Play`, `ATX_Pause`, `ATX_Set_Frame_Time` events
+- Fix "allow clientside mods from legacy directories" option not applying correctly for DDS files
 
 [@is-this-c](https://github.com/is-this-c)
 - For `Run` games, rename `Score` column to `Deaths`, and compare `Loads` in `std::ranges::sort`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ Version 1.4.0 (Lupin): Not yet released
 ### Minor features, changes, and enhancements
 [@GooberRF](https://github.com/GooberRF)
 - Support DDS texture format in level editor
+- Bump RFL version to 305
 - Add `ATX_Set_Frame`, `ATX_Play`, `ATX_Pause`, `ATX_Set_Frame_Time` events
 - Add vote-allowed levels to level autodownload list for dedicated servers
 - Add `fflink_gsk` dedicated server config field and `sv_fflink_status` / `sv_fflink_resync` console commands for FactionFiles session key exchange

--- a/editor_patch/CMakeLists.txt
+++ b/editor_patch/CMakeLists.txt
@@ -14,6 +14,8 @@ set(SRCS
     corona.cpp
     corona.h
     textures.cpp
+    bitmap_loaders.cpp
+    bitmap_loaders.h
     meshes.cpp
     meshes.h
     tbl.cpp
@@ -39,7 +41,11 @@ setup_debug_info(AlpineEditor)
 target_compile_definitions(AlpineEditor PRIVATE WIN32_LEAN_AND_MEAN NOMINMAX BUILD_DLL)
 
 target_include_directories(AlpineEditor PRIVATE
+    ${CMAKE_SOURCE_DIR}/vendor
     ${CMAKE_SOURCE_DIR}/vendor/d3d8
+    ${CMAKE_SOURCE_DIR}/vendor/dds
+    ${CMAKE_SOURCE_DIR}/vendor/stb
+    ${CMAKE_SOURCE_DIR}/vendor/toml++
 )
 
 target_link_libraries(AlpineEditor
@@ -48,4 +54,5 @@ target_link_libraries(AlpineEditor
     Xlog
     CrashHandlerStub
     shlwapi
+    stb_image
 )

--- a/editor_patch/CMakeLists.txt
+++ b/editor_patch/CMakeLists.txt
@@ -43,9 +43,7 @@ target_compile_definitions(AlpineEditor PRIVATE WIN32_LEAN_AND_MEAN NOMINMAX BUI
 target_include_directories(AlpineEditor PRIVATE
     ${CMAKE_SOURCE_DIR}/vendor
     ${CMAKE_SOURCE_DIR}/vendor/d3d8
-    ${CMAKE_SOURCE_DIR}/vendor/dds
     ${CMAKE_SOURCE_DIR}/vendor/stb
-    ${CMAKE_SOURCE_DIR}/vendor/toml++
 )
 
 target_link_libraries(AlpineEditor

--- a/editor_patch/bitmap_loaders.cpp
+++ b/editor_patch/bitmap_loaders.cpp
@@ -1,0 +1,547 @@
+#include <cctype>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include <algorithm>
+#include <dds.h>
+#include <stb_image.h>
+#include <toml++/toml.hpp>
+#include <xlog/xlog.h>
+#include <patch_common/FunHook.h>
+#include <common/utils/string-utils.h>
+#include <common/bitmap/formats.h>
+#include <common/atx/parse.h>
+#include "bitmap_loaders.h"
+#include "vtypes.h"
+#include "textures.h"
+#include "level.h"
+
+namespace
+{
+    enum class DdsKind { Unsupported, RGBA32, RGB24, DXT1, DXT3, DXT5 };
+
+    // Editor's renderer can't consume DXT directly, so DXT-format DDS files decompress for editor view
+    DdsKind classify_dds(const DDS_PIXELFORMAT& p)
+    {
+        switch (bm_format_from_dds(p)) {
+            case BM_FORMAT_8888_ARGB: return DdsKind::RGBA32;
+            case BM_FORMAT_888_RGB:   return DdsKind::RGB24;
+            case BM_FORMAT_DXT1:      return DdsKind::DXT1;
+            case BM_FORMAT_DXT3:      return DdsKind::DXT3;
+            case BM_FORMAT_DXT5:      return DdsKind::DXT5;
+            default:                   return DdsKind::Unsupported;
+        }
+    }
+
+    // DXT block decoders output 4×4 RGBA pixels in BGRA byte order
+
+    inline void unpack_565(uint16_t v, uint8_t* rgba)
+    {
+        uint8_t r = static_cast<uint8_t>((v >> 11) & 0x1F);
+        uint8_t g = static_cast<uint8_t>((v >> 5)  & 0x3F);
+        uint8_t b = static_cast<uint8_t>( v        & 0x1F);
+        rgba[0] = static_cast<uint8_t>((r << 3) | (r >> 2)); // R
+        rgba[1] = static_cast<uint8_t>((g << 2) | (g >> 4)); // G
+        rgba[2] = static_cast<uint8_t>((b << 3) | (b >> 2)); // B
+        rgba[3] = 255;                                       // A
+    }
+
+    inline uint16_t read_u16le(const uint8_t* p) { return static_cast<uint16_t>(p[0] | (p[1] << 8)); }
+    inline uint32_t read_u32le(const uint8_t* p)
+    {
+        return static_cast<uint32_t>(p[0])
+             | (static_cast<uint32_t>(p[1]) << 8)
+             | (static_cast<uint32_t>(p[2]) << 16)
+             | (static_cast<uint32_t>(p[3]) << 24);
+    }
+
+    void decode_dxt_color(const uint8_t* block, uint8_t out_palette[4][4], bool dxt1)
+    {
+        uint16_t c0 = read_u16le(block);
+        uint16_t c1 = read_u16le(block + 2);
+        unpack_565(c0, out_palette[0]);
+        unpack_565(c1, out_palette[1]);
+
+        if (!dxt1 || c0 > c1) {
+            for (int i = 0; i < 3; ++i) {
+                out_palette[2][i] = static_cast<uint8_t>((2 * out_palette[0][i] + out_palette[1][i]) / 3);
+                out_palette[3][i] = static_cast<uint8_t>((out_palette[0][i] + 2 * out_palette[1][i]) / 3);
+            }
+            out_palette[2][3] = 255;
+            out_palette[3][3] = 255;
+        }
+        else {
+            for (int i = 0; i < 3; ++i) {
+                out_palette[2][i] = static_cast<uint8_t>((out_palette[0][i] + out_palette[1][i]) / 2);
+                out_palette[3][i] = 0;
+            }
+            out_palette[2][3] = 255;
+            out_palette[3][3] = 0; // 1-bit alpha: index 3 = transparent black for DXT1
+        }
+    }
+
+    void emit_dxt_color_block(const uint8_t* block, uint8_t* out, int stride, int max_w, int max_h, bool dxt1)
+    {
+        uint8_t pal[4][4];
+        decode_dxt_color(block, pal, dxt1);
+        uint32_t lookup = read_u32le(block + 4);
+        for (int y = 0; y < 4 && y < max_h; ++y) {
+            uint8_t* row = out + y * stride;
+            for (int x = 0; x < 4 && x < max_w; ++x) {
+                int idx = (lookup >> ((y * 4 + x) * 2)) & 0x3;
+                row[x * 4 + 0] = pal[idx][2]; // B
+                row[x * 4 + 1] = pal[idx][1]; // G
+                row[x * 4 + 2] = pal[idx][0]; // R
+                row[x * 4 + 3] = pal[idx][3]; // A (color-block alpha; overridden for DXT3/5 below)
+            }
+        }
+    }
+
+    void overlay_dxt3_alpha(const uint8_t* alpha_block, uint8_t* out, int stride, int max_w, int max_h)
+    {
+        // 4 bits per pixel, 16 pixels = 64 bits = 8 bytes.
+        for (int y = 0; y < 4 && y < max_h; ++y) {
+            uint16_t row_bits = read_u16le(alpha_block + y * 2);
+            uint8_t* row = out + y * stride;
+            for (int x = 0; x < 4 && x < max_w; ++x) {
+                uint8_t a4 = static_cast<uint8_t>((row_bits >> (x * 4)) & 0xF);
+                row[x * 4 + 3] = static_cast<uint8_t>((a4 << 4) | a4);
+            }
+        }
+    }
+
+    void overlay_dxt5_alpha(const uint8_t* alpha_block, uint8_t* out, int stride, int max_w, int max_h)
+    {
+        uint8_t a0 = alpha_block[0];
+        uint8_t a1 = alpha_block[1];
+        uint8_t a[8];
+        a[0] = a0;
+        a[1] = a1;
+        if (a0 > a1) {
+            for (int i = 1; i < 7; ++i) {
+                a[i + 1] = static_cast<uint8_t>(((7 - i) * a0 + i * a1) / 7);
+            }
+        }
+        else {
+            for (int i = 1; i < 5; ++i) {
+                a[i + 1] = static_cast<uint8_t>(((5 - i) * a0 + i * a1) / 5);
+            }
+            a[6] = 0;
+            a[7] = 255;
+        }
+        // 3 bits per pixel × 16 pixels = 48 bits packed in 6 bytes after the two endpoints.
+        uint64_t indices = 0;
+        for (int i = 0; i < 6; ++i) {
+            indices |= static_cast<uint64_t>(alpha_block[2 + i]) << (i * 8);
+        }
+        for (int y = 0; y < 4 && y < max_h; ++y) {
+            uint8_t* row = out + y * stride;
+            for (int x = 0; x < 4 && x < max_w; ++x) {
+                int idx = static_cast<int>((indices >> ((y * 4 + x) * 3)) & 0x7);
+                row[x * 4 + 3] = a[idx];
+            }
+        }
+    }
+
+    bool decompress_dxt(DdsKind kind, const uint8_t* blocks, int width, int height, uint8_t* out_bgra)
+    {
+        const int blk_w = (width + 3) / 4;
+        const int blk_h = (height + 3) / 4;
+        const int stride = width * 4;
+        const bool is_dxt1 = (kind == DdsKind::DXT1);
+        const int block_bytes = is_dxt1 ? 8 : 16;
+
+        for (int by = 0; by < blk_h; ++by) {
+            for (int bx = 0; bx < blk_w; ++bx) {
+                const uint8_t* block = blocks + (by * blk_w + bx) * block_bytes;
+                uint8_t* out = out_bgra + (by * 4) * stride + (bx * 4) * 4;
+                int max_w = std::min(4, width - bx * 4);
+                int max_h = std::min(4, height - by * 4);
+
+                if (is_dxt1) {
+                    emit_dxt_color_block(block, out, stride, max_w, max_h, true);
+                }
+                else if (kind == DdsKind::DXT3) {
+                    emit_dxt_color_block(block + 8, out, stride, max_w, max_h, false);
+                    overlay_dxt3_alpha(block, out, stride, max_w, max_h);
+                }
+                else { // DXT5
+                    emit_dxt_color_block(block + 8, out, stride, max_w, max_h, false);
+                    overlay_dxt5_alpha(block, out, stride, max_w, max_h);
+                }
+            }
+        }
+        return true;
+    }
+
+    using BmReadHeaderFn = int(__cdecl*)(const char* name, int* w, int* h, int* format,
+        int* num_levels, void* pal_unused, int* num_frames, int* fps, int* total_bytes,
+        void* vbm_ver_unused, const char* default_path);
+    using BmLockFn = int(__cdecl*)(int handle, void** pixels_out, void** palette_out);
+
+    // Extension predicates live at global scope in common/bitmap/formats.h (shared with game side).
+
+    bool read_file_to_vector(const char* filename, std::vector<uint8_t>& out)
+    {
+        // Editor's rf::File::open() is a *find* — open_mode() does the real fopen. close() on a
+        // not-actually-opened File crashes with NULL fclose, so always go through open_mode.
+        rf::File file;
+        if (file.open_mode(filename) != 0) {
+            return false;
+        }
+        const int file_size = file.get_size();
+        if (file_size <= 0) {
+            file.close();
+            return false;
+        }
+        out.resize(static_cast<size_t>(file_size));
+        const int bytes_read = file.read(out.data(), file_size);
+        file.close();
+        return bytes_read == file_size;
+    }
+
+    bool read_file_to_string(const char* filename, std::string& out)
+    {
+        rf::File file;
+        if (file.open_mode(filename) != 0) return false;
+        int file_size = file.get_size();
+        if (file_size <= 0) { file.close(); return false; }
+        out.assign(static_cast<size_t>(file_size), '\0');
+        int n = file.read(out.data(), file_size);
+        file.close();
+        return n == file_size;
+    }
+
+    // PNG/JPEG via stb_image
+
+    bool fill_stb_header(const char* filename, int* w, int* h, int* format, int* num_levels,
+                        int* num_frames, int* fps, int* total_bytes)
+    {
+        std::vector<uint8_t> file_bytes;
+        if (!read_file_to_vector(filename, file_bytes)) return false;
+        int sw = 0, sh = 0, channels = 0;
+        if (!stbi_info_from_memory(file_bytes.data(), static_cast<int>(file_bytes.size()),
+                                   &sw, &sh, &channels)) {
+            xlog::warn("editor stb_image: failed to read header for '{}': {}",
+                       filename, stbi_failure_reason());
+            return false;
+        }
+        if (sw <= 0 || sh <= 0) return false;
+
+        // Channel-count → format mapping shared with game side via common/bitmap/formats.h
+        // (1/3 channel → 24-bit RGB, 2/4 channel → 32-bit RGBA).
+        *w = sw;
+        *h = sh;
+        *format = bm_format_from_stb_channels(channels);
+        *num_levels = 1;
+        *num_frames = 1;
+        *fps = 0;
+        *total_bytes = -1;
+        return true;
+    }
+
+    bool fill_stb_locked_data(BitmapEntry& entry)
+    {
+        // Defensively null out before any failure path so a re-lock-after-unlock can't expose
+        // the previous (already-freed) pointer if the new lock fails partway through.
+        entry.locked_data = nullptr;
+        entry.locked_palette = nullptr;
+
+        std::vector<uint8_t> file_bytes;
+        if (!read_file_to_vector(entry.name, file_bytes)) {
+            xlog::error("editor stb_image: failed to reopen '{}' during lock", entry.name);
+            return false;
+        }
+        // Output channels match the format we declared at read_header time.
+        const int desired = (entry.format == EDITOR_BM_FORMAT_8888_ARGB) ? 4 : 3;
+        int w = 0, h = 0, source_channels = 0;
+        uint8_t* pixels = stbi_load_from_memory(file_bytes.data(),
+            static_cast<int>(file_bytes.size()), &w, &h, &source_channels, desired);
+        if (!pixels) {
+            xlog::error("editor stb_image: decode failed for '{}': {}",
+                        entry.name, stbi_failure_reason());
+            return false;
+        }
+        if (w != entry.orig_width || h != entry.orig_height) {
+            xlog::error("editor stb_image: '{}' dims changed between header and decode", entry.name);
+            stbi_image_free(pixels);
+            return false;
+        }
+        const size_t total = static_cast<size_t>(w) * h * desired;
+        void* dst = rf_alloc(total);
+        if (!dst) { stbi_image_free(pixels); return false; }
+        std::memcpy(dst, pixels, total);
+        // stb returns RGB(A) byte order; both FORMAT_888_RGB and FORMAT_8888_ARGB use BGR(A)
+        // memory layout (R at the highest channel position). Swap channel 0 and 2 per pixel.
+        auto* p = static_cast<uint8_t*>(dst);
+        for (int i = 0; i < w * h; ++i) std::swap(p[i * desired + 0], p[i * desired + 2]);
+        entry.locked_data = dst;
+        entry.locked_palette = nullptr;
+        stbi_image_free(pixels);
+        return true;
+    }
+
+    // DDS
+
+    // Parse just the header so we can fill read_header outputs without decoding pixels.
+    bool fill_dds_header(const char* filename, int* w, int* h, int* format, int* num_levels,
+                         int* num_frames, int* fps, int* total_bytes)
+    {
+        std::vector<uint8_t> file_bytes;
+        if (!read_file_to_vector(filename, file_bytes)) return false;
+        if (file_bytes.size() < 4 + sizeof(DDS_HEADER)) return false;
+
+        if (read_u32le(file_bytes.data()) != DDS_MAGIC) {
+            xlog::warn("editor DDS: '{}' has wrong magic", filename);
+            return false;
+        }
+        DDS_HEADER hdr;
+        std::memcpy(&hdr, file_bytes.data() + 4, sizeof(hdr));
+        if (hdr.size != sizeof(DDS_HEADER)) {
+            xlog::warn("editor DDS: '{}' header size {} unexpected", filename, hdr.size);
+            return false;
+        }
+
+        DdsKind kind = classify_dds(hdr.ddspf);
+        if (kind == DdsKind::Unsupported) {
+            xlog::warn("editor DDS: '{}' uses an unsupported pixel format (flags=0x{:x} "
+                       "fourCC=0x{:x} bits={})",
+                       filename, hdr.ddspf.flags, hdr.ddspf.fourCC, hdr.ddspf.RGBBitCount);
+            return false;
+        }
+
+        *w = static_cast<int>(hdr.width);
+        *h = static_cast<int>(hdr.height);
+        *format = EDITOR_BM_FORMAT_8888_ARGB; // we always decode to RGBA8
+        *num_levels = 1;                      // editor uses only base mip; saves DXT mip work
+        *num_frames = 1;
+        *fps = 0;
+        *total_bytes = -1;
+        return true;
+    }
+
+    bool fill_dds_locked_data(BitmapEntry& entry)
+    {
+        // Same defensive nulling as fill_stb_locked_data — protects against any path that
+        // reads entry.locked_data after a re-lock that fails before the success store.
+        entry.locked_data = nullptr;
+        entry.locked_palette = nullptr;
+
+        std::vector<uint8_t> file_bytes;
+        if (!read_file_to_vector(entry.name, file_bytes)) return false;
+        if (file_bytes.size() < 4 + sizeof(DDS_HEADER)) return false;
+        if (read_u32le(file_bytes.data()) != DDS_MAGIC) return false;
+
+        DDS_HEADER hdr;
+        std::memcpy(&hdr, file_bytes.data() + 4, sizeof(hdr));
+        DdsKind kind = classify_dds(hdr.ddspf);
+        const uint8_t* data = file_bytes.data() + 4 + sizeof(DDS_HEADER);
+        const size_t data_bytes = file_bytes.size() - 4 - sizeof(DDS_HEADER);
+        const int w = static_cast<int>(hdr.width);
+        const int h = static_cast<int>(hdr.height);
+
+        const size_t out_bytes = static_cast<size_t>(w) * h * 4;
+        void* dst = rf_alloc(out_bytes);
+        if (!dst) return false;
+        auto* out = static_cast<uint8_t*>(dst);
+
+        if (kind == DdsKind::RGBA32) {
+            const size_t need = static_cast<size_t>(w) * h * 4;
+            if (data_bytes < need) { editor_free(dst); return false; }
+            std::memcpy(out, data, need);
+            // Source is typically BGRA already (D3DFMT_A8R8G8B8), which is what we want — no swap.
+        }
+        else if (kind == DdsKind::RGB24) {
+            const size_t need = static_cast<size_t>(w) * h * 3;
+            if (data_bytes < need) { editor_free(dst); return false; }
+            // Expand BGR → BGRA, A=255.
+            for (int i = 0; i < w * h; ++i) {
+                out[i * 4 + 0] = data[i * 3 + 0];
+                out[i * 4 + 1] = data[i * 3 + 1];
+                out[i * 4 + 2] = data[i * 3 + 2];
+                out[i * 4 + 3] = 255;
+            }
+        }
+        else { // DXT1 / DXT3 / DXT5
+            const int blk_w = (w + 3) / 4;
+            const int blk_h = (h + 3) / 4;
+            const int block_bytes = (kind == DdsKind::DXT1) ? 8 : 16;
+            const size_t need = static_cast<size_t>(blk_w) * blk_h * block_bytes;
+            if (data_bytes < need) {
+                xlog::error("editor DDS: '{}' truncated (need {} bytes for blocks, have {})",
+                            entry.name, need, data_bytes);
+                editor_free(dst);
+                return false;
+            }
+            decompress_dxt(kind, data, w, h, out);
+        }
+
+        entry.locked_data = dst;
+        entry.locked_palette = nullptr;
+        return true;
+    }
+
+    // ATX (frame-0 preview)
+    // Editor doesn't run the game tick, so animation is irrelevant
+    std::unordered_map<std::string, std::string> g_atx_redirects;
+
+    // Re-entrancy guard in case anything goes weird while loading a child texture.
+    bool g_loading_atx_child = false;
+
+    std::optional<std::string> get_atx_frame0_filename(const char* atx_filename)
+    {
+        std::string content;
+        if (!read_file_to_string(atx_filename, content)) return std::nullopt;
+        auto spec = parse_atx(content, atx_filename);
+        if (!spec || spec->frames.empty()) return std::nullopt;
+        return spec->frames[0].filename;
+    }
+
+    bool fill_atx_header(const char* atx_filename, int* w, int* h, int* format, int* num_levels,
+                         int* num_frames, int* fps, int* total_bytes)
+    {
+        auto frame0 = get_atx_frame0_filename(atx_filename);
+        if (!frame0) return false;
+
+        // Recursively load the child via the editor's bm system. With g_loading_atx_child set,
+        // our hook refuses to recurse on .atx names.
+        int child_handle = -1;
+        {
+            g_loading_atx_child = true;
+            child_handle = BitmapEntry::load(frame0->c_str(), 0);
+            g_loading_atx_child = false;
+        }
+        if (child_handle < 0) {
+            xlog::warn("editor ATX: '{}' could not load frame[0] '{}'", atx_filename, *frame0);
+            return false;
+        }
+        const int idx = BitmapEntry::handle_to_index(child_handle);
+        if (idx < 0) return false;
+        BitmapEntry& child = BitmapEntry::entries[idx];
+
+        *w = child.orig_width ? child.orig_width : child.width;
+        *h = child.orig_height ? child.orig_height : child.height;
+        *format = child.format;
+        *num_levels = child.num_levels ? child.num_levels : 1;
+        *num_frames = 1;
+        *fps = 0;
+        *total_bytes = -1;
+
+        g_atx_redirects[string_to_lower(atx_filename)] = *frame0;
+        return true;
+    }
+
+    FunHook<int(const char*, int*, int*, int*, int*, void*, int*, int*, int*, void*, const char*)>
+    editor_bm_read_header_hook{
+        0x004BC200,
+        [](const char* name, int* w, int* h, int* format, int* num_levels, void* pal_buf,
+           int* num_frames, int* fps, int* total_bytes, void* vbm_ver_buf, const char* default_path)
+        {
+            if (is_stb_filename(name)) {
+                if (fill_stb_header(name, w, h, format, num_levels, num_frames, fps, total_bytes)) {
+                    return EDITOR_BM_TYPE_STB;
+                }
+                return 0;
+            }
+            if (is_dds_filename(name)) {
+                if (fill_dds_header(name, w, h, format, num_levels, num_frames, fps, total_bytes)) {
+                    return EDITOR_BM_TYPE_DDS;
+                }
+                return 0; // unsupported DDS subformat → placeholder, no error dialog
+            }
+            if (is_atx_filename(name)) {
+                if (g_loading_atx_child) return 0; // refuse recursive .atx load
+                if (fill_atx_header(name, w, h, format, num_levels, num_frames, fps, total_bytes)) {
+                    return EDITOR_BM_TYPE_ATX;
+                }
+                return 0;
+            }
+            return editor_bm_read_header_hook.call_target(name, w, h, format, num_levels, pal_buf,
+                num_frames, fps, total_bytes, vbm_ver_buf, default_path);
+        }
+    };
+
+    FunHook<int(int, void**, void**)> editor_bm_lock_hook{
+        0x004BCCD0,
+        [](int handle, void** pixels_out, void** palette_out) -> int {
+            const int idx = BitmapEntry::handle_to_index(handle);
+            if (idx < 0) {
+                *pixels_out = nullptr;
+                *palette_out = nullptr;
+                return 0;
+            }
+            BitmapEntry& entry = BitmapEntry::entries[idx];
+
+            if (entry.bm_type == EDITOR_BM_TYPE_STB) {
+                if (fill_stb_locked_data(entry)) {
+                    *pixels_out = entry.locked_data;
+                    *palette_out = entry.locked_palette;
+                    return entry.format;
+                }
+                *pixels_out = nullptr; *palette_out = nullptr; return 0;
+            }
+            if (entry.bm_type == EDITOR_BM_TYPE_DDS) {
+                if (fill_dds_locked_data(entry)) {
+                    *pixels_out = entry.locked_data;
+                    *palette_out = entry.locked_palette;
+                    return entry.format;
+                }
+                *pixels_out = nullptr; *palette_out = nullptr; return 0;
+            }
+            if (entry.bm_type == EDITOR_BM_TYPE_ATX) {
+                auto it = g_atx_redirects.find(string_to_lower(entry.name));
+                if (it == g_atx_redirects.end()) {
+                    *pixels_out = nullptr; *palette_out = nullptr; return 0;
+                }
+                // Re-resolve frame[0]'s bm_handle by filename. BitmapEntry::load is name-cached
+                // (returns the existing handle if already loaded) so this is cheap, and it's
+                // robust against the original child handle having been freed and replaced.
+                int child_handle = -1;
+                {
+                    g_loading_atx_child = true;
+                    child_handle = BitmapEntry::load(it->second.c_str(), 0);
+                    g_loading_atx_child = false;
+                }
+                if (child_handle < 0) {
+                    *pixels_out = nullptr; *palette_out = nullptr; return 0;
+                }
+                // Forward lock to the child handle. Recurses through this hook; the child is
+                // not type ATX so it dispatches to the appropriate non-ATX branch.
+                return editor_bm_lock_hook.call_target(child_handle, pixels_out, palette_out);
+            }
+            return editor_bm_lock_hook.call_target(handle, pixels_out, palette_out);
+        }
+    };
+}
+
+void install_editor_bitmap_loader_hooks()
+{
+    editor_bm_read_header_hook.install();
+    editor_bm_lock_hook.install();
+    xlog::info("Editor bitmap loader hooks installed (PNG/JPG, DDS, ATX preview)");
+}
+
+std::vector<std::string> parse_atx_dependencies(const char* atx_filename)
+{
+    std::vector<std::string> deps;
+    std::string content;
+    if (!read_file_to_string(atx_filename, content)) {
+        return deps;
+    }
+
+    auto spec = parse_atx(content, atx_filename);
+    if (!spec) return deps;
+
+    // [header].alpha_mask (the parser already filtered out empty strings).
+    if (spec->header.alpha_mask && !string_iends_with(*spec->header.alpha_mask, ".atx")) {
+        deps.push_back(*spec->header.alpha_mask);
+    }
+    // Each [[frame]].file — parser already enforces non-empty and non-.atx.
+    for (auto& f : spec->frames) {
+        deps.push_back(std::move(f.filename));
+    }
+    return deps;
+}

--- a/editor_patch/bitmap_loaders.cpp
+++ b/editor_patch/bitmap_loaders.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+#include <array>
 #include <cctype>
 #include <cstdint>
 #include <cstring>
@@ -5,7 +7,6 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <algorithm>
 #include <dds.h>
 #include <stb_image.h>
 #include <toml++/toml.hpp>
@@ -243,6 +244,18 @@ namespace
         return true;
     }
 
+    // Per-binary file redirect map for STB/DDS. Populated at read_header time when a sibling
+    std::unordered_map<std::string, std::string> g_file_redirects;
+
+    // Resolve the filename to read for a given bm_entry. Returns the redirect-stored sibling
+    // filename if one was recorded at header time, otherwise the entry's literal name.
+    std::string resolve_locked_filename(const BitmapEntry& entry)
+    {
+        auto it = g_file_redirects.find(string_to_lower(entry.name));
+        if (it != g_file_redirects.end()) return it->second;
+        return entry.name;
+    }
+
     bool fill_stb_locked_data(BitmapEntry& entry)
     {
         // Defensively null out before any failure path so a re-lock-after-unlock can't expose
@@ -250,9 +263,10 @@ namespace
         entry.locked_data = nullptr;
         entry.locked_palette = nullptr;
 
+        const std::string filename = resolve_locked_filename(entry);
         std::vector<uint8_t> file_bytes;
-        if (!read_file_to_vector(entry.name, file_bytes)) {
-            xlog::error("editor stb_image: failed to reopen '{}' during lock", entry.name);
+        if (!read_file_to_vector(filename.c_str(), file_bytes)) {
+            xlog::error("editor stb_image: failed to reopen '{}' during lock", filename);
             return false;
         }
         // Output channels match the format we declared at read_header time.
@@ -330,8 +344,9 @@ namespace
         entry.locked_data = nullptr;
         entry.locked_palette = nullptr;
 
+        const std::string filename = resolve_locked_filename(entry);
         std::vector<uint8_t> file_bytes;
-        if (!read_file_to_vector(entry.name, file_bytes)) return false;
+        if (!read_file_to_vector(filename.c_str(), file_bytes)) return false;
         if (file_bytes.size() < 4 + sizeof(DDS_HEADER)) return false;
         if (read_u32le(file_bytes.data()) != DDS_MAGIC) return false;
 
@@ -386,6 +401,8 @@ namespace
 
     // ATX (frame-0 preview)
     // Editor doesn't run the game tick, so animation is irrelevant
+    // Keyed by lowercased bm_entry.name (the originally requested filename — which may be a
+    // legacy .tga/.vbm name superceded to .atx). The value is the resolved frame[0] filename.
     std::unordered_map<std::string, std::string> g_atx_redirects;
 
     // Re-entrancy guard in case anything goes weird while loading a child texture.
@@ -400,7 +417,42 @@ namespace
         return spec->frames[0].filename;
     }
 
-    bool fill_atx_header(const char* atx_filename, int* w, int* h, int* format, int* num_levels,
+    // Returns true if the editor's VFS can find the named file (either loose or in a packfile).
+    // Cheap probe used to decide whether a sibling exists before committing to decode it.
+    bool sibling_file_exists(const char* filename)
+    {
+        rf::File file;
+        if (file.open_mode(filename) != 0) return false;
+        file.close();
+        return true;
+    }
+
+    // Probe the supercede chain (.atx > .dds > .png > .jpg > .jpeg) for a sibling of
+    // `requested_name`. Returns the first existing sibling that is not the requested file
+    // itself, or empty string if none qualify. Mirrors the game-side chain so the editor
+    // previews the same file the game will actually load.
+    constexpr std::array<std::string_view, 5> editor_sibling_supercede_extensions = {
+        ".atx", ".dds", ".png", ".jpg", ".jpeg"
+    };
+
+    std::string find_supercede_sibling(const char* requested_name)
+    {
+        std::string base{get_filename_without_ext(requested_name)};
+        for (auto ext : editor_sibling_supercede_extensions) {
+            std::string candidate = base + std::string{ext};
+            // Don't resolve to ourselves — the caller already handles its own extension via
+            // the direct dispatch below. This also avoids infinite recursion when the
+            // requested file happens to be one of the new formats but doesn't exist on disk.
+            if (string_iequals(candidate, requested_name)) continue;
+            if (sibling_file_exists(candidate.c_str())) {
+                return candidate;
+            }
+        }
+        return {};
+    }
+
+    bool fill_atx_header(const char* atx_filename, const char* original_name,
+                         int* w, int* h, int* format, int* num_levels,
                          int* num_frames, int* fps, int* total_bytes)
     {
         auto frame0 = get_atx_frame0_filename(atx_filename);
@@ -430,7 +482,13 @@ namespace
         *fps = 0;
         *total_bytes = -1;
 
-        g_atx_redirects[string_to_lower(atx_filename)] = *frame0;
+        // Index the redirect under the originally-requested name (matches what the bm system
+        // will store in entry.name) AND under the .atx filename, so direct .atx loads still
+        // work alongside supercede resolutions.
+        g_atx_redirects[string_to_lower(original_name)] = *frame0;
+        if (!string_iequals(original_name, atx_filename)) {
+            g_atx_redirects[string_to_lower(atx_filename)] = *frame0;
+        }
         return true;
     }
 
@@ -454,15 +512,51 @@ namespace
             }
             if (is_atx_filename(name)) {
                 if (g_loading_atx_child) return 0; // refuse recursive .atx load
-                if (fill_atx_header(name, w, h, format, num_levels, num_frames, fps, total_bytes)) {
+                if (fill_atx_header(name, name, w, h, format, num_levels, num_frames, fps, total_bytes)) {
                     return EDITOR_BM_TYPE_ATX;
                 }
                 return 0;
+            }
+            // Legacy-named — probe the supercede chain so the editor preview
+            // matches what the game side resolves at runtime. WYSIWYG with the in-game render.
+            if (!g_loading_atx_child) {
+                std::string sibling = find_supercede_sibling(name);
+                if (!sibling.empty()) {
+                    if (is_atx_filename(sibling)) {
+                        if (fill_atx_header(sibling.c_str(), name, w, h, format, num_levels,
+                                            num_frames, fps, total_bytes)) {
+                            return EDITOR_BM_TYPE_ATX;
+                        }
+                    }
+                    else if (is_dds_filename(sibling)) {
+                        if (fill_dds_header(sibling.c_str(), w, h, format, num_levels,
+                                            num_frames, fps, total_bytes)) {
+                            g_file_redirects[string_to_lower(name)] = sibling;
+                            return EDITOR_BM_TYPE_DDS;
+                        }
+                    }
+                    else if (is_stb_filename(sibling)) {
+                        if (fill_stb_header(sibling.c_str(), w, h, format, num_levels,
+                                            num_frames, fps, total_bytes)) {
+                            g_file_redirects[string_to_lower(name)] = sibling;
+                            return EDITOR_BM_TYPE_STB;
+                        }
+                    }
+                    // sibling probe failed; fall through to stock dispatch below
+                }
             }
             return editor_bm_read_header_hook.call_target(name, w, h, format, num_levels, pal_buf,
                 num_frames, fps, total_bytes, vbm_ver_buf, default_path);
         }
     };
+
+    // Lock an entry by its bm_type. For custom types (STB/DDS), invoke the editor-side decoder
+    // directly. For stock types, invoke the trampoline so RED's original dispatch runs.
+    //
+    // RED's original bm_lock at 0x004BCCD0 contains a default-case `do { assert } while(true)`
+    // which hangs the editor on unknown bm_type, so we must NEVER let a custom bm_type
+    // (0x10/0x11/0x12) reach the trampoline.
+    int dispatch_lock(BitmapEntry& entry, int handle, void** pixels_out, void** palette_out);
 
     FunHook<int(int, void**, void**)> editor_bm_lock_hook{
         0x004BCCD0,
@@ -474,47 +568,58 @@ namespace
                 return 0;
             }
             BitmapEntry& entry = BitmapEntry::entries[idx];
-
-            if (entry.bm_type == EDITOR_BM_TYPE_STB) {
-                if (fill_stb_locked_data(entry)) {
-                    *pixels_out = entry.locked_data;
-                    *palette_out = entry.locked_palette;
-                    return entry.format;
-                }
-                *pixels_out = nullptr; *palette_out = nullptr; return 0;
-            }
-            if (entry.bm_type == EDITOR_BM_TYPE_DDS) {
-                if (fill_dds_locked_data(entry)) {
-                    *pixels_out = entry.locked_data;
-                    *palette_out = entry.locked_palette;
-                    return entry.format;
-                }
-                *pixels_out = nullptr; *palette_out = nullptr; return 0;
-            }
-            if (entry.bm_type == EDITOR_BM_TYPE_ATX) {
-                auto it = g_atx_redirects.find(string_to_lower(entry.name));
-                if (it == g_atx_redirects.end()) {
-                    *pixels_out = nullptr; *palette_out = nullptr; return 0;
-                }
-                // Re-resolve frame[0]'s bm_handle by filename. BitmapEntry::load is name-cached
-                // (returns the existing handle if already loaded) so this is cheap, and it's
-                // robust against the original child handle having been freed and replaced.
-                int child_handle = -1;
-                {
-                    g_loading_atx_child = true;
-                    child_handle = BitmapEntry::load(it->second.c_str(), 0);
-                    g_loading_atx_child = false;
-                }
-                if (child_handle < 0) {
-                    *pixels_out = nullptr; *palette_out = nullptr; return 0;
-                }
-                // Forward lock to the child handle. Recurses through this hook; the child is
-                // not type ATX so it dispatches to the appropriate non-ATX branch.
-                return editor_bm_lock_hook.call_target(child_handle, pixels_out, palette_out);
-            }
-            return editor_bm_lock_hook.call_target(handle, pixels_out, palette_out);
+            return dispatch_lock(entry, handle, pixels_out, palette_out);
         }
     };
+
+    int dispatch_lock(BitmapEntry& entry, int handle, void** pixels_out, void** palette_out)
+    {
+        if (entry.bm_type == EDITOR_BM_TYPE_STB) {
+            if (fill_stb_locked_data(entry)) {
+                *pixels_out = entry.locked_data;
+                *palette_out = entry.locked_palette;
+                return entry.format;
+            }
+            *pixels_out = nullptr; *palette_out = nullptr; return 0;
+        }
+        if (entry.bm_type == EDITOR_BM_TYPE_DDS) {
+            if (fill_dds_locked_data(entry)) {
+                *pixels_out = entry.locked_data;
+                *palette_out = entry.locked_palette;
+                return entry.format;
+            }
+            *pixels_out = nullptr; *palette_out = nullptr; return 0;
+        }
+        if (entry.bm_type == EDITOR_BM_TYPE_ATX) {
+            auto it = g_atx_redirects.find(string_to_lower(entry.name));
+            if (it == g_atx_redirects.end()) {
+                *pixels_out = nullptr; *palette_out = nullptr; return 0;
+            }
+            // Re-resolve frame[0]'s bm_handle by filename. BitmapEntry::load is name-cached
+            // (returns the existing handle if already loaded) so this is cheap, and it's
+            // robust against the original child handle having been freed and replaced.
+            int child_handle = -1;
+            {
+                g_loading_atx_child = true;
+                child_handle = BitmapEntry::load(it->second.c_str(), 0);
+                g_loading_atx_child = false;
+            }
+            if (child_handle < 0) {
+                *pixels_out = nullptr; *palette_out = nullptr; return 0;
+            }
+            const int child_idx = BitmapEntry::handle_to_index(child_handle);
+            if (child_idx < 0) {
+                *pixels_out = nullptr; *palette_out = nullptr; return 0;
+            }
+            BitmapEntry& child = BitmapEntry::entries[child_idx];
+            // Re-dispatch on the child's bm_type. This routes custom-type children (DDS/STB)
+            // through our decoders rather than RED's original lock, which would hang on those
+            // types. Stock-type children (TGA/VBM/etc.) hit the call_target branch below.
+            return dispatch_lock(child, child_handle, pixels_out, palette_out);
+        }
+        // Stock bm_type — safe to invoke RED's original lock.
+        return editor_bm_lock_hook.call_target(handle, pixels_out, palette_out);
+    }
 }
 
 void install_editor_bitmap_loader_hooks()
@@ -522,6 +627,12 @@ void install_editor_bitmap_loader_hooks()
     editor_bm_read_header_hook.install();
     editor_bm_lock_hook.install();
     xlog::info("Editor bitmap loader hooks installed (PNG/JPG, DDS, ATX preview)");
+}
+
+void clear_editor_bitmap_redirects()
+{
+    g_atx_redirects.clear();
+    g_file_redirects.clear();
 }
 
 std::vector<std::string> parse_atx_dependencies(const char* atx_filename)

--- a/editor_patch/bitmap_loaders.cpp
+++ b/editor_patch/bitmap_loaders.cpp
@@ -231,6 +231,12 @@ namespace
             return false;
         }
         if (sw <= 0 || sh <= 0) return false;
+        // Reject oversized images so the lock path's int arithmetic can't overflow.
+        if (sw > BM_STB_MAX_DIMENSION || sh > BM_STB_MAX_DIMENSION) {
+            xlog::warn("editor stb_image: '{}' rejected ({}x{} exceeds {} px ceiling)",
+                       filename, sw, sh, BM_STB_MAX_DIMENSION);
+            return false;
+        }
 
         // Channel-count → format mapping shared with game side via common/bitmap/formats.h
         // (1/3 channel → 24-bit RGB, 2/4 channel → 32-bit RGBA).
@@ -284,14 +290,17 @@ namespace
             stbi_image_free(pixels);
             return false;
         }
-        const size_t total = static_cast<size_t>(w) * h * desired;
+        // dims pre-validated against BM_STB_MAX_DIMENSION at header time, so w * h * desired
+        // stays in int range here.
+        const int num_pixels = w * h;
+        const size_t total = static_cast<size_t>(num_pixels) * desired;
         void* dst = rf_alloc(total);
         if (!dst) { stbi_image_free(pixels); return false; }
         std::memcpy(dst, pixels, total);
         // stb returns RGB(A) byte order; both FORMAT_888_RGB and FORMAT_8888_ARGB use BGR(A)
         // memory layout (R at the highest channel position). Swap channel 0 and 2 per pixel.
         auto* p = static_cast<uint8_t*>(dst);
-        for (int i = 0; i < w * h; ++i) std::swap(p[i * desired + 0], p[i * desired + 2]);
+        for (int i = 0; i < num_pixels; ++i) std::swap(p[i * desired + 0], p[i * desired + 2]);
         entry.locked_data = dst;
         entry.locked_palette = nullptr;
         stbi_image_free(pixels);

--- a/editor_patch/bitmap_loaders.cpp
+++ b/editor_patch/bitmap_loaders.cpp
@@ -282,11 +282,11 @@ namespace
             static_cast<int>(file_bytes.size()), &w, &h, &source_channels, desired);
         if (!pixels) {
             xlog::error("editor stb_image: decode failed for '{}': {}",
-                        entry.name, stbi_failure_reason());
+                        filename, stbi_failure_reason());
             return false;
         }
         if (w != entry.orig_width || h != entry.orig_height) {
-            xlog::error("editor stb_image: '{}' dims changed between header and decode", entry.name);
+            xlog::error("editor stb_image: '{}' dims changed between header and decode", filename);
             stbi_image_free(pixels);
             return false;
         }

--- a/editor_patch/bitmap_loaders.cpp
+++ b/editor_patch/bitmap_loaders.cpp
@@ -232,9 +232,9 @@ namespace
         }
         if (sw <= 0 || sh <= 0) return false;
         // Reject oversized images so the lock path's int arithmetic can't overflow.
-        if (sw > BM_STB_MAX_DIMENSION || sh > BM_STB_MAX_DIMENSION) {
+        if (sw > BM_MAX_DIMENSION || sh > BM_MAX_DIMENSION) {
             xlog::warn("editor stb_image: '{}' rejected ({}x{} exceeds {} px ceiling)",
-                       filename, sw, sh, BM_STB_MAX_DIMENSION);
+                       filename, sw, sh, BM_MAX_DIMENSION);
             return false;
         }
 
@@ -290,7 +290,7 @@ namespace
             stbi_image_free(pixels);
             return false;
         }
-        // dims pre-validated against BM_STB_MAX_DIMENSION at header time, so w * h * desired
+        // dims pre-validated against BM_MAX_DIMENSION at header time, so w * h * desired
         // stays in int range here.
         const int num_pixels = w * h;
         const size_t total = static_cast<size_t>(num_pixels) * desired;
@@ -333,6 +333,13 @@ namespace
             xlog::warn("editor DDS: '{}' uses an unsupported pixel format (flags=0x{:x} "
                        "fourCC=0x{:x} bits={})",
                        filename, hdr.ddspf.flags, hdr.ddspf.fourCC, hdr.ddspf.RGBBitCount);
+            return false;
+        }
+
+        // Reject invalid dimensions before reaching int arithmetic in fill_dds_locked_data.
+        if (hdr.width == 0 || hdr.height == 0
+            || hdr.width > BM_MAX_DIMENSION || hdr.height > BM_MAX_DIMENSION) {
+            xlog::warn("editor DDS: '{}' rejected ({}x{} outside (0, {}])", filename, hdr.width, hdr.height, BM_MAX_DIMENSION);
             return false;
         }
 

--- a/editor_patch/bitmap_loaders.h
+++ b/editor_patch/bitmap_loaders.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "vtypes.h"
+#include "textures.h"
+#include <string>
+#include <vector>
+
+// Editor-side bitmap format extensions
+constexpr int EDITOR_BM_TYPE_STB = 0x12;
+constexpr int EDITOR_BM_TYPE_DDS = 0x10;
+constexpr int EDITOR_BM_TYPE_ATX = 0x11;
+
+// Format constants matching the stock engine values
+constexpr int EDITOR_BM_FORMAT_8888_ARGB = 7;
+constexpr int EDITOR_BM_FORMAT_888_RGB = 6;
+
+void install_editor_bitmap_loader_hooks();
+
+// Parse an ATX file and return the list of texture filenames it references
+std::vector<std::string> parse_atx_dependencies(const char* atx_filename);

--- a/editor_patch/bitmap_loaders.h
+++ b/editor_patch/bitmap_loaders.h
@@ -18,3 +18,7 @@ void install_editor_bitmap_loader_hooks();
 
 // Parse an ATX file and return the list of texture filenames it references
 std::vector<std::string> parse_atx_dependencies(const char* atx_filename);
+
+// Clear the editor's ATX→frame[0] and legacy-name→sibling redirect caches. Safe to call
+// from texture-reload paths to pick up edits to .atx files made on disk during a session.
+void clear_editor_bitmap_redirects();

--- a/editor_patch/event.cpp
+++ b/editor_patch/event.cpp
@@ -35,7 +35,7 @@
 
 // Custom event support
 constexpr int original_event_count = 89;
-constexpr int new_event_count = 55; // must be 1 higher than actual count
+constexpr int new_event_count = 59; // must be 1 higher than actual count
 constexpr int total_event_count = original_event_count + new_event_count;
 std::unique_ptr<const char*[]> extended_event_names; // array to hold original + additional event names
 
@@ -95,6 +95,10 @@ const char* additional_event_names[new_event_count] = {
     "Gas_Region_State",
     "Modify_Gas_Region",
     "Resize_Gas_Region",
+    "ATX_Set_Frame",
+    "ATX_Play",
+    "ATX_Pause",
+    "ATX_Set_Frame_Time",
     "_dummy"
 };
 
@@ -761,6 +765,32 @@ std::map<AlpineDedEventID, FieldConfig> eventFieldConfigs = {
         },
         {
             {FIELD_INT1, true}
+        }
+    }},
+    {AlpineDedEventID::ATX_Set_Frame, {
+        {FIELD_STR1, FIELD_INT1},
+        {
+            {FIELD_STR1, "ATX handle (str1):"},
+            {FIELD_INT1, "Frame index (int1):"}
+        }
+    }},
+    {AlpineDedEventID::ATX_Play, {
+        {FIELD_STR1},
+        {
+            {FIELD_STR1, "ATX handle (str1):"}
+        }
+    }},
+    {AlpineDedEventID::ATX_Pause, {
+        {FIELD_STR1},
+        {
+            {FIELD_STR1, "ATX handle (str1):"}
+        }
+    }},
+    {AlpineDedEventID::ATX_Set_Frame_Time, {
+        {FIELD_STR1, FIELD_INT1},
+        {
+            {FIELD_STR1, "ATX handle (str1):"},
+            {FIELD_INT1, "Frame time ms (int1):"}
         }
     }},
 };

--- a/editor_patch/event.h
+++ b/editor_patch/event.h
@@ -81,7 +81,11 @@ enum class AlpineDedEventID : int
     Unhide_Glare,
     Gas_Region_State,
     Modify_Gas_Region,
-    Resize_Gas_Region
+    Resize_Gas_Region,
+    ATX_Set_Frame,
+    ATX_Play,
+    ATX_Pause,
+    ATX_Set_Frame_Time
 };
 
 constexpr int af_ded_event_to_int(AlpineDedEventID event_id) noexcept

--- a/editor_patch/main.cpp
+++ b/editor_patch/main.cpp
@@ -45,8 +45,6 @@ static std::string g_launcher_pathname;
 static bool g_is_play_in_multi = false;
 static std::string g_red_cmdline;
 
-constexpr size_t max_texture_name_len = 31;
-
 bool g_skip_wnd_set_text = false;
 
 static bool g_is_saving_af_version = true;
@@ -1397,6 +1395,7 @@ void ApplyLevelPatches();
 void ApplyEventsPatches();
 void ApplyTexturesPatches();
 void ApplyLightmapPatches();
+void install_editor_bitmap_loader_hooks();
 
 void LoadAlpineEditorPackfile()
 {
@@ -1554,7 +1553,7 @@ CodeInjection texture_name_buffer_overflow_injection1{
     0x00445297,
     [](auto &regs) {
         const char *filename = regs.esi;
-        if (std::strlen(filename) > max_texture_name_len) {
+        if (std::strlen(filename) > MAX_TEXTURE_NAME_LEN) {
             LogDlg_Append(GetLogDlg(), "Texture name too long: %s\n", filename);
             regs.eip = 0x00445273;
         }
@@ -1565,7 +1564,7 @@ CodeInjection texture_name_buffer_overflow_injection2{
     0x004703EC,
     [](auto &regs) {
         const char *filename = regs.ebp;
-        if (std::strlen(filename) > max_texture_name_len) {
+        if (std::strlen(filename) > MAX_TEXTURE_NAME_LEN) {
             LogDlg_Append(GetLogDlg(), "Texture name too long: %s\n", filename);
             regs.eip = 0x0047047F;
         }
@@ -1769,6 +1768,7 @@ extern "C" DWORD AF_DLL_EXPORT Init([[maybe_unused]] void* unused)
     ApplyAlpineObjectPatches();
     ApplyTexturesPatches();
     ApplyLightmapPatches();
+    install_editor_bitmap_loader_hooks();
 
     // Browse for .v3m files instead of .v3d
     static char mesh_ext_filter[] = "Mesh (*.v3m)|*.v3m|All Files (*.*)|*.*||";
@@ -1778,8 +1778,8 @@ extern "C" DWORD AF_DLL_EXPORT Init([[maybe_unused]] void* unused)
     write_mem_ptr(0x004624A9 + 1, ".v3m");
     write_mem_ptr(0x0044244A + 1, "RFBrush.v3m");
 
-    // Fix rendering of VBM textures from user_maps/textures
-    write_mem_ptr(0x004828C2 + 1, ".tga .vbm");
+    // Render all supported texture formats from user_maps/textures
+    write_mem_ptr(0x004828C2 + 1, ".tga .vbm .dds .atx .png .jpg .jpeg");
 
     // Fix lights sometimes not working
     DedLight_UpdateLevelLight_hook.install();

--- a/editor_patch/textures.cpp
+++ b/editor_patch/textures.cpp
@@ -15,6 +15,8 @@
 #include "textures.h"
 #include "meshes.h"
 #include "event.h"
+#include "bitmap_loaders.h"
+#include <common/utils/string-utils.h>
 
 // Subdirectory names registered during init, used by VPP packing fix
 static std::vector<std::string> custom_texture_subdirs;
@@ -80,7 +82,7 @@ static void register_custom_texture_subdirectories(void* texture_manager)
         cat->name.assign_0(display_name.c_str());
 
         // Register the subdirectory path with the VFS
-        cat->path_handle = file_add_path(subdir_path.c_str(), ".tga .vbm", false);
+        cat->path_handle = file_add_path(subdir_path.c_str(), ".tga .vbm .dds .atx .png .jpg .jpeg", false);
 
         // Append to the manager's category array at this+0x7C
         category_array->push_back(cat);
@@ -131,6 +133,47 @@ static char __cdecl is_custom_category(VString* name, const char* /*cstr*/)
 CallHook<char __cdecl(VString*, const char*)> custom_category_check_hook{
     {0x0046ff05, 0x00470027, 0x004776e9, 0x004774d6, 0x00445403},
     is_custom_category
+};
+
+// Permissive replacement for the texture browser entry validator
+static bool browser_extension_allowed(const char* ext)
+{
+    if (!ext || !*ext) return false;
+    return _stricmp(ext, ".tga") == 0
+        || _stricmp(ext, ".vbm") == 0
+        || _stricmp(ext, ".dds") == 0
+        || _stricmp(ext, ".atx") == 0
+        || _stricmp(ext, ".png") == 0
+        || _stricmp(ext, ".jpg") == 0
+        || _stricmp(ext, ".jpeg") == 0;
+}
+
+static int __cdecl permissive_texture_browser_validator(void* entry)
+{
+    const char* filename = static_cast<const char*>(entry) + 8;
+    if (!filename || !*filename) return 0;
+
+    // Skip "-mip" LOD variants
+    if (std::strstr(filename, "-mip") != nullptr) return 0;
+
+    // Refuse over-long names
+    if (std::strlen(filename) > MAX_TEXTURE_NAME_LEN) {
+        xlog::warn("Texture name too long, skipping: {}", filename);
+        return 0;
+    }
+
+    const char* ext = std::strrchr(filename, '.');
+    return browser_extension_allowed(ext) ? 1 : 0;
+}
+
+FunHook<int __cdecl(void*)> texture_browser_validator_hook{
+    0x00470330,
+    permissive_texture_browser_validator
+};
+
+FunHook<int __cdecl(void*)> texture_sidebar_validator_hook{
+    0x004451C0,
+    permissive_texture_browser_validator
 };
 
 // FUN_00477460 saves texture categories to red.cfg. Skip "Custom - " subdirectory
@@ -367,14 +410,15 @@ static bool has_texture_extension(const char* filename)
     if (!ext) return false;
     return (_stricmp(ext, ".tga") == 0 ||
             _stricmp(ext, ".vbm") == 0 ||
-            _stricmp(ext, ".dds") == 0);
+            _stricmp(ext, ".dds") == 0 ||
+            _stricmp(ext, ".atx") == 0 ||
+            _stricmp(ext, ".png") == 0 ||
+            _stricmp(ext, ".jpg") == 0 ||
+            _stricmp(ext, ".jpeg") == 0);
 }
 
-// Add a texture filename to the VPP temp file list if it has a valid texture extension.
-// FUN_00438640 is __thiscall(void* list, VString by_value); it checks for duplicates internally.
-static void add_texture_to_pack_list(void* temp_list, const char* filename)
+static void push_to_pack_list(void* temp_list, const char* filename)
 {
-    if (!has_texture_extension(filename)) return;
     VString str;
     str.assign_0(filename);
     // FUN_00438640 is __thiscall(list, VString by value) where VString = {int, char*}.
@@ -385,6 +429,24 @@ static void add_texture_to_pack_list(void* temp_list, const char* filename)
     str.max_len = 0;
     str.buf = nullptr;
     AddrCaller{0x00438640}.this_call<int>(temp_list, ml, b);
+}
+
+// Add a texture filename to the VPP temp file list if it has a valid texture extension.
+// For .atx files, also pulls in every dependency
+static void add_texture_to_pack_list(void* temp_list, const char* filename)
+{
+    if (!has_texture_extension(filename)) return;
+    push_to_pack_list(temp_list, filename);
+
+    if (string_iends_with(filename, ".atx")) {
+        // Parse the .atx and add each referenced texture.
+        for (const auto& dep : parse_atx_dependencies(filename)) {
+            if (has_texture_extension(dep.c_str())
+                && !string_iends_with(dep, ".atx")) {
+                push_to_pack_list(temp_list, dep.c_str());
+            }
+        }
+    }
 }
 
 // Clear the RED console log at the start of VPP packfile creation (FUN_0044cb10),
@@ -675,6 +737,8 @@ void reload_custom_textures()
 
 void ApplyTexturesPatches() {
     texture_config_init_hook.install();
+    texture_browser_validator_hook.install();
+    texture_sidebar_validator_hook.install();
     custom_category_check_hook.install();
     sidebar_custom_texture_path_injection.install();
     texture_reverse_lookup_fix.install();

--- a/editor_patch/textures.cpp
+++ b/editor_patch/textures.cpp
@@ -730,6 +730,10 @@ void reload_custom_textures()
         }
     }
 
+    // Drop cached redirects so edits to .atx files (or new sibling files dropped on disk
+    // mid-session) are re-resolved on the next read_header.
+    clear_editor_bitmap_redirects();
+
     // Reload placeholder bitmap entries so previously-failed textures load from disk.
     // This updates entries in-place (same handle) so faces referencing them stay valid.
     reload_bm_placeholders();

--- a/editor_patch/textures.h
+++ b/editor_patch/textures.h
@@ -84,6 +84,8 @@ static auto& texture_browser_scan_path = addr_as_ref<void __cdecl(
 
 // ─── Bitmap manager (RED.exe bmpman) ────────────────────────────────────────
 
+constexpr size_t MAX_TEXTURE_NAME_LEN = 31;
+
 struct BitmapEntry {
     static constexpr int TYPE_USER = 3;
     static constexpr int FORMAT_888_RGB = 6;

--- a/game_patch/CMakeLists.txt
+++ b/game_patch/CMakeLists.txt
@@ -57,6 +57,8 @@ set(SRCS
     rf/v3d.h
     rf/vmesh.h
     rf/weapon.h
+    bmpman/atx.cpp
+    bmpman/atx.h
     bmpman/dds.cpp
     bmpman/bmpman.cpp
     bmpman/bmpman.h

--- a/game_patch/CMakeLists.txt
+++ b/game_patch/CMakeLists.txt
@@ -64,6 +64,8 @@ set(SRCS
     bmpman/bmpman.h
     bmpman/fmt_conv.cpp
     bmpman/fmt_conv_templates.h
+    bmpman/stb_image_loader.cpp
+    bmpman/stb_image_loader.h
     graphics/bink.cpp
     graphics/gr_font.cpp
     graphics/gr.cpp

--- a/game_patch/CMakeLists.txt
+++ b/game_patch/CMakeLists.txt
@@ -302,8 +302,6 @@ target_include_directories(AlpineFaction PRIVATE
     ${CMAKE_SOURCE_DIR}/vendor/xxhash
     ${CMAKE_SOURCE_DIR}/vendor/stb
     ${CMAKE_SOURCE_DIR}/vendor/freetype/include
-    ${CMAKE_SOURCE_DIR}/vendor/dds
-    ${CMAKE_SOURCE_DIR}/vendor/toml++
     ${CMAKE_SOURCE_DIR}/vendor/nlohmann
 )
 

--- a/game_patch/bmpman/atx.cpp
+++ b/game_patch/bmpman/atx.cpp
@@ -1,0 +1,780 @@
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <toml++/toml.hpp>
+#include <xlog/xlog.h>
+
+#include "atx.h"
+#include "bmpman.h"
+#include "../graphics/gr.h"
+#include "../rf/bmpman.h"
+#include "../rf/file/file.h"
+#include "../rf/gr/gr.h"
+#include "../rf/os/frametime.h"
+
+namespace
+{
+    enum class AtxAnimationMode : int
+    {
+        Static = 0,    // No auto playback. Frames change only via events.
+        PingPong = 1,  // Forward to last, then backward to first, repeating.
+        Loop = 2,      // Forward; wrap to 0 after last.
+        PlayOnce = 3,  // Forward; stop and hold on the last frame.
+    };
+
+    struct AtxFrame
+    {
+        std::string filename;
+        int bm_handle = -1;
+        int frame_time_ms = -1; // -1 means inherit base_frame_time_ms
+        uint8_t* locked_pixels = nullptr;
+        uint8_t* locked_palette = nullptr;
+        // Owned per-frame buffer used when the ATX applies format coercion or alpha-masking.
+        // When non-null, locked_pixels points into this buffer and bm_handle has already been
+        // released. When null, locked_pixels points into the source child's locked pages.
+        std::unique_ptr<uint8_t[]> owned_buffer;
+        // Per-frame material override (e.g. frame is metal even though the ATX is wood).
+        // Falls back to the controller's header_material if unset.
+        std::optional<uint8_t> material_override;
+    };
+
+    struct AtxController
+    {
+        std::string handle_str; // lowercase basename (filename without extension or path)
+
+        std::vector<AtxFrame> frames;
+        AtxAnimationMode animation_mode = AtxAnimationMode::Loop;
+        int base_frame_time_ms = 100;
+        bool initially_on = true;
+
+        // Cached metadata (matches frame[0])
+        int width = 0;
+        int height = 0;
+        rf::bm::Format format = rf::bm::FORMAT_NONE;
+        int num_levels = 1;
+
+        // Runtime state
+        int current_frame = 0;
+        int direction = 1; // ping-pong only: +1 or -1
+        bool playing = true;
+        float time_in_frame_s = 0.0f;
+        int atx_bm_handle = -1; // populated on first lock
+
+        // ATX-wide material override (applied when a frame doesn't have its own).
+        std::optional<uint8_t> header_material;
+        // True if any override (header or per-frame) is configured. Used as a fast early-out
+        // in the material-getter hook so non-override ATXes pay zero overhead.
+        bool has_material_override = false;
+    };
+
+    // Single registry keyed by lowercase basename. With ATX supercede in effect a caller may
+    // load the same file under any extension (foo.tga, foo.dds, foo.atx, foo) — they all
+    // resolve to the same controller, so basename is the right key.
+    std::unordered_map<std::string, std::unique_ptr<AtxController>> g_controllers;
+
+    // Basenames whose .atx file has been seen this level and failed to parse/validate. Cached so
+    // we don't re-run the failing parse on every subsequent load of any extension that supercedes
+    // to this name (each retry would log spam and could re-disturb the bm cache).
+    std::unordered_set<std::string> g_failed;
+
+    bool g_loading_child = false;
+    struct ChildLoadGuard {
+        ChildLoadGuard() { g_loading_child = true; }
+        ~ChildLoadGuard() { g_loading_child = false; }
+    };
+
+    std::string to_lower(std::string s)
+    {
+        std::transform(s.begin(), s.end(), s.begin(),
+            [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        return s;
+    }
+
+    bool ends_with_icase(const std::string& s, const char* suffix)
+    {
+        size_t suf_len = std::strlen(suffix);
+        if (s.size() < suf_len) return false;
+        for (size_t i = 0; i < suf_len; ++i) {
+            if (std::tolower(static_cast<unsigned char>(s[s.size() - suf_len + i]))
+                != std::tolower(static_cast<unsigned char>(suffix[i]))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    std::string handle_from_filename(const char* filename)
+    {
+        std::string s = filename;
+        auto last_slash = s.find_last_of("/\\");
+        if (last_slash != std::string::npos) s = s.substr(last_slash + 1);
+        auto dot = s.find_last_of('.');
+        if (dot != std::string::npos) s.resize(dot);
+        return to_lower(std::move(s));
+    }
+
+    bool read_atx_text(const char* filename, std::string& content_out)
+    {
+        rf::File file;
+        if (file.open(filename) != 0) {
+            return false;
+        }
+        const int file_size = file.size();
+        if (file_size <= 0) {
+            file.close();
+            return false;
+        }
+        content_out.assign(static_cast<size_t>(file_size), '\0');
+        const int bytes_read = file.read(content_out.data(), file_size);
+        file.close();
+        return bytes_read == file_size;
+    }
+
+    // Drop the ATX's exclusive lock on each loaded child, but leave the bm-load reference in place.
+    // Used by parse-failure paths: dropping the ref there has caused stock RF to mis-handle later
+    // standalone loads of the same .tga, so we accept a small per-failure ref leak (goes away on
+    // level transition) in exchange for not destabilising the bm cache.
+    void unlock_children(AtxController& c)
+    {
+        for (auto& f : c.frames) {
+            if (f.bm_handle >= 0 && (f.locked_pixels || f.locked_palette)) {
+                rf::bm::unlock(f.bm_handle);
+                f.locked_pixels = nullptr;
+                f.locked_palette = nullptr;
+            }
+        }
+    }
+
+    // Full teardown: unlock then release. Only call when the ATX itself is being destroyed
+    // (atx_free, atx_level_reset).
+    void release_children(AtxController& c)
+    {
+        for (auto& f : c.frames) {
+            if (f.bm_handle >= 0) {
+                if (f.locked_pixels || f.locked_palette) {
+                    rf::bm::unlock(f.bm_handle);
+                    f.locked_pixels = nullptr;
+                    f.locked_palette = nullptr;
+                }
+                rf::bm::release(f.bm_handle);
+                f.bm_handle = -1;
+            }
+        }
+    }
+
+    int frame_time_for(const AtxController& c, int idx)
+    {
+        if (idx < 0 || idx >= static_cast<int>(c.frames.size())) {
+            return c.base_frame_time_ms;
+        }
+        const int ft = c.frames[idx].frame_time_ms;
+        return ft > 0 ? ft : c.base_frame_time_ms;
+    }
+
+    void dirty_atx(AtxController& c)
+    {
+        if (c.atx_bm_handle >= 0) {
+            rf::gr::mark_texture_dirty(c.atx_bm_handle);
+        }
+    }
+
+    AtxController* get_by_handle(const std::string& handle)
+    {
+        auto it = g_controllers.find(to_lower(handle));
+        return it == g_controllers.end() ? nullptr : it->second.get();
+    }
+
+    // Map a bm_entry name (which may carry any extension or none, depending on what the caller
+    // originally requested) to the controller key.
+    std::string key_from_bm_name(const char* bm_name)
+    {
+        return handle_from_filename(bm_name);
+    }
+
+    // Stock RF material indices (array at 0x0059CB10). Names are case-insensitive in the TOML;
+    // we normalise to lowercase before lookup.
+    std::optional<uint8_t> parse_material_name(std::string s)
+    {
+        s = to_lower(std::move(s));
+        if (s == "default") return 0;
+        if (s == "rock")    return 1;
+        if (s == "metal")   return 2;
+        if (s == "flesh")   return 3;
+        if (s == "water")   return 4;
+        if (s == "lava")    return 5;
+        if (s == "solid")   return 6;
+        if (s == "sand")    return 7;
+        if (s == "ice")     return 8;
+        if (s == "glass")   return 9;
+        return std::nullopt;
+    }
+
+    // Parse a TOML format string ("8888_argb", "4444", etc.) into the matching bm Format enum.
+    std::optional<rf::bm::Format> parse_format_string(std::string s)
+    {
+        s = to_lower(std::move(s));
+        if (s == "565" || s == "565_rgb") return rf::bm::FORMAT_565_RGB;
+        if (s == "4444" || s == "4444_argb") return rf::bm::FORMAT_4444_ARGB;
+        if (s == "1555" || s == "1555_argb") return rf::bm::FORMAT_1555_ARGB;
+        if (s == "888" || s == "888_rgb") return rf::bm::FORMAT_888_RGB;
+        if (s == "8888" || s == "8888_argb") return rf::bm::FORMAT_8888_ARGB;
+        return std::nullopt;
+    }
+
+    // Formats that the ATX transform pass can read or write. Compressed (DXT*) and paletted
+    // formats are excluded — we'd need a real codec to round-trip them.
+    bool is_supported_for_transform(rf::bm::Format f)
+    {
+        switch (f) {
+            case rf::bm::FORMAT_565_RGB:
+            case rf::bm::FORMAT_4444_ARGB:
+            case rf::bm::FORMAT_1555_ARGB:
+            case rf::bm::FORMAT_888_RGB:
+            case rf::bm::FORMAT_8888_ARGB:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    // If `f` lacks an alpha channel, return an analogous format with one. Used to auto-promote
+    // when the mapper supplies an alpha mask without explicitly choosing a target format.
+    rf::bm::Format promote_to_alpha(rf::bm::Format f)
+    {
+        switch (f) {
+            case rf::bm::FORMAT_565_RGB: return rf::bm::FORMAT_4444_ARGB;
+            case rf::bm::FORMAT_888_RGB: return rf::bm::FORMAT_8888_ARGB;
+            default: return f;
+        }
+    }
+
+    // Total bytes for a full mip chain at (w, h) in `fmt` over `num_levels`.
+    size_t mip_chain_bytes(int w, int h, rf::bm::Format fmt, int num_levels)
+    {
+        size_t total = 0;
+        int mw = w, mh = h;
+        for (int i = 0; i < num_levels; ++i) {
+            total += bm_calculate_total_bytes(mw, mh, fmt);
+            mw = std::max(mw / 2, 1);
+            mh = std::max(mh / 2, 1);
+        }
+        return total;
+    }
+
+    // Overlay an 8-bit greyscale mask as the alpha channel of a destination buffer in `dst_fmt`.
+    // Caller guarantees dst_fmt is one of the alpha-bearing supported formats.
+    void overlay_alpha(uint8_t* dst, rf::bm::Format dst_fmt, const uint8_t* mask, int num_pixels)
+    {
+        switch (dst_fmt) {
+            case rf::bm::FORMAT_8888_ARGB:
+                // Memory order is BGRA on little-endian; alpha is the 4th byte per pixel.
+                for (int i = 0; i < num_pixels; ++i) {
+                    dst[i * 4 + 3] = mask[i];
+                }
+                break;
+            case rf::bm::FORMAT_4444_ARGB:
+                // Two bytes per pixel little-endian; alpha lives in the high nibble of byte 1.
+                for (int i = 0; i < num_pixels; ++i) {
+                    dst[i * 2 + 1] = static_cast<uint8_t>((dst[i * 2 + 1] & 0x0F) | (mask[i] & 0xF0));
+                }
+                break;
+            case rf::bm::FORMAT_1555_ARGB:
+                // Single alpha bit at the top of byte 1; threshold the mask at 0x80.
+                for (int i = 0; i < num_pixels; ++i) {
+                    if (mask[i] >= 128) dst[i * 2 + 1] |= 0x80;
+                    else                dst[i * 2 + 1] &= 0x7F;
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    std::unique_ptr<AtxController> parse_and_load(const char* filename)
+    {
+        std::string content;
+        if (!read_atx_text(filename, content)) {
+            xlog::warn("ATX: failed to open '{}'", filename);
+            return nullptr;
+        }
+
+        toml::table tbl;
+        try {
+            tbl = toml::parse(content, std::string_view{filename});
+        }
+        catch (const toml::parse_error& e) {
+            xlog::warn("ATX: parse error in '{}': {}", filename, e.description());
+            return nullptr;
+        }
+
+        auto c = std::make_unique<AtxController>();
+        c->handle_str = handle_from_filename(filename);
+
+        std::optional<rf::bm::Format> target_format;
+        std::optional<std::string> alpha_mask_filename;
+
+        if (auto* hdr = tbl.get_as<toml::table>("header")) {
+            // `frame_time` in [header] is the default for any [[frame]] that doesn't specify its own.
+            if (auto v = (*hdr)["frame_time"].value<int64_t>()) {
+                c->base_frame_time_ms = std::max<int>(1, static_cast<int>(*v));
+            }
+            if (auto v = (*hdr)["initially_on"].value<bool>()) {
+                c->initially_on = *v;
+            }
+            if (auto v = (*hdr)["animation_mode"].value<int64_t>()) {
+                int mode = static_cast<int>(*v);
+                if (mode < 0 || mode > 3) {
+                    xlog::warn("ATX '{}': animation_mode {} out of range, defaulting to Loop", filename, mode);
+                    mode = static_cast<int>(AtxAnimationMode::Loop);
+                }
+                c->animation_mode = static_cast<AtxAnimationMode>(mode);
+            }
+            if (auto v = (*hdr)["format"].value<std::string>()) {
+                target_format = parse_format_string(*v);
+                if (!target_format) {
+                    xlog::error("ATX '{}': unrecognized format '{}'", filename, *v);
+                    return nullptr;
+                }
+            }
+            if (auto v = (*hdr)["alpha_mask"].value<std::string>()) {
+                alpha_mask_filename = *v;
+            }
+            if (auto v = (*hdr)["material"].value<std::string>()) {
+                auto mat = parse_material_name(*v);
+                if (!mat) {
+                    xlog::error("ATX '{}': unrecognized material '{}' in [header]", filename, *v);
+                    return nullptr;
+                }
+                c->header_material = mat;
+                c->has_material_override = true;
+            }
+        }
+
+        const auto* frames_arr = tbl.get_as<toml::array>("frame");
+        if (!frames_arr || frames_arr->empty()) {
+            xlog::warn("ATX '{}': no [[frame]] entries", filename);
+            return nullptr;
+        }
+
+        c->frames.reserve(frames_arr->size());
+        for (auto&& node : *frames_arr) {
+            const auto* frame_tbl = node.as_table();
+            if (!frame_tbl) {
+                xlog::warn("ATX '{}': non-table frame entry", filename);
+                return nullptr;
+            }
+            AtxFrame f;
+            if (auto v = (*frame_tbl)["file"].value<std::string>()) {
+                f.filename = *v;
+            }
+            if (f.filename.empty()) {
+                xlog::warn("ATX '{}': frame missing 'file'", filename);
+                return nullptr;
+            }
+            if (ends_with_icase(f.filename, ".atx")) {
+                xlog::warn("ATX '{}': nested .atx not allowed (frame '{}')", filename, f.filename);
+                return nullptr;
+            }
+            if (auto v = (*frame_tbl)["frame_time"].value<int64_t>()) {
+                f.frame_time_ms = std::max<int>(1, static_cast<int>(*v));
+            }
+            if (auto v = (*frame_tbl)["material"].value<std::string>()) {
+                auto mat = parse_material_name(*v);
+                if (!mat) {
+                    xlog::error("ATX '{}': unrecognized material '{}' in [[frame]]", filename, *v);
+                    return nullptr;
+                }
+                f.material_override = mat;
+                c->has_material_override = true;
+            }
+            c->frames.push_back(std::move(f));
+        }
+
+        for (size_t i = 0; i < c->frames.size(); ++i) {
+            auto& f = c->frames[i];
+            {
+                ChildLoadGuard guard;
+                f.bm_handle = rf::bm::load(f.filename.c_str(), -1, true);
+            }
+            if (f.bm_handle < 0) {
+                xlog::error("ATX '{}': failed to load child '{}'", filename, f.filename);
+                unlock_children(*c);
+                return nullptr;
+            }
+
+            int w = 0, h = 0, num_pixels = 0, num_levels = 0;
+            rf::bm::get_mipmap_info(f.bm_handle, &w, &h, &num_pixels, &num_levels);
+            const rf::bm::Format fmt = rf::bm::get_format(f.bm_handle);
+
+            if (i == 0) {
+                c->width = w;
+                c->height = h;
+                c->format = fmt;
+                c->num_levels = num_levels;
+            }
+            else if (w != c->width || h != c->height || fmt != c->format || num_levels != c->num_levels) {
+                xlog::error("ATX '{}': frame {} '{}' mismatch {}x{} fmt={} mips={}, expected {}x{} fmt={} mips={}",
+                    filename, i, f.filename, w, h, static_cast<int>(fmt), num_levels,
+                    c->width, c->height, static_cast<int>(c->format), c->num_levels);
+                unlock_children(*c);
+                return nullptr;
+            }
+
+            // Lock the child once and keep it resident for fast frame swaps.
+            uint8_t* px = nullptr;
+            uint8_t* pal = nullptr;
+            const rf::bm::Format locked_fmt = rf::bm::lock(f.bm_handle, &px, &pal);
+            if (locked_fmt == rf::bm::FORMAT_NONE || px == nullptr) {
+                xlog::error("ATX '{}': failed to lock child '{}'", filename, f.filename);
+                unlock_children(*c);
+                return nullptr;
+            }
+            f.locked_pixels = px;
+            f.locked_palette = pal;
+        }
+
+        // Optional transform pass — format coercion and/or alpha mask overlay.
+        // Skipped entirely (zero overhead) when both `format` and `alpha_mask` are absent.
+        // Also skipped if `format` is set but matches the source and there's no mask.
+        bool format_change = target_format && *target_format != c->format;
+        if (format_change || alpha_mask_filename) {
+            rf::bm::Format effective = target_format.value_or(c->format);
+            if (alpha_mask_filename) {
+                effective = promote_to_alpha(effective);
+            }
+
+            if (!is_supported_for_transform(c->format)) {
+                xlog::error("ATX '{}': source format {} cannot be transformed (uncompressed RGB/RGBA only)",
+                    filename, static_cast<int>(c->format));
+                unlock_children(*c);
+                return nullptr;
+            }
+            if (!is_supported_for_transform(effective)) {
+                xlog::error("ATX '{}': target format {} not supported (uncompressed RGB/RGBA only)",
+                    filename, static_cast<int>(effective));
+                unlock_children(*c);
+                return nullptr;
+            }
+
+            // Load and validate the alpha mask if one was specified.
+            int mask_handle = -1;
+            uint8_t* mask_pixels = nullptr;
+            rf::bm::Format mask_fmt = rf::bm::FORMAT_NONE;
+            if (alpha_mask_filename) {
+                {
+                    ChildLoadGuard guard;
+                    mask_handle = rf::bm::load(alpha_mask_filename->c_str(), -1, true);
+                }
+                if (mask_handle < 0) {
+                    xlog::error("ATX '{}': failed to load alpha mask '{}'", filename, *alpha_mask_filename);
+                    unlock_children(*c);
+                    return nullptr;
+                }
+                int mw = 0, mh = 0, mnp = 0, mml = 0;
+                rf::bm::get_mipmap_info(mask_handle, &mw, &mh, &mnp, &mml);
+                if (mw != c->width || mh != c->height || mml != c->num_levels) {
+                    xlog::error("ATX '{}': alpha mask '{}' dimensions/mips don't match frames "
+                                "(got {}x{} mips={}, expected {}x{} mips={})",
+                        filename, *alpha_mask_filename, mw, mh, mml,
+                        c->width, c->height, c->num_levels);
+                    rf::bm::release(mask_handle);
+                    unlock_children(*c);
+                    return nullptr;
+                }
+                mask_fmt = rf::bm::get_format(mask_handle);
+                if (mask_fmt != rf::bm::FORMAT_8_PALETTED && mask_fmt != rf::bm::FORMAT_8_ALPHA) {
+                    xlog::error("ATX '{}': alpha mask '{}' must be 8-bit greyscale (got format {})",
+                        filename, *alpha_mask_filename, static_cast<int>(mask_fmt));
+                    rf::bm::release(mask_handle);
+                    unlock_children(*c);
+                    return nullptr;
+                }
+                uint8_t* dummy_pal = nullptr;
+                rf::bm::lock(mask_handle, &mask_pixels, &dummy_pal);
+                if (!mask_pixels) {
+                    xlog::error("ATX '{}': failed to lock alpha mask '{}'", filename, *alpha_mask_filename);
+                    rf::bm::release(mask_handle);
+                    unlock_children(*c);
+                    return nullptr;
+                }
+            }
+
+            // Per-frame transform: allocate owned buffer, convert + overlay alpha for each mip,
+            // then drop the source bm reference (the owned buffer is self-contained).
+            const size_t total_bytes = mip_chain_bytes(c->width, c->height, effective, c->num_levels);
+            for (auto& f : c->frames) {
+                f.owned_buffer = std::make_unique<uint8_t[]>(total_bytes);
+
+                const uint8_t* src = f.locked_pixels;
+                uint8_t* dst = f.owned_buffer.get();
+                const uint8_t* mask = mask_pixels;
+
+                int mw = c->width, mh = c->height;
+                for (int mip = 0; mip < c->num_levels; ++mip) {
+                    const int n = mw * mh;
+                    if (effective == c->format) {
+                        std::memcpy(dst, src, bm_calculate_total_bytes(mw, mh, effective));
+                    }
+                    else {
+                        rf::bm::convert_format(dst, effective, src, c->format, n);
+                    }
+                    if (mask) {
+                        overlay_alpha(dst, effective, mask, n);
+                    }
+                    src += bm_calculate_total_bytes(mw, mh, c->format);
+                    dst += bm_calculate_total_bytes(mw, mh, effective);
+                    if (mask) mask += bm_calculate_total_bytes(mw, mh, mask_fmt);
+                    mw = std::max(mw / 2, 1);
+                    mh = std::max(mh / 2, 1);
+                }
+
+                // Source pixels are no longer needed — unlock and drop our ref. Other consumers
+                // (direct references, other ATXes) keep the source alive via their own refs.
+                rf::bm::unlock(f.bm_handle);
+                rf::bm::release(f.bm_handle);
+                f.bm_handle = -1;
+                f.locked_pixels = f.owned_buffer.get();
+                f.locked_palette = nullptr;
+            }
+
+            if (mask_handle >= 0) {
+                rf::bm::unlock(mask_handle);
+                rf::bm::release(mask_handle);
+            }
+
+            c->format = effective;
+        }
+
+        c->playing = (c->animation_mode != AtxAnimationMode::Static) && c->initially_on;
+        c->current_frame = 0;
+        c->direction = 1;
+        c->time_in_frame_s = 0.0f;
+        return c;
+    }
+} // namespace
+
+rf::bm::Type read_atx_header(const char* atx_filename, int* width_out, int* height_out,
+    rf::bm::Format* format_out, int* num_levels_out, int* num_frames_out)
+{
+    const std::string key = handle_from_filename(atx_filename);
+    if (g_failed.contains(key)) {
+        return rf::bm::TYPE_NONE;
+    }
+    AtxController* controller = nullptr;
+    if (auto it = g_controllers.find(key); it != g_controllers.end()) {
+        controller = it->second.get();
+    }
+    else {
+        auto c = parse_and_load(atx_filename);
+        if (!c) {
+            g_failed.insert(key);
+            return rf::bm::TYPE_NONE;
+        }
+        controller = c.get();
+        g_controllers.emplace(key, std::move(c));
+    }
+
+    *width_out = controller->width;
+    *height_out = controller->height;
+    *format_out = controller->format;
+    *num_levels_out = controller->num_levels;
+    *num_frames_out = 1; // ATX bitmap surfaces a single GPU texture; frames are virtualized.
+    return rf::bm::TYPE_ATX;
+}
+
+bool atx_is_loading_child()
+{
+    return g_loading_child;
+}
+
+rf::bm::Format lock_atx_bitmap(rf::bm::BitmapEntry& bm_entry, void** pixels_out, void** palette_out)
+{
+    *pixels_out = nullptr;
+    *palette_out = nullptr;
+
+    auto it = g_controllers.find(key_from_bm_name(bm_entry.name));
+    if (it == g_controllers.end()) {
+        xlog::warn("ATX: lock for unknown '{}'", bm_entry.name);
+        return rf::bm::FORMAT_NONE;
+    }
+    AtxController& c = *it->second;
+    c.atx_bm_handle = bm_entry.handle;
+
+    int idx = c.current_frame;
+    if (idx < 0 || idx >= static_cast<int>(c.frames.size())) {
+        idx = 0;
+    }
+    *pixels_out = c.frames[idx].locked_pixels;
+    *palette_out = c.frames[idx].locked_palette;
+    return bm_entry.format;
+}
+
+void unlock_atx_bitmap(rf::bm::BitmapEntry& /*bm_entry*/)
+{
+    // No-op: children remain locked for the controller's lifetime so frame swaps are O(1).
+}
+
+std::optional<uint8_t> atx_material_override(const rf::bm::BitmapEntry& bm_entry)
+{
+    auto it = g_controllers.find(key_from_bm_name(bm_entry.name));
+    if (it == g_controllers.end()) {
+        return std::nullopt;
+    }
+    const AtxController& c = *it->second;
+    if (!c.has_material_override) {
+        return std::nullopt;
+    }
+    int idx = c.current_frame;
+    if (idx >= 0 && idx < static_cast<int>(c.frames.size())) {
+        if (auto& over = c.frames[idx].material_override) {
+            return *over;
+        }
+    }
+    return c.header_material; // may be nullopt if only some frames override and this isn't one
+}
+
+void atx_free(rf::bm::BitmapEntry& bm_entry)
+{
+    auto it = g_controllers.find(key_from_bm_name(bm_entry.name));
+    if (it == g_controllers.end()) {
+        return;
+    }
+    release_children(*it->second);
+    g_controllers.erase(it);
+}
+
+void atx_do_frame()
+{
+    if (g_controllers.empty()) return;
+    const float dt_s = rf::frametime;
+    if (dt_s <= 0.0f) return;
+
+    for (auto& [key, cptr] : g_controllers) {
+        AtxController& c = *cptr;
+        if (c.animation_mode == AtxAnimationMode::Static) continue;
+        if (!c.playing) continue;
+        if (c.frames.size() < 2) continue;
+
+        c.time_in_frame_s += dt_s;
+        const int prev = c.current_frame;
+        const int n = static_cast<int>(c.frames.size());
+
+        float ft_s = frame_time_for(c, c.current_frame) / 1000.0f;
+        // Guard against a malicious 0 — frame_time_for already clamps to >=1ms via parse-time validation,
+        // but defensively skip if it ever drops to 0 to avoid an infinite loop.
+        if (ft_s <= 0.0f) continue;
+
+        bool stop_advancing = false;
+        while (c.time_in_frame_s >= ft_s) {
+            c.time_in_frame_s -= ft_s;
+            switch (c.animation_mode) {
+                case AtxAnimationMode::Loop:
+                    c.current_frame = (c.current_frame + 1) % n;
+                    break;
+                case AtxAnimationMode::PingPong:
+                    if (n == 1) break;
+                    c.current_frame += c.direction;
+                    if (c.current_frame >= n - 1) {
+                        c.current_frame = n - 1;
+                        c.direction = -1;
+                    }
+                    else if (c.current_frame <= 0) {
+                        c.current_frame = 0;
+                        c.direction = 1;
+                    }
+                    break;
+                case AtxAnimationMode::PlayOnce:
+                    if (c.current_frame < n - 1) {
+                        ++c.current_frame;
+                    }
+                    else {
+                        // Reached and held the last frame; stop the per-frame timer.
+                        c.playing = false;
+                        c.time_in_frame_s = 0.0f;
+                        stop_advancing = true;
+                    }
+                    break;
+                case AtxAnimationMode::Static:
+                    break;
+            }
+            if (stop_advancing) break;
+            ft_s = frame_time_for(c, c.current_frame) / 1000.0f;
+            if (ft_s <= 0.0f) break;
+        }
+
+        if (c.current_frame != prev) {
+            dirty_atx(c);
+        }
+    }
+}
+
+void atx_level_reset()
+{
+    for (auto& [key, cptr] : g_controllers) {
+        release_children(*cptr);
+    }
+    g_controllers.clear();
+    g_failed.clear();
+}
+
+bool atx_set_frame(const std::string& handle, int frame_index)
+{
+    AtxController* c = get_by_handle(handle);
+    if (!c) {
+        rf::bm::load((to_lower(handle) + ".atx").c_str(), -1, true);
+        c = get_by_handle(handle);
+        if (!c) return false;
+    }
+    const int n = static_cast<int>(c->frames.size());
+    if (frame_index < 0 || frame_index >= n) {
+        xlog::warn("ATX '{}': set_frame {} out of range [0,{})", handle, frame_index, n);
+        return false;
+    }
+    if (c->current_frame != frame_index) {
+        c->current_frame = frame_index;
+        c->time_in_frame_s = 0.0f;
+        dirty_atx(*c);
+    }
+    return true;
+}
+
+bool atx_play(const std::string& handle)
+{
+    AtxController* c = get_by_handle(handle);
+    if (!c) {
+        rf::bm::load((to_lower(handle) + ".atx").c_str(), -1, true);
+        c = get_by_handle(handle);
+        if (!c) return false;
+    }
+    c->playing = true;
+    return true;
+}
+
+bool atx_pause(const std::string& handle)
+{
+    AtxController* c = get_by_handle(handle);
+    if (!c) return false;
+    c->playing = false;
+    return true;
+}
+
+bool atx_set_frame_time(const std::string& handle, int frame_time_ms)
+{
+    AtxController* c = get_by_handle(handle);
+    if (!c) {
+        rf::bm::load((to_lower(handle) + ".atx").c_str(), -1, true);
+        c = get_by_handle(handle);
+        if (!c) return false;
+    }
+    c->base_frame_time_ms = std::max(1, frame_time_ms);
+    return true;
+}

--- a/game_patch/bmpman/atx.cpp
+++ b/game_patch/bmpman/atx.cpp
@@ -547,15 +547,7 @@ std::optional<uint8_t> atx_material_override(const rf::bm::BitmapEntry& bm_entry
 
 void atx_free(rf::bm::BitmapEntry& bm_entry)
 {
-    auto it = g_controllers.find(key_from_bm_name(bm_entry.name));
-    if (it == g_controllers.end()) {
-        return;
-    }
-    if (it->second->atx_bm_handle >= 0) {
-        g_by_handle.erase(it->second->atx_bm_handle);
-    }
-    release_children(*it->second);
-    g_controllers.erase(it);
+    g_by_handle.erase(bm_entry.handle);
 }
 
 void atx_do_frame()

--- a/game_patch/bmpman/atx.cpp
+++ b/game_patch/bmpman/atx.cpp
@@ -12,6 +12,9 @@
 
 #include <toml++/toml.hpp>
 #include <xlog/xlog.h>
+#include <common/bitmap/formats.h>
+#include <common/atx/parse.h>
+#include <common/utils/string-utils.h>
 
 #include "atx.h"
 #include "bmpman.h"
@@ -23,13 +26,8 @@
 
 namespace
 {
-    enum class AtxAnimationMode : int
-    {
-        Static = 0,    // No auto playback. Frames change only via events.
-        PingPong = 1,  // Forward to last, then backward to first, repeating.
-        Loop = 2,      // Forward; wrap to 0 after last.
-        PlayOnce = 3,  // Forward; stop and hold on the last frame.
-    };
+    // Alias to the shared schema enum so editor and game can't drift on values.
+    using AtxAnimationMode = AtxSpec::AnimationMode;
 
     struct AtxFrame
     {
@@ -86,31 +84,19 @@ namespace
     // to this name (each retry would log spam and could re-disturb the bm cache).
     std::unordered_set<std::string> g_failed;
 
+    // Hot-path lookup: bm_handle → controller. Populated lazily on first lock/material query so
+    // bm_get_material_idx_hook (called for every footstep/impact/decal — many per frame) can
+    // avoid a `to_lower` heap allocation + name-keyed map lookup per call. Cleared on
+    // atx_level_reset and on per-entry atx_free.
+    std::unordered_map<int, AtxController*> g_by_handle;
+
     bool g_loading_child = false;
     struct ChildLoadGuard {
         ChildLoadGuard() { g_loading_child = true; }
         ~ChildLoadGuard() { g_loading_child = false; }
     };
 
-    std::string to_lower(std::string s)
-    {
-        std::transform(s.begin(), s.end(), s.begin(),
-            [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-        return s;
-    }
-
-    bool ends_with_icase(const std::string& s, const char* suffix)
-    {
-        size_t suf_len = std::strlen(suffix);
-        if (s.size() < suf_len) return false;
-        for (size_t i = 0; i < suf_len; ++i) {
-            if (std::tolower(static_cast<unsigned char>(s[s.size() - suf_len + i]))
-                != std::tolower(static_cast<unsigned char>(suffix[i]))) {
-                return false;
-            }
-        }
-        return true;
-    }
+    // String helpers come from common/utils/string-utils.h (string_to_lower, string_iends_with).
 
     std::string handle_from_filename(const char* filename)
     {
@@ -119,7 +105,7 @@ namespace
         if (last_slash != std::string::npos) s = s.substr(last_slash + 1);
         auto dot = s.find_last_of('.');
         if (dot != std::string::npos) s.resize(dot);
-        return to_lower(std::move(s));
+        return string_to_lower(s);
     }
 
     bool read_atx_text(const char* filename, std::string& content_out)
@@ -189,7 +175,7 @@ namespace
 
     AtxController* get_by_handle(const std::string& handle)
     {
-        auto it = g_controllers.find(to_lower(handle));
+        auto it = g_controllers.find(string_to_lower(handle));
         return it == g_controllers.end() ? nullptr : it->second.get();
     }
 
@@ -204,7 +190,7 @@ namespace
     // we normalise to lowercase before lookup.
     std::optional<uint8_t> parse_material_name(std::string s)
     {
-        s = to_lower(std::move(s));
+        s = string_to_lower(s);
         if (s == "default") return 0;
         if (s == "rock")    return 1;
         if (s == "metal")   return 2;
@@ -218,46 +204,8 @@ namespace
         return std::nullopt;
     }
 
-    // Parse a TOML format string ("8888_argb", "4444", etc.) into the matching bm Format enum.
-    std::optional<rf::bm::Format> parse_format_string(std::string s)
-    {
-        s = to_lower(std::move(s));
-        if (s == "565" || s == "565_rgb") return rf::bm::FORMAT_565_RGB;
-        if (s == "4444" || s == "4444_argb") return rf::bm::FORMAT_4444_ARGB;
-        if (s == "1555" || s == "1555_argb") return rf::bm::FORMAT_1555_ARGB;
-        if (s == "888" || s == "888_rgb") return rf::bm::FORMAT_888_RGB;
-        if (s == "8888" || s == "8888_argb") return rf::bm::FORMAT_8888_ARGB;
-        return std::nullopt;
-    }
-
-    // Formats that the ATX transform pass can read or write. Compressed (DXT*) and paletted
-    // formats are excluded — we'd need a real codec to round-trip them.
-    bool is_supported_for_transform(rf::bm::Format f)
-    {
-        switch (f) {
-            case rf::bm::FORMAT_565_RGB:
-            case rf::bm::FORMAT_4444_ARGB:
-            case rf::bm::FORMAT_1555_ARGB:
-            case rf::bm::FORMAT_888_RGB:
-            case rf::bm::FORMAT_8888_ARGB:
-                return true;
-            default:
-                return false;
-        }
-    }
-
-    // If `f` lacks an alpha channel, return an analogous format with one. Used to auto-promote
-    // when the mapper supplies an alpha mask without explicitly choosing a target format.
-    rf::bm::Format promote_to_alpha(rf::bm::Format f)
-    {
-        switch (f) {
-            case rf::bm::FORMAT_565_RGB: return rf::bm::FORMAT_4444_ARGB;
-            case rf::bm::FORMAT_888_RGB: return rf::bm::FORMAT_8888_ARGB;
-            default: return f;
-        }
-    }
-
-    // Total bytes for a full mip chain at (w, h) in `fmt` over `num_levels`.
+    // Total bytes for a full mip chain at (w, h) in `fmt` over `num_levels`. Stays game-side
+    // because bm_calculate_total_bytes is a game_patch helper not yet promoted to common.
     size_t mip_chain_bytes(int w, int h, rf::bm::Format fmt, int num_levels)
     {
         size_t total = 0;
@@ -270,35 +218,6 @@ namespace
         return total;
     }
 
-    // Overlay an 8-bit greyscale mask as the alpha channel of a destination buffer in `dst_fmt`.
-    // Caller guarantees dst_fmt is one of the alpha-bearing supported formats.
-    void overlay_alpha(uint8_t* dst, rf::bm::Format dst_fmt, const uint8_t* mask, int num_pixels)
-    {
-        switch (dst_fmt) {
-            case rf::bm::FORMAT_8888_ARGB:
-                // Memory order is BGRA on little-endian; alpha is the 4th byte per pixel.
-                for (int i = 0; i < num_pixels; ++i) {
-                    dst[i * 4 + 3] = mask[i];
-                }
-                break;
-            case rf::bm::FORMAT_4444_ARGB:
-                // Two bytes per pixel little-endian; alpha lives in the high nibble of byte 1.
-                for (int i = 0; i < num_pixels; ++i) {
-                    dst[i * 2 + 1] = static_cast<uint8_t>((dst[i * 2 + 1] & 0x0F) | (mask[i] & 0xF0));
-                }
-                break;
-            case rf::bm::FORMAT_1555_ARGB:
-                // Single alpha bit at the top of byte 1; threshold the mask at 0x80.
-                for (int i = 0; i < num_pixels; ++i) {
-                    if (mask[i] >= 128) dst[i * 2 + 1] |= 0x80;
-                    else                dst[i * 2 + 1] &= 0x7F;
-                }
-                break;
-            default:
-                break;
-        }
-    }
-
     std::unique_ptr<AtxController> parse_and_load(const char* filename)
     {
         std::string content;
@@ -307,90 +226,55 @@ namespace
             return nullptr;
         }
 
-        toml::table tbl;
-        try {
-            tbl = toml::parse(content, std::string_view{filename});
-        }
-        catch (const toml::parse_error& e) {
-            xlog::warn("ATX: parse error in '{}': {}", filename, e.description());
-            return nullptr;
+        // Parse the TOML and validate format-internal constraints via the shared parser.
+        // Engine-specific concerns (material name → material index, format token → bm::Format,
+        // and child texture loading) are still handled below.
+        auto spec = parse_atx(content, filename);
+        if (!spec) {
+            return nullptr; // parser already logged the cause
         }
 
         auto c = std::make_unique<AtxController>();
         c->handle_str = handle_from_filename(filename);
+        c->base_frame_time_ms = spec->header.frame_time_ms;
+        c->initially_on = spec->header.initially_on;
+        c->animation_mode = spec->header.animation_mode;
 
         std::optional<rf::bm::Format> target_format;
-        std::optional<std::string> alpha_mask_filename;
+        std::optional<std::string> alpha_mask_filename = spec->header.alpha_mask;
 
-        if (auto* hdr = tbl.get_as<toml::table>("header")) {
-            // `frame_time` in [header] is the default for any [[frame]] that doesn't specify its own.
-            if (auto v = (*hdr)["frame_time"].value<int64_t>()) {
-                c->base_frame_time_ms = std::max<int>(1, static_cast<int>(*v));
+        if (spec->header.format) {
+            if (auto fmt = atx_parse_format_token(*spec->header.format)) {
+                target_format = static_cast<rf::bm::Format>(*fmt);
             }
-            if (auto v = (*hdr)["initially_on"].value<bool>()) {
-                c->initially_on = *v;
-            }
-            if (auto v = (*hdr)["animation_mode"].value<int64_t>()) {
-                int mode = static_cast<int>(*v);
-                if (mode < 0 || mode > 3) {
-                    xlog::warn("ATX '{}': animation_mode {} out of range, defaulting to Loop", filename, mode);
-                    mode = static_cast<int>(AtxAnimationMode::Loop);
-                }
-                c->animation_mode = static_cast<AtxAnimationMode>(mode);
-            }
-            if (auto v = (*hdr)["format"].value<std::string>()) {
-                target_format = parse_format_string(*v);
-                if (!target_format) {
-                    xlog::error("ATX '{}': unrecognized format '{}'", filename, *v);
-                    return nullptr;
-                }
-            }
-            if (auto v = (*hdr)["alpha_mask"].value<std::string>()) {
-                alpha_mask_filename = *v;
-            }
-            if (auto v = (*hdr)["material"].value<std::string>()) {
-                auto mat = parse_material_name(*v);
-                if (!mat) {
-                    xlog::error("ATX '{}': unrecognized material '{}' in [header]", filename, *v);
-                    return nullptr;
-                }
-                c->header_material = mat;
-                c->has_material_override = true;
-            }
-        }
-
-        const auto* frames_arr = tbl.get_as<toml::array>("frame");
-        if (!frames_arr || frames_arr->empty()) {
-            xlog::warn("ATX '{}': no [[frame]] entries", filename);
-            return nullptr;
-        }
-
-        c->frames.reserve(frames_arr->size());
-        for (auto&& node : *frames_arr) {
-            const auto* frame_tbl = node.as_table();
-            if (!frame_tbl) {
-                xlog::warn("ATX '{}': non-table frame entry", filename);
+            else {
+                xlog::error("ATX '{}': unrecognized format '{}'", filename, *spec->header.format);
                 return nullptr;
             }
+        }
+        if (spec->header.material) {
+            auto mat = parse_material_name(*spec->header.material);
+            if (!mat) {
+                xlog::error("ATX '{}': unrecognized material '{}' in [header]",
+                            filename, *spec->header.material);
+                return nullptr;
+            }
+            c->header_material = mat;
+            c->has_material_override = true;
+        }
+
+        c->frames.reserve(spec->frames.size());
+        for (auto& src : spec->frames) {
             AtxFrame f;
-            if (auto v = (*frame_tbl)["file"].value<std::string>()) {
-                f.filename = *v;
+            f.filename = std::move(src.filename);
+            if (src.frame_time_ms) {
+                f.frame_time_ms = *src.frame_time_ms;
             }
-            if (f.filename.empty()) {
-                xlog::warn("ATX '{}': frame missing 'file'", filename);
-                return nullptr;
-            }
-            if (ends_with_icase(f.filename, ".atx")) {
-                xlog::warn("ATX '{}': nested .atx not allowed (frame '{}')", filename, f.filename);
-                return nullptr;
-            }
-            if (auto v = (*frame_tbl)["frame_time"].value<int64_t>()) {
-                f.frame_time_ms = std::max<int>(1, static_cast<int>(*v));
-            }
-            if (auto v = (*frame_tbl)["material"].value<std::string>()) {
-                auto mat = parse_material_name(*v);
+            if (src.material) {
+                auto mat = parse_material_name(*src.material);
                 if (!mat) {
-                    xlog::error("ATX '{}': unrecognized material '{}' in [[frame]]", filename, *v);
+                    xlog::error("ATX '{}': unrecognized material '{}' in [[frame]]",
+                                filename, *src.material);
                     return nullptr;
                 }
                 f.material_override = mat;
@@ -449,16 +333,16 @@ namespace
         if (format_change || alpha_mask_filename) {
             rf::bm::Format effective = target_format.value_or(c->format);
             if (alpha_mask_filename) {
-                effective = promote_to_alpha(effective);
+                effective = static_cast<rf::bm::Format>(bm_promote_to_alpha(effective));
             }
 
-            if (!is_supported_for_transform(c->format)) {
+            if (!bm_format_is_uncompressed_rgb(c->format)) {
                 xlog::error("ATX '{}': source format {} cannot be transformed (uncompressed RGB/RGBA only)",
                     filename, static_cast<int>(c->format));
                 unlock_children(*c);
                 return nullptr;
             }
-            if (!is_supported_for_transform(effective)) {
+            if (!bm_format_is_uncompressed_rgb(effective)) {
                 xlog::error("ATX '{}': target format {} not supported (uncompressed RGB/RGBA only)",
                     filename, static_cast<int>(effective));
                 unlock_children(*c);
@@ -528,7 +412,7 @@ namespace
                         rf::bm::convert_format(dst, effective, src, c->format, n);
                     }
                     if (mask) {
-                        overlay_alpha(dst, effective, mask, n);
+                        bm_overlay_alpha_mask(dst, effective, mask, n);
                     }
                     src += bm_calculate_total_bytes(mw, mh, c->format);
                     dst += bm_calculate_total_bytes(mw, mh, effective);
@@ -607,13 +491,24 @@ rf::bm::Format lock_atx_bitmap(rf::bm::BitmapEntry& bm_entry, void** pixels_out,
         return rf::bm::FORMAT_NONE;
     }
     AtxController& c = *it->second;
-    c.atx_bm_handle = bm_entry.handle;
+    if (c.atx_bm_handle != bm_entry.handle) {
+        c.atx_bm_handle = bm_entry.handle;
+        // Populate the hot-path lookup so bm_get_material_idx_hook can find the controller in
+        // O(1) by handle without re-hashing the entry name.
+        g_by_handle[bm_entry.handle] = &c;
+    }
 
     int idx = c.current_frame;
     if (idx < 0 || idx >= static_cast<int>(c.frames.size())) {
         idx = 0;
     }
-    *pixels_out = c.frames[idx].locked_pixels;
+    auto* px = c.frames[idx].locked_pixels;
+    if (!px) {
+        // Shouldn't happen — parse_and_load locks every frame and only succeeds if every lock
+        // succeeds. Defensive: report FORMAT_NONE so the caller doesn't dereference nullptr.
+        return rf::bm::FORMAT_NONE;
+    }
+    *pixels_out = px;
     *palette_out = c.frames[idx].locked_palette;
     return bm_entry.format;
 }
@@ -625,21 +520,29 @@ void unlock_atx_bitmap(rf::bm::BitmapEntry& /*bm_entry*/)
 
 std::optional<uint8_t> atx_material_override(const rf::bm::BitmapEntry& bm_entry)
 {
-    auto it = g_controllers.find(key_from_bm_name(bm_entry.name));
-    if (it == g_controllers.end()) {
+    // Hot path — called from bm_get_material_idx_hook for every footstep/bullet impact/decal.
+    // Try the handle-keyed map first (no string allocation). Fall back to the name-keyed map
+    // for the rare case where a material query happens before lock_atx_bitmap has populated
+    // g_by_handle (e.g. very first query at level start).
+    const AtxController* c = nullptr;
+    if (auto it = g_by_handle.find(bm_entry.handle); it != g_by_handle.end()) {
+        c = it->second;
+    }
+    else {
+        auto it2 = g_controllers.find(key_from_bm_name(bm_entry.name));
+        if (it2 == g_controllers.end()) return std::nullopt;
+        c = it2->second.get();
+    }
+    if (!c->has_material_override) {
         return std::nullopt;
     }
-    const AtxController& c = *it->second;
-    if (!c.has_material_override) {
-        return std::nullopt;
-    }
-    int idx = c.current_frame;
-    if (idx >= 0 && idx < static_cast<int>(c.frames.size())) {
-        if (auto& over = c.frames[idx].material_override) {
+    int idx = c->current_frame;
+    if (idx >= 0 && idx < static_cast<int>(c->frames.size())) {
+        if (auto& over = c->frames[idx].material_override) {
             return *over;
         }
     }
-    return c.header_material; // may be nullopt if only some frames override and this isn't one
+    return c->header_material; // may be nullopt if only some frames override and this isn't one
 }
 
 void atx_free(rf::bm::BitmapEntry& bm_entry)
@@ -647,6 +550,9 @@ void atx_free(rf::bm::BitmapEntry& bm_entry)
     auto it = g_controllers.find(key_from_bm_name(bm_entry.name));
     if (it == g_controllers.end()) {
         return;
+    }
+    if (it->second->atx_bm_handle >= 0) {
+        g_by_handle.erase(it->second->atx_bm_handle);
     }
     release_children(*it->second);
     g_controllers.erase(it);
@@ -673,8 +579,19 @@ void atx_do_frame()
         // but defensively skip if it ever drops to 0 to avoid an infinite loop.
         if (ft_s <= 0.0f) continue;
 
+        // Cap inner-loop iterations to two full cycles. After a long stall (level transition,
+        // alt-tab) `dt_s` could be huge, and a tight `frame_time_ms` would otherwise loop
+        // thousands of times here. Two cycles is enough to land on the right frame for any
+        // mode (Loop wraps once, PingPong needs at most 2*(n-1) advances to return to phase).
+        // If we hit the cap, drop the leftover accumulated time so we don't carry the deficit.
+        const int max_advances = std::max(2, n * 2);
+        int advances = 0;
         bool stop_advancing = false;
         while (c.time_in_frame_s >= ft_s) {
+            if (advances++ >= max_advances) {
+                c.time_in_frame_s = 0.0f;
+                break;
+            }
             c.time_in_frame_s -= ft_s;
             switch (c.animation_mode) {
                 case AtxAnimationMode::Loop:
@@ -723,6 +640,7 @@ void atx_level_reset()
         release_children(*cptr);
     }
     g_controllers.clear();
+    g_by_handle.clear();
     g_failed.clear();
 }
 
@@ -730,7 +648,7 @@ bool atx_set_frame(const std::string& handle, int frame_index)
 {
     AtxController* c = get_by_handle(handle);
     if (!c) {
-        rf::bm::load((to_lower(handle) + ".atx").c_str(), -1, true);
+        rf::bm::load((string_to_lower(handle) + ".atx").c_str(), -1, true);
         c = get_by_handle(handle);
         if (!c) return false;
     }
@@ -751,7 +669,7 @@ bool atx_play(const std::string& handle)
 {
     AtxController* c = get_by_handle(handle);
     if (!c) {
-        rf::bm::load((to_lower(handle) + ".atx").c_str(), -1, true);
+        rf::bm::load((string_to_lower(handle) + ".atx").c_str(), -1, true);
         c = get_by_handle(handle);
         if (!c) return false;
     }
@@ -771,7 +689,7 @@ bool atx_set_frame_time(const std::string& handle, int frame_time_ms)
 {
     AtxController* c = get_by_handle(handle);
     if (!c) {
-        rf::bm::load((to_lower(handle) + ".atx").c_str(), -1, true);
+        rf::bm::load((string_to_lower(handle) + ".atx").c_str(), -1, true);
         c = get_by_handle(handle);
         if (!c) return false;
     }

--- a/game_patch/bmpman/atx.cpp
+++ b/game_patch/bmpman/atx.cpp
@@ -72,6 +72,44 @@ namespace
         // True if any override (header or per-frame) is configured. Used as a fast early-out
         // in the material-getter hook so non-override ATXes pay zero overhead.
         bool has_material_override = false;
+
+        AtxController() = default;
+        AtxController(const AtxController&) = delete;
+        AtxController& operator=(const AtxController&) = delete;
+
+        // Failure-path RAII: drop any outstanding locks but DO NOT release bm refs.
+        ~AtxController()
+        {
+            for (auto& f : frames) {
+                if (f.bm_handle >= 0 && (f.locked_pixels || f.locked_palette)) {
+                    rf::bm::unlock(f.bm_handle);
+                    f.locked_pixels = nullptr;
+                    f.locked_palette = nullptr;
+                }
+            }
+        }
+    };
+
+    // RAII guard for the alpha mask child bm during parse_and_load's transform block.
+    struct MaskHandleGuard
+    {
+        int handle = -1;
+        bool locked = false;
+        ~MaskHandleGuard()
+        {
+            if (handle >= 0 && locked) {
+                rf::bm::unlock(handle);
+            }
+        }
+        void release()
+        {
+            if (handle >= 0) {
+                if (locked) rf::bm::unlock(handle);
+                rf::bm::release(handle);
+            }
+            handle = -1;
+            locked = false;
+        }
     };
 
     // Single registry keyed by lowercase basename. With ATX supercede in effect a caller may
@@ -350,19 +388,20 @@ namespace
             }
 
             // Load and validate the alpha mask if one was specified.
-            int mask_handle = -1;
+            MaskHandleGuard mask_guard;
             uint8_t* mask_pixels = nullptr;
             rf::bm::Format mask_fmt = rf::bm::FORMAT_NONE;
             if (alpha_mask_filename) {
+                int mask_handle = -1;
                 {
                     ChildLoadGuard guard;
                     mask_handle = rf::bm::load(alpha_mask_filename->c_str(), -1, true);
                 }
                 if (mask_handle < 0) {
                     xlog::error("ATX '{}': failed to load alpha mask '{}'", filename, *alpha_mask_filename);
-                    unlock_children(*c);
                     return nullptr;
                 }
+                mask_guard.handle = mask_handle;
                 int mw = 0, mh = 0, mnp = 0, mml = 0;
                 rf::bm::get_mipmap_info(mask_handle, &mw, &mh, &mnp, &mml);
                 if (mw != c->width || mh != c->height || mml != c->num_levels) {
@@ -370,26 +409,21 @@ namespace
                                 "(got {}x{} mips={}, expected {}x{} mips={})",
                         filename, *alpha_mask_filename, mw, mh, mml,
                         c->width, c->height, c->num_levels);
-                    rf::bm::release(mask_handle);
-                    unlock_children(*c);
                     return nullptr;
                 }
                 mask_fmt = rf::bm::get_format(mask_handle);
                 if (mask_fmt != rf::bm::FORMAT_8_PALETTED && mask_fmt != rf::bm::FORMAT_8_ALPHA) {
                     xlog::error("ATX '{}': alpha mask '{}' must be 8-bit greyscale (got format {})",
                         filename, *alpha_mask_filename, static_cast<int>(mask_fmt));
-                    rf::bm::release(mask_handle);
-                    unlock_children(*c);
                     return nullptr;
                 }
                 uint8_t* dummy_pal = nullptr;
                 rf::bm::lock(mask_handle, &mask_pixels, &dummy_pal);
                 if (!mask_pixels) {
                     xlog::error("ATX '{}': failed to lock alpha mask '{}'", filename, *alpha_mask_filename);
-                    rf::bm::release(mask_handle);
-                    unlock_children(*c);
                     return nullptr;
                 }
+                mask_guard.locked = true;
             }
 
             // Per-frame transform: allocate owned buffer, convert + overlay alpha for each mip,
@@ -423,18 +457,17 @@ namespace
 
                 // Source pixels are no longer needed — unlock and drop our ref. Other consumers
                 // (direct references, other ATXes) keep the source alive via their own refs.
+                f.locked_pixels = nullptr;
+                f.locked_palette = nullptr;
                 rf::bm::unlock(f.bm_handle);
                 rf::bm::release(f.bm_handle);
                 f.bm_handle = -1;
                 f.locked_pixels = f.owned_buffer.get();
-                f.locked_palette = nullptr;
             }
 
-            if (mask_handle >= 0) {
-                rf::bm::unlock(mask_handle);
-                rf::bm::release(mask_handle);
-            }
-
+            // Success path: drop the mask's ref now that the per-frame transform has copied
+            // its data into each owned_buffer.
+            mask_guard.release();
             c->format = effective;
         }
 
@@ -636,13 +669,15 @@ void atx_level_reset()
     g_failed.clear();
 }
 
+// Each event entry point requires the controller to already exist (i.e. the texture has been
+// referenced through the bm system at least once).
 bool atx_set_frame(const std::string& handle, int frame_index)
 {
     AtxController* c = get_by_handle(handle);
     if (!c) {
-        rf::bm::load((string_to_lower(handle) + ".atx").c_str(), -1, true);
-        c = get_by_handle(handle);
-        if (!c) return false;
+        xlog::warn("ATX_Set_Frame: '{}' not loaded — texture must be referenced by the level "
+                   "before this event fires", handle);
+        return false;
     }
     const int n = static_cast<int>(c->frames.size());
     if (frame_index < 0 || frame_index >= n) {
@@ -661,9 +696,9 @@ bool atx_play(const std::string& handle)
 {
     AtxController* c = get_by_handle(handle);
     if (!c) {
-        rf::bm::load((string_to_lower(handle) + ".atx").c_str(), -1, true);
-        c = get_by_handle(handle);
-        if (!c) return false;
+        xlog::warn("ATX_Play: '{}' not loaded — texture must be referenced by the level "
+                   "before this event fires", handle);
+        return false;
     }
     c->playing = true;
     return true;
@@ -672,7 +707,11 @@ bool atx_play(const std::string& handle)
 bool atx_pause(const std::string& handle)
 {
     AtxController* c = get_by_handle(handle);
-    if (!c) return false;
+    if (!c) {
+        xlog::warn("ATX_Pause: '{}' not loaded — texture must be referenced by the level "
+                   "before this event fires", handle);
+        return false;
+    }
     c->playing = false;
     return true;
 }
@@ -681,9 +720,9 @@ bool atx_set_frame_time(const std::string& handle, int frame_time_ms)
 {
     AtxController* c = get_by_handle(handle);
     if (!c) {
-        rf::bm::load((string_to_lower(handle) + ".atx").c_str(), -1, true);
-        c = get_by_handle(handle);
-        if (!c) return false;
+        xlog::warn("ATX_Set_Frame_Time: '{}' not loaded — texture must be referenced by the "
+                   "level before this event fires", handle);
+        return false;
     }
     c->base_frame_time_ms = std::max(1, frame_time_ms);
     return true;

--- a/game_patch/bmpman/atx.cpp
+++ b/game_patch/bmpman/atx.cpp
@@ -83,14 +83,18 @@ namespace
         AtxController(const AtxController&) = delete;
         AtxController& operator=(const AtxController&) = delete;
 
-        // Failure-path RAII: drop any outstanding locks but DO NOT release bm refs.
+        // Release every child handle this controller owns.
         ~AtxController()
         {
             for (auto& f : frames) {
-                if (f.bm_handle >= 0 && (f.locked_pixels || f.locked_palette)) {
-                    rf::bm::unlock(f.bm_handle);
-                    f.locked_pixels = nullptr;
-                    f.locked_palette = nullptr;
+                if (f.bm_handle >= 0) {
+                    if (f.locked_pixels || f.locked_palette) {
+                        rf::bm::unlock(f.bm_handle);
+                        f.locked_pixels = nullptr;
+                        f.locked_palette = nullptr;
+                    }
+                    rf::bm::release(f.bm_handle);
+                    f.bm_handle = -1;
                 }
             }
         }
@@ -103,18 +107,10 @@ namespace
         bool locked = false;
         ~MaskHandleGuard()
         {
-            if (handle >= 0 && locked) {
-                rf::bm::unlock(handle);
-            }
-        }
-        void release()
-        {
             if (handle >= 0) {
                 if (locked) rf::bm::unlock(handle);
                 rf::bm::release(handle);
             }
-            handle = -1;
-            locked = false;
         }
     };
 
@@ -167,38 +163,6 @@ namespace
         const int bytes_read = file.read(content_out.data(), file_size);
         file.close();
         return bytes_read == file_size;
-    }
-
-    // Drop the ATX's exclusive lock on each loaded child, but leave the bm-load reference in place.
-    // Used by parse-failure paths: dropping the ref there has caused stock RF to mis-handle later
-    // standalone loads of the same .tga, so we accept a small per-failure ref leak (goes away on
-    // level transition) in exchange for not destabilising the bm cache.
-    void unlock_children(AtxController& c)
-    {
-        for (auto& f : c.frames) {
-            if (f.bm_handle >= 0 && (f.locked_pixels || f.locked_palette)) {
-                rf::bm::unlock(f.bm_handle);
-                f.locked_pixels = nullptr;
-                f.locked_palette = nullptr;
-            }
-        }
-    }
-
-    // Full teardown: unlock then release. Only call when the ATX itself is being destroyed
-    // (atx_free, atx_level_reset).
-    void release_children(AtxController& c)
-    {
-        for (auto& f : c.frames) {
-            if (f.bm_handle >= 0) {
-                if (f.locked_pixels || f.locked_palette) {
-                    rf::bm::unlock(f.bm_handle);
-                    f.locked_pixels = nullptr;
-                    f.locked_palette = nullptr;
-                }
-                rf::bm::release(f.bm_handle);
-                f.bm_handle = -1;
-            }
-        }
     }
 
     int frame_time_for(const AtxController& c, int idx)
@@ -338,7 +302,6 @@ namespace
             }
             if (f.bm_handle < 0) {
                 xlog::error("ATX '{}': failed to load child '{}'", filename, f.filename);
-                unlock_children(*c);
                 return nullptr;
             }
 
@@ -356,7 +319,6 @@ namespace
                 xlog::error("ATX '{}': frame {} '{}' mismatch {}x{} fmt={} mips={}, expected {}x{} fmt={} mips={}",
                     filename, i, f.filename, w, h, static_cast<int>(fmt), num_levels,
                     c->width, c->height, static_cast<int>(c->format), c->num_levels);
-                unlock_children(*c);
                 return nullptr;
             }
 
@@ -366,7 +328,6 @@ namespace
             const rf::bm::Format locked_fmt = rf::bm::lock(f.bm_handle, &px, &pal);
             if (locked_fmt == rf::bm::FORMAT_NONE || px == nullptr) {
                 xlog::error("ATX '{}': failed to lock child '{}'", filename, f.filename);
-                unlock_children(*c);
                 return nullptr;
             }
             f.locked_pixels = px;
@@ -386,13 +347,11 @@ namespace
             if (!bm_format_is_uncompressed_rgb(c->format)) {
                 xlog::error("ATX '{}': source format {} cannot be transformed (uncompressed RGB/RGBA only)",
                     filename, static_cast<int>(c->format));
-                unlock_children(*c);
                 return nullptr;
             }
             if (!bm_format_is_uncompressed_rgb(effective)) {
                 xlog::error("ATX '{}': target format {} not supported (uncompressed RGB/RGBA only)",
                     filename, static_cast<int>(effective));
-                unlock_children(*c);
                 return nullptr;
             }
 
@@ -474,9 +433,7 @@ namespace
                 f.locked_pixels = f.owned_buffer.get();
             }
 
-            // Success path: drop the mask's ref now that the per-frame transform has copied
-            // its data into each owned_buffer.
-            mask_guard.release();
+            // mask_guard releases the mask at end of scope (unlock+release).
             c->format = effective;
         }
 
@@ -677,9 +634,6 @@ void atx_do_frame()
 
 void atx_level_reset()
 {
-    for (auto& [key, cptr] : g_controllers) {
-        release_children(*cptr);
-    }
     g_controllers.clear();
     g_by_handle.clear();
     g_failed.clear();

--- a/game_patch/bmpman/atx.cpp
+++ b/game_patch/bmpman/atx.cpp
@@ -562,8 +562,8 @@ void atx_do_frame()
     const float dt_s = rf::frametime;
     if (dt_s <= 0.0f) return;
 
-    for (auto& [key, cptr] : g_controllers) {
-        AtxController& c = *cptr;
+    for (auto& kv : g_controllers) {
+        AtxController& c = *kv.second;
         if (c.animation_mode == AtxAnimationMode::Static) continue;
         if (!c.playing) continue;
         if (c.frames.size() < 2) continue;

--- a/game_patch/bmpman/atx.cpp
+++ b/game_patch/bmpman/atx.cpp
@@ -65,7 +65,13 @@ namespace
         int direction = 1; // ping-pong only: +1 or -1
         bool playing = true;
         float time_in_frame_s = 0.0f;
-        int atx_bm_handle = -1; // populated on first lock
+
+        // Every bm cache entry currently backed by this controller. Multiple entries can
+        // co-exist when the same ATX is referenced under different extensions in one level
+        // (e.g. brushes via .tga, meshes via .dds), each producing a separate bm_handle that
+        // resolves to the same controller via basename. dirty_atx must mark all of them so
+        // every GPU surface re-uploads; populated on lock, removed on atx_free.
+        std::unordered_set<int> bm_handles;
 
         // ATX-wide material override (applied when a frame doesn't have its own).
         std::optional<uint8_t> header_material;
@@ -206,8 +212,11 @@ namespace
 
     void dirty_atx(AtxController& c)
     {
-        if (c.atx_bm_handle >= 0) {
-            rf::gr::mark_texture_dirty(c.atx_bm_handle);
+        // Mark every bm_handle that maps to this controller. Without this, only the
+        // most-recently-locked handle would re-upload to the GPU, freezing animation on any
+        // other in-world instance that references this ATX through a different extension.
+        for (int h : c.bm_handles) {
+            rf::gr::mark_texture_dirty(h);
         }
     }
 
@@ -524,12 +533,11 @@ rf::bm::Format lock_atx_bitmap(rf::bm::BitmapEntry& bm_entry, void** pixels_out,
         return rf::bm::FORMAT_NONE;
     }
     AtxController& c = *it->second;
-    if (c.atx_bm_handle != bm_entry.handle) {
-        c.atx_bm_handle = bm_entry.handle;
-        // Populate the hot-path lookup so bm_get_material_idx_hook can find the controller in
-        // O(1) by handle without re-hashing the entry name.
-        g_by_handle[bm_entry.handle] = &c;
-    }
+    // Insertions are idempotent. We track every bm_handle that locks this controller so
+    // dirty_atx can refresh all GPU surfaces on frame change, and so bm_get_material_idx_hook
+    // can resolve a controller from a handle in O(1) without re-hashing the entry name.
+    c.bm_handles.insert(bm_entry.handle);
+    g_by_handle[bm_entry.handle] = &c;
 
     int idx = c.current_frame;
     if (idx < 0 || idx >= static_cast<int>(c.frames.size())) {
@@ -580,7 +588,15 @@ std::optional<uint8_t> atx_material_override(const rf::bm::BitmapEntry& bm_entry
 
 void atx_free(rf::bm::BitmapEntry& bm_entry)
 {
-    g_by_handle.erase(bm_entry.handle);
+    // Forget this handle. Other bm_entries (e.g. the same ATX referenced under a different
+    // extension) may still be backed by the same controller, so we don't tear down the
+    // controller here — that's bounded to atx_level_reset (level transition). The set
+    // shrinks to empty naturally when the last reference is freed; the controller and its
+    // child bm refs are retained until level reset, matching the level-based asset model.
+    if (auto it = g_by_handle.find(bm_entry.handle); it != g_by_handle.end()) {
+        it->second->bm_handles.erase(bm_entry.handle);
+        g_by_handle.erase(it);
+    }
 }
 
 void atx_do_frame()

--- a/game_patch/bmpman/atx.h
+++ b/game_patch/bmpman/atx.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include "../rf/bmpman.h"
+
+// ATX is a text-based (TOML) container that bundles a list of existing texture files
+// (.tga/.dds/.vbm/etc.) into a single virtual bitmap addressable as "<name>.atx".
+// Frames share width/height/format with frame[0]; the loader validates this.
+// The handle used by events is the .atx filename without its extension.
+
+// Called from bm_read_header_hook when an .atx file should be loaded for the requested name.
+// The `atx_filename` argument is the resolved .atx filename (e.g. "mytexture.atx"), regardless
+// of which extension the caller originally requested.
+rf::bm::Type read_atx_header(const char* atx_filename, int* width_out, int* height_out,
+    rf::bm::Format* format_out, int* num_levels_out, int* num_frames_out);
+
+// True while parse_and_load is loading a child texture. The bm_read_header hook checks this to
+// suppress .atx supercede during ATX child loads, which prevents both nested-ATX and
+// recursive-cycle scenarios in one stroke.
+bool atx_is_loading_child();
+
+// Called from bm_lock_hook for TYPE_ATX bitmaps. Forwards to the currently-selected
+// child texture's locked pixels. Returns the format from the bitmap entry.
+rf::bm::Format lock_atx_bitmap(rf::bm::BitmapEntry& bm_entry, void** pixels_out, void** palette_out);
+
+// Called from bm_unlock_hook for TYPE_ATX bitmaps (no-op; child stays locked for fast frame swaps).
+void unlock_atx_bitmap(rf::bm::BitmapEntry& bm_entry);
+
+// Called from the bm_get_cached_material_idx hook. Returns the effective material override for
+// the ATX's current frame, or nullopt if the ATX has no overrides configured (caller falls
+// through to the stock material logic in that case).
+std::optional<uint8_t> atx_material_override(const rf::bm::BitmapEntry& bm_entry);
+
+// Called from bm_free_entry_hook for TYPE_ATX bitmaps. Releases child handles.
+void atx_free(rf::bm::BitmapEntry& bm_entry);
+
+// Per-frame tick: advance auto-playing controllers, dirty texture cache when frame index changes.
+void atx_do_frame();
+
+// Drop all controllers and release child handles. Called at level load to reset state.
+void atx_level_reset();
+
+// Event control entry points. `handle` is the .atx filename without extension (case-insensitive).
+// If the controller isn't loaded yet, attempts to load it lazily.
+bool atx_set_frame(const std::string& handle, int frame_index);
+bool atx_play(const std::string& handle);
+bool atx_pause(const std::string& handle);
+bool atx_set_frame_time(const std::string& handle, int frame_time_ms);

--- a/game_patch/bmpman/atx.h
+++ b/game_patch/bmpman/atx.h
@@ -47,7 +47,9 @@ void atx_do_frame();
 void atx_level_reset();
 
 // Event control entry points. `handle` is the .atx filename without extension (case-insensitive).
-// If the controller isn't loaded yet, attempts to load it lazily.
+// Returns false (with a warning) when the controller hasn't been loaded yet — these entry
+// points do NOT lazy-load. The texture must be referenced through the bm system at least once
+// before any event can manipulate it, otherwise frame changes wouldn't reach a GPU surface anyway.
 bool atx_set_frame(const std::string& handle, int frame_index);
 bool atx_play(const std::string& handle);
 bool atx_pause(const std::string& handle);

--- a/game_patch/bmpman/atx.h
+++ b/game_patch/bmpman/atx.h
@@ -33,7 +33,11 @@ void unlock_atx_bitmap(rf::bm::BitmapEntry& bm_entry);
 // through to the stock material logic in that case).
 std::optional<uint8_t> atx_material_override(const rf::bm::BitmapEntry& bm_entry);
 
-// Called from bm_free_entry_hook for TYPE_ATX bitmaps. Releases child handles.
+// Called from bm_free_entry_hook for TYPE_ATX bitmaps. Removes this handle from the
+// controller's tracking set so subsequent dirty marks don't reach a freed handle. Does NOT
+// release the controller or its child bm handles — multiple bm_entries can share one
+// controller (via basename), and child release is bounded to atx_level_reset (level
+// transition), matching the level-based lifetime of every other ATX-cached asset.
 void atx_free(rf::bm::BitmapEntry& bm_entry);
 
 // Per-frame tick: advance auto-playing controllers, dirty texture cache when frame index changes.

--- a/game_patch/bmpman/bmpman.cpp
+++ b/game_patch/bmpman/bmpman.cpp
@@ -7,6 +7,7 @@
 #include "../graphics/gr.h"
 #include "../rf/file/file.h"
 #include "../misc/vpackfile.h"
+#include "atx.h"
 #include "dds.h"
 
 int bm_calculate_pitch(int w, rf::bm::Format format)
@@ -86,8 +87,24 @@ bm_read_header_hook{
         *total_bytes_m2v_out = -1;
         *vbm_ver_out = 1;
 
-        rf::File dds_file;
         std::string filename_without_ext{get_filename_without_ext(filename)};
+
+        // ATX: text-based proxy format that wraps existing texture files
+        if (!atx_is_loading_child()) {
+            auto atx_filename = filename_without_ext + ".atx";
+            rf::File atx_file;
+            if (atx_file.open(atx_filename.c_str()) == 0) {
+                atx_file.close();
+                xlog::trace("Loading ATX {} (resolved from {})", atx_filename, filename);
+                auto bm_type = read_atx_header(atx_filename.c_str(), width_out, height_out,
+                    pixel_fmt_out, num_levels_out, num_frames_out);
+                if (bm_type != rf::bm::TYPE_NONE) {
+                    return bm_type;
+                }
+            }
+        }
+
+        rf::File dds_file;
         auto dds_filename = filename_without_ext + ".dds";
         if (dds_file.open(dds_filename.c_str()) == 0) {
             xlog::trace("Loading {}", dds_filename);
@@ -127,6 +144,9 @@ FunHook<rf::bm::Format(int, void**, void**)> bm_lock_hook{
             *palette_out = bm_entry.locked_palette;
             return bm_entry.format;
         }
+        if (bm_entry.bm_type == rf::bm::TYPE_ATX) {
+            return lock_atx_bitmap(bm_entry, pixels_out, palette_out);
+        }
         auto pixel_fmt = bm_lock_hook.call_target(bmh, pixels_out, palette_out);
         if (pixel_fmt == rf::bm::FORMAT_NONE) {
             *pixels_out = nullptr;
@@ -157,10 +177,39 @@ FunHook<bool(int)> bm_has_alpha_hook{
     },
 };
 
+FunHook<uint8_t(int)> bm_get_material_idx_hook{
+    0x00511780,
+    [](int bmh) -> uint8_t {
+        auto& bm_entry = rf::bm::bitmaps[rf::bm::get_cache_slot(bmh)];
+        if (bm_entry.bm_type == rf::bm::TYPE_ATX) {
+            if (auto over = atx_material_override(bm_entry)) {
+                return *over;
+            }
+        }
+        return bm_get_material_idx_hook.call_target(bmh);
+    },
+};
+
+FunHook<void(int)> bm_unlock_hook{
+    0x00511700,
+    [](int bmh) {
+        auto& bm_entry = rf::bm::bitmaps[rf::bm::get_cache_slot(bmh)];
+        if (bm_entry.bm_type == rf::bm::TYPE_ATX) {
+            unlock_atx_bitmap(bm_entry);
+            return;
+        }
+        bm_unlock_hook.call_target(bmh);
+    },
+};
+
 FunHook<void(int)> bm_free_entry_hook{
     0x0050F240,
     [](int bm_index) {
-        rf::bm::bitmaps[bm_index].dynamic = false;
+        auto& bm_entry = rf::bm::bitmaps[bm_index];
+        if (bm_entry.bm_type == rf::bm::TYPE_ATX) {
+            atx_free(bm_entry);
+        }
+        bm_entry.dynamic = false;
         bm_free_entry_hook.call_target(bm_index);
     },
 };
@@ -253,6 +302,8 @@ void bm_apply_patch()
 {
     bm_read_header_hook.install();
     bm_lock_hook.install();
+    bm_unlock_hook.install();
+    bm_get_material_idx_hook.install();
     bm_has_alpha_hook.install();
     bm_free_entry_hook.install();
 

--- a/game_patch/bmpman/bmpman.cpp
+++ b/game_patch/bmpman/bmpman.cpp
@@ -4,11 +4,13 @@
 #include <patch_common/AsmWriter.h>
 #include <xlog/xlog.h>
 #include <common/utils/string-utils.h>
+#include <common/bitmap/formats.h>
 #include "../graphics/gr.h"
 #include "../rf/file/file.h"
 #include "../misc/vpackfile.h"
 #include "atx.h"
 #include "dds.h"
+#include "stb_image_loader.h"
 
 int bm_calculate_pitch(int w, rf::bm::Format format)
 {
@@ -89,7 +91,7 @@ bm_read_header_hook{
 
         std::string filename_without_ext{get_filename_without_ext(filename)};
 
-        // ATX: text-based proxy format that wraps existing texture files
+        // ATX supercedes DDS, PNG, JPG, VBM, and TGA
         if (!atx_is_loading_child()) {
             auto atx_filename = filename_without_ext + ".atx";
             rf::File atx_file;
@@ -104,6 +106,7 @@ bm_read_header_hook{
             }
         }
 
+        // DDS supercedes PNG, JPG, VBM, and TGA
         rf::File dds_file;
         auto dds_filename = filename_without_ext + ".dds";
         if (dds_file.open(dds_filename.c_str()) == 0) {
@@ -114,6 +117,16 @@ bm_read_header_hook{
             }
         }
 
+        // PNG/JPG supercedes VBM and TGA
+        {
+            auto bm_type = read_stb_header(filename, width_out, height_out, pixel_fmt_out, num_levels_out);
+            if (bm_type != rf::bm::TYPE_NONE) {
+                xlog::trace("Loading PNG/JPG sibling for '{}'", filename);
+                return bm_type;
+            }
+        }
+
+        // Precedence chain: ATX > DDS > PNG/JPG > VBM > TGA.
         xlog::trace("Loading bitmap header for '{}'", filename);
         auto bm_type = bm_read_header_hook.call_target(filename, width_out, height_out, pixel_fmt_out, num_levels_out,
             num_levels_external_mips_out, num_frames_out, fps_out, total_bytes_m2v_out, vbm_ver_out, a11);
@@ -142,7 +155,15 @@ FunHook<rf::bm::Format(int, void**, void**)> bm_lock_hook{
             lock_dds_bitmap(bm_entry);
             *pixels_out = bm_entry.locked_data;
             *palette_out = bm_entry.locked_palette;
-            return bm_entry.format;
+            // If the load failed, locked_data is left null, report FORMAT_NONE so the
+            // caller doesn't dereference null with a "valid" format code.
+            return bm_entry.locked_data ? bm_entry.format : rf::bm::FORMAT_NONE;
+        }
+        if (bm_entry.bm_type == rf::bm::TYPE_STB) {
+            lock_stb_bitmap(bm_entry);
+            *pixels_out = bm_entry.locked_data;
+            *palette_out = bm_entry.locked_palette;
+            return bm_entry.locked_data ? bm_entry.format : rf::bm::FORMAT_NONE;
         }
         if (bm_entry.bm_type == rf::bm::TYPE_ATX) {
             return lock_atx_bitmap(bm_entry, pixels_out, palette_out);

--- a/game_patch/bmpman/bmpman.cpp
+++ b/game_patch/bmpman/bmpman.cpp
@@ -91,29 +91,38 @@ bm_read_header_hook{
 
         std::string filename_without_ext{get_filename_without_ext(filename)};
 
-        // ATX supercedes DDS, PNG, JPG, VBM, and TGA
+        // ATX supercedes DDS, PNG, JPG, VBM, and TGA. Each candidate sibling is gated by
+        // vpackfile_supercede_allowed so user_maps content can't override stock when the
+        // "allow overwrite game files" toggle is off — same policy that already gates
+        // same-name overrides for every other asset type.
         if (!atx_is_loading_child()) {
             auto atx_filename = filename_without_ext + ".atx";
-            rf::File atx_file;
-            if (atx_file.open(atx_filename.c_str()) == 0) {
-                atx_file.close();
-                xlog::trace("Loading ATX {} (resolved from {})", atx_filename, filename);
-                auto bm_type = read_atx_header(atx_filename.c_str(), width_out, height_out,
-                    pixel_fmt_out, num_levels_out, num_frames_out);
-                if (bm_type != rf::bm::TYPE_NONE) {
-                    return bm_type;
+            if (vpackfile_supercede_allowed(filename, atx_filename.c_str())) {
+                rf::File atx_file;
+                if (atx_file.open(atx_filename.c_str()) == 0) {
+                    atx_file.close();
+                    xlog::trace("Loading ATX {} (resolved from {})", atx_filename, filename);
+                    auto bm_type = read_atx_header(atx_filename.c_str(), width_out, height_out,
+                        pixel_fmt_out, num_levels_out, num_frames_out);
+                    if (bm_type != rf::bm::TYPE_NONE) {
+                        return bm_type;
+                    }
                 }
             }
         }
 
         // DDS supercedes PNG, JPG, VBM, and TGA
-        rf::File dds_file;
-        auto dds_filename = filename_without_ext + ".dds";
-        if (dds_file.open(dds_filename.c_str()) == 0) {
-            xlog::trace("Loading {}", dds_filename);
-            auto bm_type = read_dds_header(dds_file, width_out, height_out, pixel_fmt_out, num_levels_out);
-            if (bm_type != rf::bm::TYPE_NONE) {
-                return bm_type;
+        {
+            auto dds_filename = filename_without_ext + ".dds";
+            if (vpackfile_supercede_allowed(filename, dds_filename.c_str())) {
+                rf::File dds_file;
+                if (dds_file.open(dds_filename.c_str()) == 0) {
+                    xlog::trace("Loading {}", dds_filename);
+                    auto bm_type = read_dds_header(dds_file, width_out, height_out, pixel_fmt_out, num_levels_out);
+                    if (bm_type != rf::bm::TYPE_NONE) {
+                        return bm_type;
+                    }
+                }
             }
         }
 

--- a/game_patch/bmpman/dds.cpp
+++ b/game_patch/bmpman/dds.cpp
@@ -1,6 +1,7 @@
 #include <dds.h>
 #include <xlog/xlog.h>
 #include <common/utils/string-utils.h>
+#include <common/bitmap/formats.h>
 #include "../graphics/gr.h"
 #include "../os/os.h"
 #include "../multi/multi.h"
@@ -11,40 +12,11 @@
 
 rf::bm::Format get_bm_format_from_dds_pixel_format(DDS_PIXELFORMAT& ddspf)
 {
-    if (ddspf.flags & DDS_RGB) {
-        switch (ddspf.RGBBitCount) {
-            case 32:
-                if (ddspf.ABitMask)
-                    return rf::bm::FORMAT_8888_ARGB;
-                else
-                    break;
-            case 24:
-                return rf::bm::FORMAT_888_RGB;
-            case 16:
-                if (ddspf.ABitMask == 0x8000)
-                    return rf::bm::FORMAT_1555_ARGB;
-                else if (ddspf.ABitMask)
-                    return rf::bm::FORMAT_4444_ARGB;
-                else
-                    return rf::bm::FORMAT_565_RGB;
-        }
+    int fmt = bm_format_from_dds(ddspf);
+    if (fmt == BM_FORMAT_NONE) {
+        xlog::warn("Unsupported DDS pixel format");
     }
-    else if (ddspf.flags & DDS_FOURCC) {
-        switch (ddspf.fourCC) {
-            case MAKEFOURCC('D', 'X', 'T', '1'):
-                return rf::bm::FORMAT_DXT1;
-            case MAKEFOURCC('D', 'X', 'T', '2'):
-                return rf::bm::FORMAT_DXT2;
-            case MAKEFOURCC('D', 'X', 'T', '3'):
-                return rf::bm::FORMAT_DXT3;
-            case MAKEFOURCC('D', 'X', 'T', '4'):
-                return rf::bm::FORMAT_DXT4;
-            case MAKEFOURCC('D', 'X', 'T', '5'):
-                return rf::bm::FORMAT_DXT5;
-        }
-    }
-    xlog::warn("Unsupported DDS pixel format");
-    return rf::bm::FORMAT_NONE;
+    return static_cast<rf::bm::Format>(fmt);
 }
 
 rf::bm::Type read_dds_header(rf::File& file, int *width_out, int *height_out, rf::bm::Format *format_out,
@@ -90,6 +62,10 @@ rf::bm::Type read_dds_header(rf::File& file, int *width_out, int *height_out, rf
 
 int lock_dds_bitmap(rf::bm::BitmapEntry& bm_entry)
 {
+    // Defensively null both fields up front so any failure path returning -1 cannot leave a stale pointer
+    bm_entry.locked_data = nullptr;
+    bm_entry.locked_palette = nullptr;
+
     rf::File file;
     std::string filename_without_ext{get_filename_without_ext(bm_entry.name)};
     auto dds_filename = filename_without_ext + ".dds";

--- a/game_patch/bmpman/dds.cpp
+++ b/game_patch/bmpman/dds.cpp
@@ -46,10 +46,17 @@ rf::bm::Type read_dds_header(rf::File& file, int *width_out, int *height_out, rf
         return rf::bm::TYPE_NONE;
     }
 
+    // Reject invalid dimensions before reaching int arithmetic.
+    if (hdr.width == 0 || hdr.height == 0
+        || hdr.width > BM_MAX_DIMENSION || hdr.height > BM_MAX_DIMENSION) {
+        xlog::warn("DDS rejected: dimensions {}x{} outside (0, {}]", hdr.width, hdr.height, BM_MAX_DIMENSION);
+        return rf::bm::TYPE_NONE;
+    }
+
     xlog::trace("Using DDS format 0x{:x}", format);
 
-    *width_out = hdr.width;
-    *height_out = hdr.height;
+    *width_out = static_cast<int>(hdr.width);
+    *height_out = static_cast<int>(hdr.height);
     *format_out = format;
 
     *num_levels_out = 1;

--- a/game_patch/bmpman/stb_image_loader.cpp
+++ b/game_patch/bmpman/stb_image_loader.cpp
@@ -13,6 +13,7 @@
 #include "../rf/math/vector.h"
 #include "../rf/math/matrix.h"
 #include "../rf/file/file.h"
+#include "../misc/vpackfile.h"
 
 namespace
 {
@@ -34,14 +35,18 @@ namespace
         return bytes_read == file_size;
     }
 
-    // Probe for a PNG/JPG/JPEG sibling of `base_filename` (any extension stripped). Reads the
-    // first file that exists into `out` and returns true. If none exists, returns false. Used
-    // by both read_stb_header and lock_stb_bitmap
-    bool read_stb_sibling(const char* base_filename, std::vector<uint8_t>& out)
+    // Probe for a PNG/JPG/JPEG sibling of `requested_filename` (any extension stripped). For
+    // each candidate extension, the supercede policy gate (vpackfile_supercede_allowed) is
+    // checked first — same toggle that gates user_maps overriding stock for any other asset
+    // type. The first allowed-and-existing sibling wins; if none qualify, returns false.
+    bool read_stb_sibling(const char* requested_filename, std::vector<uint8_t>& out)
     {
-        std::string base{get_filename_without_ext(base_filename)};
+        std::string base{get_filename_without_ext(requested_filename)};
         for (const char* ext : {".png", ".jpg", ".jpeg"}) {
             auto candidate = base + ext;
+            if (!vpackfile_supercede_allowed(requested_filename, candidate.c_str())) {
+                continue;
+            }
             if (read_file_to_vector(candidate.c_str(), out)) {
                 return true;
             }

--- a/game_patch/bmpman/stb_image_loader.cpp
+++ b/game_patch/bmpman/stb_image_loader.cpp
@@ -1,0 +1,150 @@
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include <stb_image.h>
+#include <xlog/xlog.h>
+#include <common/utils/string-utils.h>
+#include <common/bitmap/formats.h>
+
+#include "stb_image_loader.h"
+#include "../rf/bmpman.h"
+#include "../rf/crt.h"
+#include "../rf/math/vector.h"
+#include "../rf/math/matrix.h"
+#include "../rf/file/file.h"
+
+namespace
+{
+    // Slurp an entire file via rf::File (handles packfile + disk via the standard lookup).
+    bool read_file_to_vector(const char* filename, std::vector<uint8_t>& out)
+    {
+        rf::File file;
+        if (file.open(filename) != 0) {
+            return false;
+        }
+        const int file_size = file.size();
+        if (file_size <= 0) {
+            file.close();
+            return false;
+        }
+        out.resize(static_cast<size_t>(file_size));
+        const int bytes_read = file.read(out.data(), file_size);
+        file.close();
+        return bytes_read == file_size;
+    }
+
+    // Probe for a PNG/JPG/JPEG sibling of `base_filename` (any extension stripped). Reads the
+    // first file that exists into `out` and returns true. If none exists, returns false. Used
+    // by both read_stb_header and lock_stb_bitmap
+    bool read_stb_sibling(const char* base_filename, std::vector<uint8_t>& out)
+    {
+        std::string base{get_filename_without_ext(base_filename)};
+        for (const char* ext : {".png", ".jpg", ".jpeg"}) {
+            auto candidate = base + ext;
+            if (read_file_to_vector(candidate.c_str(), out)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Channel-count → bm format mapping lives in common/bitmap/formats.h so the editor uses
+    // the same rule (drift-proof). Thin wrapper provides the rf::bm::Format cast at this site.
+    rf::bm::Format format_for_channels(int channels)
+    {
+        return static_cast<rf::bm::Format>(bm_format_from_stb_channels(channels));
+    }
+
+    // stb returns RGBA (or RGB) in memory order; RF's 8888_ARGB / 888_RGB store BGRA / BGR.
+    // Swap channels 0 and 2 in place.
+    void swizzle_rb(uint8_t* pixels, int num_pixels, int bytes_per_pixel)
+    {
+        for (int i = 0; i < num_pixels; ++i) {
+            uint8_t* p = pixels + i * bytes_per_pixel;
+            std::swap(p[0], p[2]);
+        }
+    }
+}
+
+rf::bm::Type read_stb_header(const char* filename, int* width_out, int* height_out,
+    rf::bm::Format* format_out, int* num_levels_out)
+{
+    // Probe for any PNG/JPG/JPEG sibling of the requested name. Returning TYPE_NONE here is
+    // not an error — it just means no sibling exists, and the caller falls through to stock.
+    std::vector<uint8_t> file_bytes;
+    if (!read_stb_sibling(filename, file_bytes)) {
+        return rf::bm::TYPE_NONE;
+    }
+
+    int w = 0, h = 0, channels = 0;
+    if (!stbi_info_from_memory(file_bytes.data(), static_cast<int>(file_bytes.size()),
+                               &w, &h, &channels)) {
+        xlog::warn("stb_image: failed to read header for '{}': {}", filename, stbi_failure_reason());
+        return rf::bm::TYPE_NONE;
+    }
+    if (w <= 0 || h <= 0 || channels < 1 || channels > 4) {
+        return rf::bm::TYPE_NONE;
+    }
+
+    *width_out = w;
+    *height_out = h;
+    *format_out = format_for_channels(channels);
+    *num_levels_out = 1; // No mip chain in PNG/JPEG; engine handles auto-mip if enabled.
+    return rf::bm::TYPE_STB;
+}
+
+int lock_stb_bitmap(rf::bm::BitmapEntry& bm_entry)
+{
+    // Defensively null both fields up front. If any failure path returns -1 below, the bm_lock
+    // hook reads these fields directly, so leaving stale pointers from a prior load could be a
+    // use-after-free. Stock unlock frees locked_data and presumably nulls it, but explicit null
+    // here is cheap insurance.
+    bm_entry.locked_data = nullptr;
+    bm_entry.locked_palette = nullptr;
+
+    // Probe siblings the same way read_stb_header did. The bm system stored the originally
+    // requested name (which might be foo.tga even though we superceded with foo.png), so we
+    // can't just reopen by name — we have to re-resolve.
+    std::vector<uint8_t> file_bytes;
+    if (!read_stb_sibling(bm_entry.name, file_bytes)) {
+        xlog::error("stb_image: no PNG/JPG sibling found for '{}' during lock", bm_entry.name);
+        return -1;
+    }
+
+    // Choose 4-channel output if we declared 8888 in read_header, else 3-channel.
+    const int desired_channels = (bm_entry.format == rf::bm::FORMAT_8888_ARGB) ? 4 : 3;
+
+    int w = 0, h = 0, source_channels = 0;
+    uint8_t* pixels = stbi_load_from_memory(file_bytes.data(), static_cast<int>(file_bytes.size()),
+                                            &w, &h, &source_channels, desired_channels);
+    if (!pixels) {
+        xlog::error("stb_image: decode failed for '{}': {}", bm_entry.name, stbi_failure_reason());
+        return -1;
+    }
+    if (w != bm_entry.orig_width || h != bm_entry.orig_height) {
+        xlog::error("stb_image: '{}' dimensions changed between header read and decode", bm_entry.name);
+        stbi_image_free(pixels);
+        return -1;
+    }
+
+    const int num_pixels = w * h;
+    const int bytes_per_pixel = desired_channels;
+    const size_t total_bytes = static_cast<size_t>(num_pixels) * bytes_per_pixel;
+
+    // Allocate via rf::rf_malloc so stock unlock can free this buffer with its matching free.
+    void* dst = rf::rf_malloc(static_cast<int>(total_bytes));
+    if (!dst) {
+        xlog::error("stb_image: rf_malloc failed for {} bytes ('{}')", total_bytes, bm_entry.name);
+        stbi_image_free(pixels);
+        return -1;
+    }
+
+    std::memcpy(dst, pixels, total_bytes);
+    swizzle_rb(static_cast<uint8_t*>(dst), num_pixels, bytes_per_pixel);
+
+    bm_entry.locked_data = dst;
+    bm_entry.locked_palette = nullptr;
+    stbi_image_free(pixels);
+    return 0;
+}

--- a/game_patch/bmpman/stb_image_loader.cpp
+++ b/game_patch/bmpman/stb_image_loader.cpp
@@ -36,8 +36,8 @@ namespace
     // Probe for a PNG/JPG/JPEG sibling of `requested_filename` (any extension stripped). For
     // each candidate extension, the supercede policy gate (vpackfile_supercede_allowed) is
     // checked first — same toggle that gates user_maps overriding stock for any other asset
-    // type. The first allowed-and-existing sibling wins; if none qualify, returns false.
-    bool read_stb_sibling(const char* requested_filename, std::vector<uint8_t>& out)
+    // type.
+    std::string read_stb_sibling(const char* requested_filename, std::vector<uint8_t>& out)
     {
         std::string base{get_filename_without_ext(requested_filename)};
         for (const char* ext : {".png", ".jpg", ".jpeg"}) {
@@ -46,10 +46,10 @@ namespace
                 continue;
             }
             if (read_file_to_vector(candidate.c_str(), out)) {
-                return true;
+                return candidate;
             }
         }
-        return false;
+        return {};
     }
 
     // Channel-count → bm format mapping lives in common/bitmap/formats.h so the editor uses
@@ -76,14 +76,15 @@ rf::bm::Type read_stb_header(const char* filename, int* width_out, int* height_o
     // Probe for any PNG/JPG/JPEG sibling of the requested name. Returning TYPE_NONE here is
     // not an error — it just means no sibling exists, and the caller falls through to stock.
     std::vector<uint8_t> file_bytes;
-    if (!read_stb_sibling(filename, file_bytes)) {
+    const std::string resolved = read_stb_sibling(filename, file_bytes);
+    if (resolved.empty()) {
         return rf::bm::TYPE_NONE;
     }
 
     int w = 0, h = 0, channels = 0;
     if (!stbi_info_from_memory(file_bytes.data(), static_cast<int>(file_bytes.size()),
                                &w, &h, &channels)) {
-        xlog::warn("stb_image: failed to read header for '{}': {}", filename, stbi_failure_reason());
+        xlog::warn("stb_image: failed to read header for '{}': {}", resolved, stbi_failure_reason());
         return rf::bm::TYPE_NONE;
     }
     if (w <= 0 || h <= 0 || channels < 1 || channels > 4) {
@@ -91,7 +92,7 @@ rf::bm::Type read_stb_header(const char* filename, int* width_out, int* height_o
     }
     // Reject invalid dimensions before reaching int arithmetic.
     if (w > BM_MAX_DIMENSION || h > BM_MAX_DIMENSION) {
-        xlog::warn("stb_image: '{}' rejected ({}x{} exceeds {} px ceiling)", filename, w, h, BM_MAX_DIMENSION);
+        xlog::warn("stb_image: '{}' rejected ({}x{} exceeds {} px ceiling)", resolved, w, h, BM_MAX_DIMENSION);
         return rf::bm::TYPE_NONE;
     }
 
@@ -115,7 +116,8 @@ int lock_stb_bitmap(rf::bm::BitmapEntry& bm_entry)
     // requested name (which might be foo.tga even though we superceded with foo.png), so we
     // can't just reopen by name — we have to re-resolve.
     std::vector<uint8_t> file_bytes;
-    if (!read_stb_sibling(bm_entry.name, file_bytes)) {
+    const std::string resolved = read_stb_sibling(bm_entry.name, file_bytes);
+    if (resolved.empty()) {
         xlog::error("stb_image: no PNG/JPG sibling found for '{}' during lock", bm_entry.name);
         return -1;
     }
@@ -127,11 +129,11 @@ int lock_stb_bitmap(rf::bm::BitmapEntry& bm_entry)
     uint8_t* pixels = stbi_load_from_memory(file_bytes.data(), static_cast<int>(file_bytes.size()),
                                             &w, &h, &source_channels, desired_channels);
     if (!pixels) {
-        xlog::error("stb_image: decode failed for '{}': {}", bm_entry.name, stbi_failure_reason());
+        xlog::error("stb_image: decode failed for '{}': {}", resolved, stbi_failure_reason());
         return -1;
     }
     if (w != bm_entry.orig_width || h != bm_entry.orig_height) {
-        xlog::error("stb_image: '{}' dimensions changed between header read and decode", bm_entry.name);
+        xlog::error("stb_image: '{}' dimensions changed between header read and decode", resolved);
         stbi_image_free(pixels);
         return -1;
     }
@@ -144,7 +146,7 @@ int lock_stb_bitmap(rf::bm::BitmapEntry& bm_entry)
     // Allocate via rf::rf_malloc so stock unlock can free this buffer with its matching free.
     void* dst = rf::rf_malloc(static_cast<int>(total_bytes));
     if (!dst) {
-        xlog::error("stb_image: rf_malloc failed for {} bytes ('{}')", total_bytes, bm_entry.name);
+        xlog::error("stb_image: rf_malloc failed for {} bytes ('{}')", total_bytes, resolved);
         stbi_image_free(pixels);
         return -1;
     }

--- a/game_patch/bmpman/stb_image_loader.cpp
+++ b/game_patch/bmpman/stb_image_loader.cpp
@@ -89,10 +89,9 @@ rf::bm::Type read_stb_header(const char* filename, int* width_out, int* height_o
     if (w <= 0 || h <= 0 || channels < 1 || channels > 4) {
         return rf::bm::TYPE_NONE;
     }
-    // Reject oversized images at header time so the lock path can rely on int arithmetic
-    // staying inside INT_MAX. See BM_STB_MAX_DIMENSION docstring for the rationale.
-    if (w > BM_STB_MAX_DIMENSION || h > BM_STB_MAX_DIMENSION) {
-        xlog::warn("stb_image: '{}' rejected ({}x{} exceeds {} px ceiling)", filename, w, h, BM_STB_MAX_DIMENSION);
+    // Reject invalid dimensions before reaching int arithmetic.
+    if (w > BM_MAX_DIMENSION || h > BM_MAX_DIMENSION) {
+        xlog::warn("stb_image: '{}' rejected ({}x{} exceeds {} px ceiling)", filename, w, h, BM_MAX_DIMENSION);
         return rf::bm::TYPE_NONE;
     }
 
@@ -136,7 +135,7 @@ int lock_stb_bitmap(rf::bm::BitmapEntry& bm_entry)
         stbi_image_free(pixels);
         return -1;
     }
-    // dims pre-validated against BM_STB_MAX_DIMENSION at header time, so w * h * channels
+    // dims pre-validated against BM_MAX_DIMENSION at header time, so w * h * channels
     // stays in int range here.
     const int bytes_per_pixel = desired_channels;
     const int num_pixels = w * h;

--- a/game_patch/bmpman/stb_image_loader.cpp
+++ b/game_patch/bmpman/stb_image_loader.cpp
@@ -1,12 +1,10 @@
 #include <cstdint>
 #include <cstring>
 #include <vector>
-
 #include <stb_image.h>
 #include <xlog/xlog.h>
 #include <common/utils/string-utils.h>
 #include <common/bitmap/formats.h>
-
 #include "stb_image_loader.h"
 #include "../rf/bmpman.h"
 #include "../rf/crt.h"
@@ -91,6 +89,12 @@ rf::bm::Type read_stb_header(const char* filename, int* width_out, int* height_o
     if (w <= 0 || h <= 0 || channels < 1 || channels > 4) {
         return rf::bm::TYPE_NONE;
     }
+    // Reject oversized images at header time so the lock path can rely on int arithmetic
+    // staying inside INT_MAX. See BM_STB_MAX_DIMENSION docstring for the rationale.
+    if (w > BM_STB_MAX_DIMENSION || h > BM_STB_MAX_DIMENSION) {
+        xlog::warn("stb_image: '{}' rejected ({}x{} exceeds {} px ceiling)", filename, w, h, BM_STB_MAX_DIMENSION);
+        return rf::bm::TYPE_NONE;
+    }
 
     *width_out = w;
     *height_out = h;
@@ -132,9 +136,10 @@ int lock_stb_bitmap(rf::bm::BitmapEntry& bm_entry)
         stbi_image_free(pixels);
         return -1;
     }
-
-    const int num_pixels = w * h;
+    // dims pre-validated against BM_STB_MAX_DIMENSION at header time, so w * h * channels
+    // stays in int range here.
     const int bytes_per_pixel = desired_channels;
+    const int num_pixels = w * h;
     const size_t total_bytes = static_cast<size_t>(num_pixels) * bytes_per_pixel;
 
     // Allocate via rf::rf_malloc so stock unlock can free this buffer with its matching free.

--- a/game_patch/bmpman/stb_image_loader.h
+++ b/game_patch/bmpman/stb_image_loader.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "../rf/bmpman.h"
+
+// Called from bm_read_header_hook. Reads the file from packfiles/disk via rf::File, peeks at
+// the header to fill width/height/format/num_levels. Returns TYPE_STB on success or TYPE_NONE
+// if the file can't be opened, decoded, or the format is unsupported.
+rf::bm::Type read_stb_header(const char* filename, int* width_out, int* height_out,
+    rf::bm::Format* format_out, int* num_levels_out);
+
+// Called from bm_lock_hook for TYPE_STB bitmaps. Decodes the file into an rf-allocated buffer,
+// stores it in bm_entry.locked_data (matching the DDS pattern, so stock unlock frees it).
+int lock_stb_bitmap(rf::bm::BitmapEntry& bm_entry);

--- a/game_patch/main/main.cpp
+++ b/game_patch/main/main.cpp
@@ -18,6 +18,7 @@
 #include "main.h"
 #include "../os/console.h"
 #include "../os/os.h"
+#include "../bmpman/atx.h"
 #include "../bmpman/bmpman.h"
 #include "../debug/debug.h"
 #include "../graphics/gr.h"
@@ -154,6 +155,7 @@ FunHook<int()> rf_do_frame_hook{
         client_bot_do_frame();
         koth_do_frame();
         alpine_mesh_do_frame();
+        atx_do_frame();
         int result = rf_do_frame_hook.call_target();
         maybe_autosave();
         debug_do_frame_post();
@@ -204,6 +206,7 @@ FunHook<int(rf::String&, rf::String&, char*)> level_load_hook{
         xlog::info("Loading level: {}", level_filename);
         evaluate_pow2tex(level_filename);
         waypoints_level_reset();
+        atx_level_reset();
         if (!save_filename.empty())
             xlog::info("Restoring game from save file: {}", save_filename);
 

--- a/game_patch/misc/vpackfile.cpp
+++ b/game_patch/misc/vpackfile.cpp
@@ -428,6 +428,28 @@ static bool is_lookup_table_entry_override_allowed(rf::VPackfileEntry* old_entry
     return true;
 }
 
+bool vpackfile_supercede_allowed(const char* requested_filename, const char* sibling_filename)
+{
+    if (!sibling_filename || !*sibling_filename) return false;
+
+    // The sibling must actually exist somewhere — otherwise there's nothing to supercede with.
+    auto sibling_it = g_loopup_table.find(string_to_lower(sibling_filename));
+    if (sibling_it == g_loopup_table.end()) {
+        return false;
+    }
+
+    // If no original asset exists at the requested name, the sibling is the only source.
+    // Allow it — there's no override happening, just a regular load.
+    auto requested_it = g_loopup_table.find(string_to_lower(requested_filename));
+    if (requested_it == g_loopup_table.end()) {
+        return true;
+    }
+
+    // Reuse the existing same-name override policy: treat the original as the "old" entry and
+    // the sibling as the "new" entry.
+    return is_lookup_table_entry_override_allowed(requested_it->second, sibling_it->second);
+}
+
 static void vpackfile_add_to_lookup_table(rf::VPackfileEntry* entry)
 {
     std::string filename_str = string_to_lower(entry->name);

--- a/game_patch/misc/vpackfile.cpp
+++ b/game_patch/misc/vpackfile.cpp
@@ -437,17 +437,37 @@ bool vpackfile_supercede_allowed(const char* requested_filename, const char* sib
     if (sibling_it == g_loopup_table.end()) {
         return false;
     }
+    rf::VPackfileEntry* sibling = sibling_it->second;
 
-    // If no original asset exists at the requested name, the sibling is the only source.
-    // Allow it — there's no override happening, just a regular load.
-    auto requested_it = g_loopup_table.find(string_to_lower(requested_filename));
-    if (requested_it == g_loopup_table.end()) {
+    // Sources outside user_maps — root game packfiles, mods/, client_mods/ — can supercede
+    // unconditionally. Matches the same-name override policy for these sources.
+    //
+    // Note: deliberately NOT consulting g_is_overriding_disabled (the flag set after init).
+    // That flag protects against late packfile registration; runtime cache lookups are not
+    // late registrations, so reusing it here would falsely deny every supercede during
+    // gameplay (which is when bm_read_header_hook actually runs).
+    if (!sibling->parent->is_user_maps) {
+        if (sibling->parent->is_client_mods) {
+            g_is_modded_game = true;
+        }
         return true;
     }
 
-    // Reuse the existing same-name override policy: treat the original as the "old" entry and
-    // the sibling as the "new" entry.
-    return is_lookup_table_entry_override_allowed(requested_it->second, sibling_it->second);
+    // Sibling is from user_maps. Same-name policy says: user_maps can override another
+    // user_maps entry regardless of toggle, but can only override a non-user_maps entry
+    // when the "allow overwrite game files" toggle is on. Mirror that here.
+    auto requested_it = g_loopup_table.find(string_to_lower(requested_filename));
+    bool requested_is_user_maps =
+        (requested_it != g_loopup_table.end()) && requested_it->second->parent->is_user_maps;
+
+    if (requested_is_user_maps) {
+        return true;
+    }
+    if (g_game_config.allow_overwrite_game_files) {
+        g_is_modded_game = true;
+        return true;
+    }
+    return false;
 }
 
 static void vpackfile_add_to_lookup_table(rf::VPackfileEntry* entry)

--- a/game_patch/misc/vpackfile.cpp
+++ b/game_patch/misc/vpackfile.cpp
@@ -457,9 +457,15 @@ bool vpackfile_supercede_allowed(const char* requested_filename, const char* sib
     // user_maps entry regardless of toggle, but can only override a non-user_maps entry
     // when the "allow overwrite game files" toggle is on. Mirror that here.
     auto requested_it = g_loopup_table.find(string_to_lower(requested_filename));
-    bool requested_is_user_maps =
-        (requested_it != g_loopup_table.end()) && requested_it->second->parent->is_user_maps;
 
+    // If the requested file doesn't exist anywhere, the sibling isn't overriding anything —
+    // it's a net-new asset that the user_maps content needs in place of the legacy reference.
+    if (requested_it == g_loopup_table.end()) {
+        g_is_modded_game = true;
+        return true;
+    }
+
+    bool requested_is_user_maps = requested_it->second->parent->is_user_maps;
     if (requested_is_user_maps) {
         return true;
     }

--- a/game_patch/misc/vpackfile.h
+++ b/game_patch/misc/vpackfile.h
@@ -20,3 +20,7 @@ int vpackfile_load_user_maps_packfiles();
 // suppress unnecessary missing asset warnings for asset files referenced by but missing
 // from the stock game
 bool is_known_missing_stock_asset(std::string_view filename);
+
+// Used to normalize supercede checks across extensions for the
+// "allow clientside mods from legacy directories" option
+bool vpackfile_supercede_allowed(const char* requested_filename, const char* sibling_filename);

--- a/game_patch/object/event_alpine.cpp
+++ b/game_patch/object/event_alpine.cpp
@@ -7,6 +7,7 @@
 #include <cassert>
 #include <unordered_set>
 #include "event_alpine.h"
+#include "../bmpman/atx.h"
 #include "../hud/hud_world.h"
 #include "../misc/misc.h"
 #include "../misc/level.h"
@@ -100,6 +101,10 @@ FunHook<int(const rf::String* name)> event_lookup_type_hook{
                 {"Gas_Region_State", 151},
                 {"Modify_Gas_Region", 152},
                 {"Resize_Gas_Region", 153},
+                {"ATX_Set_Frame", 154},
+                {"ATX_Play", 155},
+                {"ATX_Pause", 156},
+                {"ATX_Set_Frame_Time", 157},
             };
 
             auto it = custom_event_ids.find(name->c_str());
@@ -179,6 +184,10 @@ FunHook<rf::Event*(int event_type)> event_allocate_hook{
                 {151, []() { return new rf::EventGasRegionState(); }},
                 {152, []() { return new rf::EventModifyGasRegion(); }},
                 {153, []() { return new rf::EventResizeGasRegion(); }},
+                {154, []() { return new rf::EventATXSetFrame(); }},
+                {155, []() { return new rf::EventATXPlay(); }},
+                {156, []() { return new rf::EventATXPause(); }},
+                {157, []() { return new rf::EventATXSetFrameTime(); }},
             };
 
             // find type and allocate
@@ -262,6 +271,10 @@ FunHook<void(rf::Event*)> event_deallocate_hook{
                 {151, [](rf::Event* e) { delete static_cast<rf::EventGasRegionState*>(e); }},
                 {152, [](rf::Event* e) { delete static_cast<rf::EventModifyGasRegion*>(e); }},
                 {153, [](rf::Event* e) { delete static_cast<rf::EventResizeGasRegion*>(e); }},
+                {154, [](rf::Event* e) { delete static_cast<rf::EventATXSetFrame*>(e); }},
+                {155, [](rf::Event* e) { delete static_cast<rf::EventATXPlay*>(e); }},
+                {156, [](rf::Event* e) { delete static_cast<rf::EventATXPause*>(e); }},
+                {157, [](rf::Event* e) { delete static_cast<rf::EventATXSetFrameTime*>(e); }},
             };
 
             // find type and deallocate
@@ -316,7 +329,11 @@ bool is_forward_exempt(rf::EventType event_type) {
         rf::EventType::Unhide_Glare,
         rf::EventType::Gas_Region_State,
         rf::EventType::Modify_Gas_Region,
-        rf::EventType::Resize_Gas_Region
+        rf::EventType::Resize_Gas_Region,
+        rf::EventType::ATX_Set_Frame,
+        rf::EventType::ATX_Play,
+        rf::EventType::ATX_Pause,
+        rf::EventType::ATX_Set_Frame_Time
     };
 
     // AF_Heal should be forward exempt, but this was missed when AF_Heal was added in RFL v300
@@ -856,6 +873,52 @@ static std::unordered_map<rf::EventType, EventFactory> event_factories {
             return event;
         }
     },
+    // ATX_Set_Frame
+    {
+        rf::EventType::ATX_Set_Frame, [](const rf::EventCreateParams& params) {
+            auto* base_event = rf::event_create(params.pos, rf::event_type_to_int(rf::EventType::ATX_Set_Frame));
+            auto* event = dynamic_cast<rf::EventATXSetFrame*>(base_event);
+            if (event) {
+                event->handle = params.str1;
+                event->frame_index = params.int1;
+            }
+            return event;
+        }
+    },
+    // ATX_Play
+    {
+        rf::EventType::ATX_Play, [](const rf::EventCreateParams& params) {
+            auto* base_event = rf::event_create(params.pos, rf::event_type_to_int(rf::EventType::ATX_Play));
+            auto* event = dynamic_cast<rf::EventATXPlay*>(base_event);
+            if (event) {
+                event->handle = params.str1;
+            }
+            return event;
+        }
+    },
+    // ATX_Pause
+    {
+        rf::EventType::ATX_Pause, [](const rf::EventCreateParams& params) {
+            auto* base_event = rf::event_create(params.pos, rf::event_type_to_int(rf::EventType::ATX_Pause));
+            auto* event = dynamic_cast<rf::EventATXPause*>(base_event);
+            if (event) {
+                event->handle = params.str1;
+            }
+            return event;
+        }
+    },
+    // ATX_Set_Frame_Time
+    {
+        rf::EventType::ATX_Set_Frame_Time, [](const rf::EventCreateParams& params) {
+            auto* base_event = rf::event_create(params.pos, rf::event_type_to_int(rf::EventType::ATX_Set_Frame_Time));
+            auto* event = dynamic_cast<rf::EventATXSetFrameTime*>(base_event);
+            if (event) {
+                event->handle = params.str1;
+                event->frame_time_ms = params.int1;
+            }
+            return event;
+        }
+    },
     // Resize_Gas_Region
     {
         rf::EventType::Resize_Gas_Region, [](const rf::EventCreateParams& params) {
@@ -920,6 +983,46 @@ CodeInjection level_read_events_factories_patch {
         }
     }
 };
+
+// ATX event turn_on implementations (out-of-line so event_alpine.h doesn't need to pull in atx.h).
+namespace rf
+{
+    void EventATXSetFrame::turn_on()
+    {
+        if (handle.empty()) {
+            xlog::warn("[ATX_Set_Frame] uid={} called with empty handle", this->uid);
+            return;
+        }
+        atx_set_frame(handle, frame_index);
+    }
+
+    void EventATXPlay::turn_on()
+    {
+        if (handle.empty()) {
+            xlog::warn("[ATX_Play] uid={} called with empty handle", this->uid);
+            return;
+        }
+        atx_play(handle);
+    }
+
+    void EventATXPause::turn_on()
+    {
+        if (handle.empty()) {
+            xlog::warn("[ATX_Pause] uid={} called with empty handle", this->uid);
+            return;
+        }
+        atx_pause(handle);
+    }
+
+    void EventATXSetFrameTime::turn_on()
+    {
+        if (handle.empty()) {
+            xlog::warn("[ATX_Set_Frame_Time] uid={} called with empty handle", this->uid);
+            return;
+        }
+        atx_set_frame_time(handle, frame_time_ms);
+    }
+} // namespace rf
 
 // set p_data orient for Anchor_Marker_Orient when event is created (required for use in moving groups)
 CodeInjection level_read_events_movers_patch {

--- a/game_patch/object/event_alpine.h
+++ b/game_patch/object/event_alpine.h
@@ -3004,4 +3004,88 @@ namespace rf
         }
     };
 
+    // id 154 — ATX_Set_Frame: jump the named ATX texture to a specific frame index.
+    // str1 = handle (atx filename without extension), int1 = frame index (0-based).
+    struct EventATXSetFrame : Event
+    {
+        char padding_align[3];
+        int frame_index = 0;
+        std::string handle;
+
+        void register_variable_handlers() override
+        {
+            Event::register_variable_handlers();
+            auto& handlers = variable_handler_storage[this];
+            handlers[SetVarOpts::int1] = [](Event* event, const std::string& value) {
+                static_cast<EventATXSetFrame*>(event)->frame_index = std::stoi(value);
+            };
+            handlers[SetVarOpts::str1] = [](Event* event, const std::string& value) {
+                static_cast<EventATXSetFrame*>(event)->handle = value;
+            };
+        }
+
+        void turn_on() override;
+    };
+
+    // id 155 — ATX_Play: resume time-based playback for the named ATX texture.
+    // str1 = handle. No-op for animation_mode = Static (engine just won't advance).
+    struct EventATXPlay : Event
+    {
+        char padding_align[3];
+        std::string handle;
+
+        void register_variable_handlers() override
+        {
+            Event::register_variable_handlers();
+            auto& handlers = variable_handler_storage[this];
+            handlers[SetVarOpts::str1] = [](Event* event, const std::string& value) {
+                static_cast<EventATXPlay*>(event)->handle = value;
+            };
+        }
+
+        void turn_on() override;
+    };
+
+    // id 156 — ATX_Pause: stop time-based playback for the named ATX texture at the current frame.
+    // str1 = handle.
+    struct EventATXPause : Event
+    {
+        char padding_align[3];
+        std::string handle;
+
+        void register_variable_handlers() override
+        {
+            Event::register_variable_handlers();
+            auto& handlers = variable_handler_storage[this];
+            handlers[SetVarOpts::str1] = [](Event* event, const std::string& value) {
+                static_cast<EventATXPause*>(event)->handle = value;
+            };
+        }
+
+        void turn_on() override;
+    };
+
+    // id 157 — ATX_Set_Frame_Time: change base_frame_time_ms at runtime.
+    // str1 = handle, int1 = ms per frame (clamped to >= 1).
+    struct EventATXSetFrameTime : Event
+    {
+        char padding_align[3];
+        int frame_time_ms = 100;
+        std::string handle;
+
+        void register_variable_handlers() override
+        {
+            Event::register_variable_handlers();
+            auto& handlers = variable_handler_storage[this];
+            handlers[SetVarOpts::int1] = [](Event* event, const std::string& value) {
+                static_cast<EventATXSetFrameTime*>(event)->frame_time_ms = std::stoi(value);
+            };
+            handlers[SetVarOpts::str1] = [](Event* event, const std::string& value) {
+                static_cast<EventATXSetFrameTime*>(event)->handle = value;
+            };
+        }
+
+        void turn_on() override;
+    };
+
 } // namespace rf

--- a/game_patch/rf/bmpman.h
+++ b/game_patch/rf/bmpman.h
@@ -41,6 +41,7 @@ namespace rf::bm
 #ifdef ALPINE_FACTION
         // Custom bitmap types
         TYPE_DDS = 0x10,
+        TYPE_ATX = 0x11,
 #endif
     };
 

--- a/game_patch/rf/bmpman.h
+++ b/game_patch/rf/bmpman.h
@@ -42,6 +42,7 @@ namespace rf::bm
         // Custom bitmap types
         TYPE_DDS = 0x10,
         TYPE_ATX = 0x11,
+        TYPE_STB = 0x12, // PNG/JPEG via stb_image
 #endif
     };
 

--- a/game_patch/rf/event.h
+++ b/game_patch/rf/event.h
@@ -357,7 +357,11 @@ namespace rf
         Unhide_Glare,
         Gas_Region_State,
         Modify_Gas_Region,
-        Resize_Gas_Region
+        Resize_Gas_Region,
+        ATX_Set_Frame,
+        ATX_Play,
+        ATX_Pause,
+        ATX_Set_Frame_Time
     };
 
     // int to EventType

--- a/resources/tables/events.tbl
+++ b/resources/tables/events.tbl
@@ -415,6 +415,18 @@ $RFE Level1:      "AF_General"
 $Event Name:      "Resize_Gas_Region"
 $RFE Level1:      "AF_General"
 
+$Event Name:      "ATX_Set_Frame"
+$RFE Level1:      "AF_General"
+
+$Event Name:      "ATX_Play"
+$RFE Level1:      "AF_General"
+
+$Event Name:      "ATX_Pause"
+$RFE Level1:      "AF_General"
+
+$Event Name:      "ATX_Set_Frame_Time"
+$RFE Level1:      "AF_General"
+
 #End
 
 // ------------------------------------------------


### PR DESCRIPTION
- Support Alpine Texture (ATX) declarative texture format in game and level editor
  - Fine tuned texture animation without being subject to VBM format limitations
  - Accessible to event system via handle for level-driven behaviour scripting
- Support PNG and JPG texture formats in game and level editor
- Support DDS texture format in level editor
- Add `ATX_Set_Frame`, `ATX_Play`, `ATX_Pause`, `ATX_Set_Frame_Time` events
- Fix "allow clientside mods from legacy directories" option not applying correctly for DDS files