### PR TITLE
Add UNK game type fallback, fix crashes

### DIFF
--- a/common/include/common/rfproto.h
+++ b/common/include/common/rfproto.h
@@ -174,6 +174,8 @@ enum RF_GameType
     RF_GT_ESC = 0x07,
     RF_GT_BM = 0x08,
     RF_GT_TBM = 0x09,
+    // Sentinel: must always be the last entry.
+    RF_GT_UNK
 };
 
 enum RF_ServerFlags

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,8 @@ Version 1.4.0 (Lupin): Not yet released
 - Fix `AF_Teleport_Player` event clientside smoothly interpolating the teleported entity position
 - Fix ability to configure invalid values for `individual_kill_limit` in ADS configs
 - Fix dedicated server crash when a non-player entity dies while `spawn_delay` is enabled
+- Fix future game types not being correctly handled by joining clients
+- Fix `Join Server` crash if `favlist.adr` entries have newer game types
 
 [@is-this-c](https://github.com/is-this-c)
 - Clear cached server config output after a shuffle of a server's rotation

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,7 @@ Version 1.4.0 (Lupin): Not yet released
 - Fix "allow clientside mods from legacy directories" option not applying correctly for DDS files
 - Fix `AF_Teleport_Player` event clientside smoothly interpolating the teleported entity position
 - Fix ability to configure invalid values for `individual_kill_limit` in ADS configs
+- Fix dedicated server crash when a non-player entity dies while `spawn_delay` is enabled
 
 [@is-this-c](https://github.com/is-this-c)
 - Clear cached server config output after a shuffle of a server's rotation

--- a/game_patch/multi/gametype.cpp
+++ b/game_patch/multi/gametype.cpp
@@ -18,7 +18,7 @@
 #include "../rf/gameseq.h"
 #include "../rf/localize.h"
 
-static char* const* g_af_gametype_names[10];
+static char* const* g_af_gametype_names[rf::NG_TYPE_UNK + 1];
 
 static char koth_name[] = "KOTH";
 static char* koth_slot = koth_name;
@@ -34,6 +34,8 @@ static char bm_name[] = "BM";
 static char* bm_slot = bm_name;
 static char tbm_name[] = "TBM";
 static char* tbm_slot = tbm_name;
+static char unk_name[] = "UNK";
+static char* unk_slot = unk_name;
 
 KothInfo g_koth_info; // KOTH and DC
 rf::Timestamp g_local_contest_alarm_cooldown;
@@ -72,6 +74,7 @@ void populate_gametype_table() {
     g_af_gametype_names[7] = &esc_slot;
     g_af_gametype_names[8] = &bm_slot;
     g_af_gametype_names[9] = &tbm_slot;
+    g_af_gametype_names[rf::NG_TYPE_UNK] = &unk_slot;
 
     for (int i = 0; i < 5; ++i) {
         const char* const* slot = g_af_gametype_names[i];
@@ -2085,9 +2088,11 @@ void gametype_do_patch()
     write_mem<uint32_t>((0x0044C227) + 3, (uint32_t)(uintptr_t)&g_af_gametype_names[0]); // multi_join_game_render_row
     write_mem<uint32_t>((0x0044C724) + 3, (uint32_t)(uintptr_t)&g_af_gametype_names[0]); // multi_join_game_init
 
-    // patch listen server create menu gametype select field to use new table
+    // patch listen server create menu gametype select field to use new table.
+    // End pointer stops at NG_TYPE_UNK so UNK doesn't appear as a host-selectable
+    // option in the dropdown — UNK is a display-only sentinel for the browser.
     const uintptr_t base = (uintptr_t)&g_af_gametype_names[0];
-    const uintptr_t end = base + sizeof(g_af_gametype_names);
+    const uintptr_t end = (uintptr_t)&g_af_gametype_names[rf::NG_TYPE_UNK];
     const uintptr_t kMovBase = 0x004459B1;
     const uintptr_t kCmpEnd = 0x004459CE;
     write_mem<uint32_t>(kMovBase + 1, (uint32_t)base);

--- a/game_patch/multi/gametype.cpp
+++ b/game_patch/multi/gametype.cpp
@@ -34,6 +34,7 @@ static char bm_name[] = "BM";
 static char* bm_slot = bm_name;
 static char tbm_name[] = "TBM";
 static char* tbm_slot = tbm_name;
+// UNK is the sentinel; new game types must be added above
 static char unk_name[] = "UNK";
 static char* unk_slot = unk_name;
 
@@ -82,6 +83,20 @@ void populate_gametype_table() {
         //xlog::warn("GameType[{}]: {} (slot={}, name_ptr={})", i, name, static_cast<const void*>(slot), static_cast<const void*>(*slot));
     }
 }
+
+FunHook<int(uint8_t*, int)> server_list_load_entry_game_type_guard{
+    0x0044B810,
+    [](uint8_t* record, int is_favorite) -> int {
+        if (record) {
+            constexpr int num_gametypes = sizeof(g_af_gametype_names) / sizeof(g_af_gametype_names[0]);
+            auto& game_type = *reinterpret_cast<int32_t*>(record + 0x58);
+            if (game_type < 0 || game_type >= num_gametypes) {
+                game_type = static_cast<int32_t>(rf::NG_TYPE_UNK);
+            }
+        }
+        return server_list_load_entry_game_type_guard.call_target(record, is_favorite);
+    },
+};
 
 CallHook<char*(const char*, const char*)> listen_server_map_list_filename_contains_hook{
     0x00445730,
@@ -2097,6 +2112,9 @@ void gametype_do_patch()
     const uintptr_t kCmpEnd = 0x004459CE;
     write_mem<uint32_t>(kMovBase + 1, (uint32_t)base);
     write_mem<uint32_t>(kCmpEnd + 2, (uint32_t)end);
+
+    // Defensive clamp against game_type OOB crash in stale server records (like from favlist.adr)
+    server_list_load_entry_game_type_guard.install();
 
     // team_score packet expansion to support new team gametypes
     send_team_score_server_do_frame_patch.install();

--- a/game_patch/multi/gametype.cpp
+++ b/game_patch/multi/gametype.cpp
@@ -65,17 +65,17 @@ static void stop_hill_sounds()
 }
 
 void populate_gametype_table() {
-    g_af_gametype_names[0] = &rf::strings::dm;
-    g_af_gametype_names[1] = &rf::strings::ctf;
-    g_af_gametype_names[2] = &rf::strings::teamdm;
-    g_af_gametype_names[3] = &koth_slot;
-    g_af_gametype_names[4] = &dc_slot;
-    g_af_gametype_names[5] = &rev_slot;
-    g_af_gametype_names[6] = &run_slot;
-    g_af_gametype_names[7] = &esc_slot;
-    g_af_gametype_names[8] = &bm_slot;
-    g_af_gametype_names[9] = &tbm_slot;
-    g_af_gametype_names[rf::NG_TYPE_UNK] = &unk_slot;
+    g_af_gametype_names[rf::NG_TYPE_DM]     = &rf::strings::dm;
+    g_af_gametype_names[rf::NG_TYPE_CTF]    = &rf::strings::ctf;
+    g_af_gametype_names[rf::NG_TYPE_TEAMDM] = &rf::strings::teamdm;
+    g_af_gametype_names[rf::NG_TYPE_KOTH]   = &koth_slot;
+    g_af_gametype_names[rf::NG_TYPE_DC]     = &dc_slot;
+    g_af_gametype_names[rf::NG_TYPE_REV]    = &rev_slot;
+    g_af_gametype_names[rf::NG_TYPE_RUN]    = &run_slot;
+    g_af_gametype_names[rf::NG_TYPE_ESC]    = &esc_slot;
+    g_af_gametype_names[rf::NG_TYPE_BM]     = &bm_slot;
+    g_af_gametype_names[rf::NG_TYPE_TBM]    = &tbm_slot;
+    g_af_gametype_names[rf::NG_TYPE_UNK]    = &unk_slot;
 
     for (int i = 0; i < 5; ++i) {
         const char* const* slot = g_af_gametype_names[i];

--- a/game_patch/multi/multi.cpp
+++ b/game_patch/multi/multi.cpp
@@ -795,6 +795,8 @@ std::string_view multi_game_type_name(const rf::NetGameType game_type) {
         return std::string_view{"Bagman"};
     } else if (game_type == rf::NG_TYPE_TBM) {
         return std::string_view{"Team Bagman"};
+    } else if (game_type == rf::NG_TYPE_UNK) {
+        return std::string_view{"Unknown"};
     } else {
         if (game_type != rf::NG_TYPE_TEAMDM) {
             xlog::warn("{} is an invalid `NetGameType`", static_cast<int>(game_type));
@@ -822,6 +824,8 @@ std::string_view multi_game_type_name_upper(const rf::NetGameType game_type) {
         return std::string_view{"BAGMAN"};
     } else if (game_type == rf::NG_TYPE_TBM) {
         return std::string_view{"TEAM BAGMAN"};
+    } else if (game_type == rf::NG_TYPE_UNK) {
+        return std::string_view{"UNKNOWN"};
     } else {
         if (game_type != rf::NG_TYPE_TEAMDM) {
             xlog::warn("{} is an invalid `NetGameType`", static_cast<int>(game_type));
@@ -849,6 +853,8 @@ std::string_view multi_game_type_name_short(const rf::NetGameType game_type) {
         return std::string_view{"BM"};
     } else if (game_type == rf::NG_TYPE_TBM) {
         return std::string_view{"TBM"};
+    } else if (game_type == rf::NG_TYPE_UNK) {
+        return std::string_view{"UNK"};
     } else {
         if (game_type != rf::NG_TYPE_TEAMDM) {
             xlog::warn("{} is an invalid `NetGameType`", static_cast<int>(game_type));
@@ -875,9 +881,12 @@ std::string_view multi_game_type_prefix(const rf::NetGameType game_type) {
     } else if (game_type == rf::NG_TYPE_ESC) {
         return std::string_view{"esc"};
     } else if (game_type == rf::NG_TYPE_BM) {
-        return std::string_view{"bagman"};
+        return std::string_view{"bm"};
     } else if (game_type == rf::NG_TYPE_TBM) {
         return std::string_view{"tbm"};
+    } else if (game_type == rf::NG_TYPE_UNK) {
+        // No real level-name prefix for unknown game types; "dm" is the safest fallback.
+        return std::string_view{"dm"};
     } else {
         if (game_type != rf::NG_TYPE_TEAMDM) {
             xlog::warn("{} is an invalid `NetGameType`", static_cast<int>(game_type));

--- a/game_patch/multi/network.cpp
+++ b/game_patch/multi/network.cpp
@@ -598,7 +598,8 @@ FunHook<MultiIoPacketHandler> process_game_info_packet_hook{
         char name[256]{};
         if (!read_string(name, sizeof(name))) { clear_extra(); return; }
         if (end - r < 3) { clear_extra(); return; }
-        uint8_t game_type = std::clamp<uint8_t>(*r++, 0, RF_GT_TBM);
+        // Values from newer-protocol servers show as UNK
+        uint8_t game_type = std::min<uint8_t>(*r++, RF_GT_UNK);
         uint8_t players = *r++;
         uint8_t max_players = *r++;
 

--- a/game_patch/multi/network.cpp
+++ b/game_patch/multi/network.cpp
@@ -46,6 +46,7 @@
 #include "../rf/os/timer.h"
 #include "../rf/geometry.h"
 #include "../rf/level.h"
+#include "../rf/ui.h"
 #include "../misc/misc.h"
 #include "../misc/player.h"
 #include "../misc/alpine_settings.h"
@@ -62,6 +63,25 @@
 #endif
 
 static constexpr int CLIENT_NET_FPS = 30;
+
+// Popup shown when the user attempts to join a server whose game type this build doesn't recognize.
+static void show_unsupported_game_type_popup()
+{
+    rf::ui::popup_message(
+        "Update Required",
+        "This server is running a game type that your version of Alpine\n"
+        "Faction doesn't support. Visit alpinefaction.com to update.",
+        nullptr,
+        false);
+}
+
+// Lightweight cancel sequence for an in-progress join.
+// Stock cancel path (0x0044B9A0) does this, but also kicks off a server list refresh.
+static void cancel_pending_join()
+{
+    rf::multi_clear_current_server_addr();
+    rf::multi_join_in_progress = false;
+}
 
 ClientSoftware g_joining_client_version = ClientSoftware::Unknown;
 AlpineFactionJoinReqPacketExt g_joining_player_info{};
@@ -599,7 +619,9 @@ FunHook<MultiIoPacketHandler> process_game_info_packet_hook{
         if (!read_string(name, sizeof(name))) { clear_extra(); return; }
         if (end - r < 3) { clear_extra(); return; }
         // Values from newer-protocol servers show as UNK
-        uint8_t game_type = std::min<uint8_t>(*r++, RF_GT_UNK);
+        const uint8_t raw_game_type = *r++;
+        const bool unknown_game_type = raw_game_type >= RF_GT_UNK;
+        const uint8_t game_type = std::min<uint8_t>(raw_game_type, RF_GT_UNK);
         uint8_t players = *r++;
         uint8_t max_players = *r++;
 
@@ -646,6 +668,7 @@ FunHook<MultiIoPacketHandler> process_game_info_packet_hook{
                     extra.num_human_players = *ext_r++;
                     extra.num_browsers = *ext_r++;
                     extra.num_total_clients = *ext_r++;
+                    extra.unknown_game_type = unknown_game_type;
                     g_server_browser_extra[key] = std::move(extra);
                     parsed = true;
                 }
@@ -677,13 +700,27 @@ FunHook<MultiIoPacketHandler> process_game_info_packet_hook{
                 if (ext_r < footer_start)
                     extra.level_filename.assign(
                         reinterpret_cast<const char*>(fname_start), ext_r - fname_start);
+                extra.unknown_game_type = unknown_game_type;
                 g_server_browser_extra[key] = std::move(extra);
                 parsed = true;
             }
         }
 
-        if (!parsed)
-            clear_extra();
+        if (!parsed) {
+            if (unknown_game_type) {
+                // No AF extension on the wire, but the server is reporting a
+                // game type this build doesn't recognize. Keep a minimal entry
+                // around so the join gate can block users from joining it.
+                // This should never be possible under normal circumstances,
+                // but the guard is very cheap and safer.
+                AFGameInfoExtra extra{};
+                extra.unknown_game_type = true;
+                g_server_browser_extra[key] = std::move(extra);
+            }
+            else {
+                clear_extra();
+            }
+        }
 
         // Update netgame name if this is from the connected server
         if (addr == rf::netgame.server_addr) {
@@ -1475,6 +1512,17 @@ enum JoinReqTlv : uint8_t {
 CallHook<int(const rf::NetAddr*, std::byte*, size_t)> send_join_req_packet_hook{
     0x0047ABFB,
     [] (const rf::NetAddr* const addr, std::byte* const data, const size_t len) {
+        // If this server's browser entry says its game type is one we don't
+        // recognize, block the join here before any packet goes out.
+        if (addr) {
+            const AFGameInfoExtra* extra = get_server_browser_extra(*addr);
+            if (extra && extra->unknown_game_type) {
+                cancel_pending_join();
+                show_unsupported_game_type_popup();
+                return 0;
+            }
+        }
+
         const bool session_client_bot_mode = client_bot_launch_enabled();
 
         // Add Alpine Faction info to join_req packet
@@ -1673,6 +1721,49 @@ static bool parse_join_accept_af_ext(const uint8_t* payload, size_t payload_len,
     std::memcpy(&out, p, copy_len);
     return out.af_signature == ALPINE_FACTION_SIGNATURE;
 }
+
+// Gate process_join_accept_packet so the engine never assigns an unknown
+// game type to rf::netgame.type. Covers cases the browser-side gate can't.
+// Examples: direct connect and stale browser entries.
+FunHook<MultiIoPacketHandler> process_join_accept_unsupported_gt_guard{
+    0x0047A840,
+    [](char* data, const rf::NetAddr& addr) {
+        if (data) {
+            uint16_t payload_len = 0;
+            std::memcpy(&payload_len, data - 2, sizeof(payload_len));
+
+            const uint8_t* payload = reinterpret_cast<const uint8_t*>(data);
+            const uint8_t* end = payload + payload_len;
+            const uint8_t* p = payload;
+
+            // Skip null-terminated level filename
+            while (p < end && *p != 0) ++p;
+            if (p < end) {
+                ++p; // skip null terminator
+                if (static_cast<size_t>(end - p) >= sizeof(RF_JoinAcceptRest)) {
+                    RF_JoinAcceptRest rest;
+                    std::memcpy(&rest, p, sizeof(rest));
+                    if (rest.game_type >= RF_GT_UNK) {
+                        // Cache the result. The server browser only sends
+                        // game_info_req to tracker-discovered servers, so a
+                        // server reached via -url / direct-connect won't have
+                        // an entry.
+                        AFGameInfoExtra cached{};
+                        cached.unknown_game_type = true;
+                        g_server_browser_extra[addr_key(addr)] = std::move(cached);
+
+                        cancel_pending_join();
+                        rf::multi_stop();
+                        show_unsupported_game_type_popup();
+                        rf::gameseq_set_state(rf::GS_MAIN_MENU, false);
+                        return;
+                    }
+                }
+            }
+        }
+        process_join_accept_unsupported_gt_guard.call_target(data, addr);
+    },
+};
 
 CodeInjection process_join_accept_injection{
     0x0047A979,
@@ -2904,6 +2995,7 @@ void network_init()
     process_join_req_packet_hook.install();
     process_join_req_injection.install();
     send_join_accept_packet_hook.install();
+    process_join_accept_unsupported_gt_guard.install();
     process_join_accept_injection.install();
     process_join_accept_send_game_info_req_injection.install();
     multi_stop_hook.install();

--- a/game_patch/multi/network.cpp
+++ b/game_patch/multi/network.cpp
@@ -709,13 +709,10 @@ FunHook<MultiIoPacketHandler> process_game_info_packet_hook{
         if (!parsed) {
             if (unknown_game_type) {
                 // No AF extension on the wire, but the server is reporting a
-                // game type this build doesn't recognize. Keep a minimal entry
-                // around so the join gate can block users from joining it.
+                // game type this build doesn't recognize.
                 // This should never be possible under normal circumstances,
                 // but the guard is very cheap and safer.
-                AFGameInfoExtra extra{};
-                extra.unknown_game_type = true;
-                g_server_browser_extra[key] = std::move(extra);
+                g_server_browser_extra[key].unknown_game_type = true;
             }
             else {
                 clear_extra();

--- a/game_patch/multi/network.h
+++ b/game_patch/multi/network.h
@@ -264,6 +264,8 @@ struct AFGameInfoExtra
     uint8_t num_human_players = 0;
     uint8_t num_browsers = 0;
     uint8_t num_total_clients = 0;
+    // Server's reported game_type was >= RF_GT_UNK, used to block joins.
+    bool unknown_game_type = false;
 };
 
 // Look up AF extra data for a server by address. Returns nullptr if not found.

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -3299,49 +3299,47 @@ void entity_drop_powerup(rf::Entity* ep, int powerup_type, int count)
 CodeInjection entity_maybe_die_patch{
     0x00420600,
     [](auto& regs) {
-        if (rf::is_multi && (rf::is_server || rf::is_dedicated_server)) {
-            rf::Entity* ep = regs.esi;
+        if (!(rf::is_multi && (rf::is_server || rf::is_dedicated_server))) return;
 
-            if (ep) {
-                rf::Player* player = rf::player_from_entity_handle(ep->handle);
+        rf::Entity* ep = regs.esi;
+        if (!ep) return;
 
-                if (g_alpine_server_config_active_rules.spawn_delay.enabled) {
-                    rf::Player* player = rf::player_from_entity_handle(ep->handle);
-                    player->respawn_timer.set(g_alpine_server_config_active_rules.spawn_delay.base_value);
-                    bool respawn_allowed = true; // nothing currently disables respawns
-                    bool force_respawn = (rf::multi_server_flags & rf::NetGameFlags::NG_FLAG_FORCE_RESPAWN) != 0;
+        rf::Player* player = rf::player_from_entity_handle(ep->handle);
 
-                    if (rf::is_server) {
-                        set_local_spawn_delay(respawn_allowed, force_respawn, static_cast<uint16_t>(player->respawn_timer.time_until()));
-                    }
-                    af_send_just_died_info_packet(player, respawn_allowed, force_respawn, static_cast<uint16_t>(player->respawn_timer.time_until()));
+        if (player && g_alpine_server_config_active_rules.spawn_delay.enabled) {
+            player->respawn_timer.set(g_alpine_server_config_active_rules.spawn_delay.base_value);
+            bool respawn_allowed = true; // nothing currently disables respawns
+            bool force_respawn = (rf::multi_server_flags & rf::NetGameFlags::NG_FLAG_FORCE_RESPAWN) != 0;
+
+            if (rf::is_server) {
+                set_local_spawn_delay(respawn_allowed, force_respawn, static_cast<uint16_t>(player->respawn_timer.time_until()));
+            }
+            af_send_just_died_info_packet(player, respawn_allowed, force_respawn, static_cast<uint16_t>(player->respawn_timer.time_until()));
+        }
+
+        if (player && g_alpine_server_config_active_rules.drop_amps && !gt_is_bagman_any()) {
+            if (rf::multi_powerup_has_player(player, 1)) {
+                int amp_count = 0;
+                int time_left = rf::multi_powerup_get_time_until(player, 1);
+                amp_count = time_left >= 1000 ? time_left : 0;
+
+                if (amp_count >= 1000) { // only drop if at least 1 second left
+                    entity_drop_powerup(ep, 1, amp_count / 1000); // item_touch_multi_amp multiplies by 1000
                 }
+            }
 
-                if (g_alpine_server_config_active_rules.drop_amps && !gt_is_bagman_any()) {
-                    if (rf::multi_powerup_has_player(player, 1)) {
-                        int amp_count = 0;
-                        int time_left = rf::multi_powerup_get_time_until(player, 1);
-                        amp_count = time_left >= 1000 ? time_left : 0;
+            if (rf::multi_powerup_has_player(player, 0)) {
+                int invuln_count = 0;
+                int time_left = rf::multi_powerup_get_time_until(player, 0);
+                invuln_count = time_left >= 1000 ? time_left : 0;
 
-                        if (amp_count >= 1000) { // only drop if at least 1 second left
-                            entity_drop_powerup(ep, 1, amp_count / 1000); // item_touch_multi_amp multiplies by 1000
-                        }
-                    }
-
-                    if (rf::multi_powerup_has_player(player, 0)) {
-                        int invuln_count = 0;
-                        int time_left = rf::multi_powerup_get_time_until(player, 0);
-                        invuln_count = time_left >= 1000 ? time_left : 0;
-
-                        if (invuln_count >= 1000) { // only drop if at least 1 second left
-                            entity_drop_powerup(ep, 0, invuln_count / 1000); // item_touch_multi_amp multiplies by 1000
-                        }
-                    }
+                if (invuln_count >= 1000) { // only drop if at least 1 second left
+                    entity_drop_powerup(ep, 0, invuln_count / 1000); // item_touch_multi_amp multiplies by 1000
                 }
-
-                bagman_on_entity_will_die(ep);
             }
         }
+
+        bagman_on_entity_will_die(ep);
     },
 };
 

--- a/game_patch/rf/multi.h
+++ b/game_patch/rf/multi.h
@@ -143,7 +143,7 @@ namespace rf
         NG_TYPE_ESC = 7,    // Escalation, as of AF v1.2
         NG_TYPE_BM = 8,     // Bagman, as of AF v1.4
         NG_TYPE_TBM = 9,    // Team Bagman, as of AF v1.4
-        // Sentinel: must always be the last entry.
+        // Sentinel: UNK must always be the last entry.
         NG_TYPE_UNK
     };
 
@@ -298,6 +298,8 @@ namespace rf
     static auto& multi_chat_say = addr_as_ref<void(const char *msg, bool is_team_msg)>(0x00444150);
     static auto& multi_chat_add_msg = addr_as_ref<void(Player* pp, const char* msg, bool is_team_msg)>(0x00443FB0);
     static auto& multi_is_connecting_to_server = addr_as_ref<uint8_t(const NetAddr& addr)>(0x0044AD80);
+    static auto& multi_clear_current_server_addr = addr_as_ref<void()>(0x0044AD60);
+    static auto& multi_join_in_progress = addr_as_ref<bool>(0x0063E93C);
     using MultiIoProcessPackets_Type = void(const void* data, size_t len, const NetAddr& addr, Player* player);
     static auto& multi_io_process_packets = addr_as_ref<MultiIoProcessPackets_Type>(0x004790D0);
     static auto& multi_kill_local_player = addr_as_ref<void()>(0x004757A0);

--- a/game_patch/rf/multi.h
+++ b/game_patch/rf/multi.h
@@ -143,6 +143,8 @@ namespace rf
         NG_TYPE_ESC = 7,    // Escalation, as of AF v1.2
         NG_TYPE_BM = 8,     // Bagman, as of AF v1.4
         NG_TYPE_TBM = 9,    // Team Bagman, as of AF v1.4
+        // Sentinel: must always be the last entry.
+        NG_TYPE_UNK
     };
 
     enum NetGameFlags


### PR DESCRIPTION
- Fix dedicated server crash when a non-player entity dies while `spawn_delay` is enabled
- Fix future game types not being correctly handled by joining clients
- Fix `Join Server` crash if `favlist.adr` entries have newer game types