### PR TITLE
Add reliable drop network debug logging to help nail down long-standing evasive netcode problems

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -52,6 +52,7 @@ Version 1.4.0 (Lupin): Not yet released
 - Add the ability to drop reusable static cameras in free look spectate, then cycle level-placed and player-dropped cameras in static camera view
 - Add numpad quick-binds to jump directly to bound players or cameras while spectating, with dropped cameras and binds persisted per level
 - Add `spectate_cameras` console command to toggle showing camera meshes at static camera locations while free look spectating
+- Add `-debug` command line switch to enable additional debug logging, intended to help identify long-standing netcode issues that are difficult to nail down.
 
 [@is-this-c](https://github.com/is-this-c)
 - Add `Anti-aliasing` option to `ADVANCED` options panel

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -91,6 +91,7 @@ Version 1.4.0 (Lupin): Not yet released
 - Fix camera angle snapping when switching between free look and third person camera modes
 - Fix a server crash that could be triggered by a zero-length UDP packet in the packet receive pump
 - Fix overlapping decals rendering with the oldest on top instead of the newest
+- Fix crash on MinGW builds when launching a dedicated server
 
 [@is-this-c](https://github.com/is-this-c)
 - Clear cached server config output after a shuffle of a server's rotation

--- a/game_patch/CMakeLists.txt
+++ b/game_patch/CMakeLists.txt
@@ -157,6 +157,7 @@ set(SRCS
     multi/kill.cpp
     multi/network.cpp
     multi/network.h
+    multi/network_debug.cpp
     multi/saved_info.cpp
     multi/saved_info.h
     multi/level_download.cpp

--- a/game_patch/misc/alpine_options.cpp
+++ b/game_patch/misc/alpine_options.cpp
@@ -588,7 +588,7 @@ FunHook<void(int, int)> extras_summoner_trailer_click_hook{
                 break;
             case 4: { // Load level
                 auto level_filename = get_option_value<std::string>(AlpineOptionID::SumTrailerButtonLevelFile);
-                rf::level_set_level_to_load(level_filename.c_str(), "");
+                rf::level_set_level_to_load(rf::String{level_filename.c_str()}, rf::String{""});
                 rf::game_new_game();
                 break;
             }

--- a/game_patch/multi/network.cpp
+++ b/game_patch/multi/network.cpp
@@ -3087,6 +3087,9 @@ void network_init()
     // Fix room_index out of bounds vulnerability in pregame_boolean packet
     process_pregame_boolean_packet_validate_room_uid_patch.install();
 
+    // Reliable socket drop diagnostics (when launched with -debug).
+    network_debug_apply_patches();
+
     // Fix crash if room does not exist in glass_kill packet
     process_glass_kill_packet_check_room_exists_patch.install();
 

--- a/game_patch/multi/network.h
+++ b/game_patch/multi/network.h
@@ -278,5 +278,6 @@ void handle_vote_or_ready_up_msg(std::string_view msg);
 void handle_sound_msg(std::string_view name);
 void send_queues_rel_clear_packets(int socket_id);
 void send_queues_rel_add_packet(int socket_id, const uint8_t* data, size_t len);
+void network_debug_apply_patches();
 void clear_rcon_profile_sessions();
 void multi_disconnect_from_server();

--- a/game_patch/multi/network_debug.cpp
+++ b/game_patch/multi/network_debug.cpp
@@ -7,7 +7,6 @@
 #include "../rf/multi.h"
 #include "../rf/player/player.h"
 #include "../rf/os/console.h"
-#include "../rf/os/timer.h"
 #include "../os/os.h"
 
 // -----------------------------------------------------------------------------
@@ -57,12 +56,16 @@ static const char* reliable_socket_status_name(int status)
 }
 
 // Throttle: at most one log per socket per second (each site passes its own array).
-static bool reliable_drop_should_log(int socket_id, int* last_warn_ms)
+// Uses AF's 64-bit monotonic timer (timer::get_i64) rather than the engine's 32-bit
+// timer::get: the 32-bit value deliberately truncates get_i64 and rolls over ~every
+// 24.8 days of uptime, whereas the 64-bit ms count effectively never wraps, so the
+// elapsed subtraction below is always correct without any wrap-handling.
+static bool reliable_drop_should_log(int socket_id, int64_t* last_warn_ms)
 {
     if (socket_id < 0 || socket_id >= rf::NET_MAX_REL_SOCKETS) {
         return true;
     }
-    int now = rf::timer::get(1000);
+    int64_t now = timer::get_i64(1000);
     if (last_warn_ms[socket_id] == 0 || now - last_warn_ms[socket_id] >= 1000) {
         last_warn_ms[socket_id] = now;
         return true;
@@ -109,7 +112,7 @@ static const char* reliable_packet_type_name(int type)
 static CodeInjection net_rel_send_window_saturated_injection{
     0x0052A3A7,
     [](auto& regs) {
-        static int last_warn_ms[rf::NET_MAX_REL_SOCKETS] = {};
+        static int64_t last_warn_ms[rf::NET_MAX_REL_SOCKETS] = {};
         rf::NetReliableSocket* sock = regs.ebx;
         int id = static_cast<int>(sock - rf::net_rel_sockets);
         if (!reliable_drop_should_log(id, last_warn_ms)) {
@@ -133,8 +136,8 @@ static CodeInjection net_rel_send_window_saturated_injection{
 static CodeInjection net_rel_send_not_connected_injection{
     0x0052A373,
     [](auto& regs) {
-        static int last_debug_ms[rf::NET_MAX_REL_SOCKETS] = {};
-        static int last_warn_ms[rf::NET_MAX_REL_SOCKETS] = {};
+        static int64_t last_debug_ms[rf::NET_MAX_REL_SOCKETS] = {};
+        static int64_t last_warn_ms[rf::NET_MAX_REL_SOCKETS] = {};
         int id = static_cast<int>(regs.eax);
         int status = static_cast<int>(regs.ecx);
         bool expected = (status == 5 /*CONNECTING*/ || status == 0 /*EMPTY*/);
@@ -163,7 +166,7 @@ static CodeInjection net_rel_send_not_connected_injection{
 static CodeInjection net_rel_send_window_high_water_injection{
     0x0052A3BC,
     [](auto& regs) {
-        static int last_warn_ms[rf::NET_MAX_REL_SOCKETS] = {};
+        static int64_t last_warn_ms[rf::NET_MAX_REL_SOCKETS] = {};
         constexpr int high_water = 60; // of 75 in-flight
         rf::NetReliableSocket* sock = regs.ebx;
         int in_flight = 1; // counting the packet about to be queued

--- a/game_patch/multi/network_debug.cpp
+++ b/game_patch/multi/network_debug.cpp
@@ -1,0 +1,210 @@
+#include <cstdint>
+#include <patch_common/CodeInjection.h>
+#include <xlog/xlog.h>
+#include <common/rfproto.h>
+#include <common/utils/list-utils.h>
+#include "network.h"
+#include "../rf/multi.h"
+#include "../rf/player/player.h"
+#include "../rf/os/console.h"
+#include "../rf/os/timer.h"
+#include "../os/os.h"
+
+// -----------------------------------------------------------------------------
+// Reliable-socket drop instrumentation, experimental debug only.
+// This logging is intended to be used to better diagnose and eventually fix
+// long-standing netcode issues, such as occasionally items not being picked up.
+//
+// RF's reliable-UDP layer (nw_rel_send @ 0x0052A310) has two failure paths that
+// drop a "reliable" packet with no visible log:
+//   1. All 75 in-flight send slots are occupied (window saturated) -> the socket
+//      is forced to TIMED_OUT (status 2) and the packet is dropped. Stock code
+//      logs nothing here at all. The socket is later reaped by the connection
+//      health check, disconnecting that client.
+//   2. A send is attempted while the socket is not CONNECTED (e.g. CONNECTING /
+//      limbo). The packet is dropped, never queued, never retransmitted, and no
+//      disconnect follows - a genuinely silent reliable-packet loss (the stock
+//      "Can't send packet because of state" string is formatted into a throwaway
+//      buffer and discarded).
+// Both manifest as unexplained desyncs (e.g. a missed item pickup) rather than an
+// obvious error, so surface them here. Warnings are throttled to at most one per
+// socket per second per site to avoid flooding the log during a burst.
+//
+// These hooks are installed only when the process is launched with `-debug`
+// -----------------------------------------------------------------------------
+
+static rf::Player* find_player_by_reliable_socket(unsigned socket_id)
+{
+    for (rf::Player& player : SinglyLinkedList{rf::player_list}) {
+        if (player.net_data && player.net_data->reliable_socket == socket_id) {
+            return &player;
+        }
+    }
+    return nullptr;
+}
+
+static const char* reliable_socket_status_name(int status)
+{
+    switch (status) {
+    case 0: return "EMPTY";
+    case 1: return "CONNECTED";
+    case 2: return "TIMED_OUT";
+    case 3: return "UNK_3";
+    case 4: return "CONNECTED_REMOTE";
+    case 5: return "CONNECTING";
+    default: return "?";
+    }
+}
+
+// Throttle: at most one log per socket per second (each site passes its own array).
+static bool reliable_drop_should_log(int socket_id, int* last_warn_ms)
+{
+    if (socket_id < 0 || socket_id >= rf::NET_MAX_REL_SOCKETS) {
+        return true;
+    }
+    int now = rf::timer::get(1000);
+    if (last_warn_ms[socket_id] == 0 || now - last_warn_ms[socket_id] >= 1000) {
+        last_warn_ms[socket_id] = now;
+        return true;
+    }
+    return false;
+}
+
+// In nw_rel_send the outgoing packet pointer is param_2, which the stock prologue
+// reads from [esp+0x374] (param_1 from [esp+0x370]); esp is unchanged at all three
+// injection sites below. The first payload byte is the RF packet type. Returns -1 if
+// the pointer is null (should not happen for a real send, but guard regardless).
+static int reliable_send_packet_type(uintptr_t esp)
+{
+    const uint8_t* const* data_slot = reinterpret_cast<const uint8_t* const*>(esp + 0x374);
+    const uint8_t* data = *data_slot;
+    return data ? static_cast<int>(data[0]) : -1;
+}
+
+// Names for the reliable server->client packets most likely to show up in a drop.
+// Unlisted types fall back to the raw hex code in the log message.
+static const char* reliable_packet_type_name(int type)
+{
+    switch (type) {
+    case RF_GPT_TRIGGER_ACTIVATE:      return "trigger_activate";
+    case RF_GPT_STATE_INFO_DONE:       return "state_info_done";
+    case RF_GPT_PREGAME_BOOLEAN:       return "pregame_boolean";
+    case RF_GPT_PREGAME_GLASS:         return "pregame_glass";
+    case RF_GPT_PREGAME_REMOTE_CHARGE: return "pregame_remote_charge";
+    case 0x27:                         return "obj_kill"; // no rfproto constant
+    case RF_GPT_ITEM_APPLY:            return "item_apply";
+    case RF_GPT_BOOLEAN:               return "boolean";
+    case RF_GPT_RESPAWN:               return "respawn";
+    case RF_GPT_ENTITY_CREATE:         return "entity_create";
+    case RF_GPT_ITEM_CREATE:           return "item_create";
+    case RF_GPT_RELOAD:                return "reload";
+    case RF_GPT_SOUND:                 return "sound";
+    case RF_GPT_GLASS_KILL:            return "glass_kill";
+    default:                           return "?";
+    }
+}
+
+// nw_rel_send: no free send slot -> window saturated, status about to be set to
+// TIMED_OUT. EBX = &net_rel_sockets[id]; fires just before `mov [ebx+0x67a], 2`.
+static CodeInjection net_rel_send_window_saturated_injection{
+    0x0052A3A7,
+    [](auto& regs) {
+        static int last_warn_ms[rf::NET_MAX_REL_SOCKETS] = {};
+        rf::NetReliableSocket* sock = regs.ebx;
+        int id = static_cast<int>(sock - rf::net_rel_sockets);
+        if (!reliable_drop_should_log(id, last_warn_ms)) {
+            return;
+        }
+        rf::Player* pp = find_player_by_reliable_socket(static_cast<unsigned>(id));
+        const char* who = pp ? pp->name.c_str() : "no player";
+        int pkt = reliable_send_packet_type(static_cast<uintptr_t>(regs.esp));
+        xlog::warn("Reliable socket {} ({}) send window SATURATED (75 unACK'd) - DROPPED {} packet "
+                   "(0x{:02X}); socket will be reaped and the client disconnected (AF reserves 32 "
+                   "slots, so this means stock reliable traffic overwhelmed the window)",
+                   id, who, reliable_packet_type_name(pkt), pkt);
+    },
+};
+
+// nw_rel_send: send attempted while socket status != CONNECTED. Packet is dropped
+// with no retransmit and no disconnect. EAX = socket id, ECX = current status.
+// CONNECTING/EMPTY are expected during joins and level transitions (kept at debug);
+// TIMED_OUT/UNK_3 at send time is a genuine silent loss on a live socket (warn).
+// Separate throttles so an expected debug event never suppresses a real warn.
+static CodeInjection net_rel_send_not_connected_injection{
+    0x0052A373,
+    [](auto& regs) {
+        static int last_debug_ms[rf::NET_MAX_REL_SOCKETS] = {};
+        static int last_warn_ms[rf::NET_MAX_REL_SOCKETS] = {};
+        int id = static_cast<int>(regs.eax);
+        int status = static_cast<int>(regs.ecx);
+        bool expected = (status == 5 /*CONNECTING*/ || status == 0 /*EMPTY*/);
+        if (!reliable_drop_should_log(id, expected ? last_debug_ms : last_warn_ms)) {
+            return;
+        }
+        rf::Player* pp = find_player_by_reliable_socket(static_cast<unsigned>(id));
+        const char* who = pp ? pp->name.c_str() : "no player";
+        int pkt = reliable_send_packet_type(static_cast<uintptr_t>(regs.esp));
+        if (expected) {
+            xlog::debug("Reliable send skipped: socket {} ({}) {} packet (0x{:02X}) status {} ({}) - not yet connected",
+                        id, who, reliable_packet_type_name(pkt), pkt, status, reliable_socket_status_name(status));
+        }
+        else {
+            xlog::warn("Reliable send DROPPED (no retransmit): socket {} ({}) {} packet (0x{:02X}) status {} ({}) - not CONNECTED",
+                       id, who, reliable_packet_type_name(pkt), pkt, status, reliable_socket_status_name(status));
+        }
+    },
+};
+
+// nw_rel_send: a free send slot was found and a packet is about to be queued.
+// Count how many of the 75 slots are already occupied (unACK'd) and warn when the
+// window is filling, so a socket trending toward a saturation-disconnect is visible
+// BEFORE it actually dies. EBX = &net_rel_sockets[id]; the slot for this send is
+// still null here, so in-flight after this send is (occupied + 1).
+static CodeInjection net_rel_send_window_high_water_injection{
+    0x0052A3BC,
+    [](auto& regs) {
+        static int last_warn_ms[rf::NET_MAX_REL_SOCKETS] = {};
+        constexpr int high_water = 60; // of 75 in-flight
+        rf::NetReliableSocket* sock = regs.ebx;
+        int in_flight = 1; // counting the packet about to be queued
+        for (void* slot : sock->sbuffers) {
+            if (slot) {
+                ++in_flight;
+            }
+        }
+        if (in_flight < high_water) {
+            return;
+        }
+        int id = static_cast<int>(sock - rf::net_rel_sockets);
+        if (!reliable_drop_should_log(id, last_warn_ms)) {
+            return;
+        }
+        rf::Player* pp = find_player_by_reliable_socket(static_cast<unsigned>(id));
+        const char* who = pp ? pp->name.c_str() : "no player";
+        int pkt = reliable_send_packet_type(static_cast<uintptr_t>(regs.esp));
+        xlog::warn("Reliable socket {} ({}) send window filling: {}/75 in-flight (unACK'd) - queuing {} "
+                   "packet (0x{:02X}), approaching saturation",
+                   id, who, in_flight, reliable_packet_type_name(pkt), pkt);
+    },
+};
+
+// in game_boot_do_frame / rf_init
+CodeInjection net_debug_startup_notice_injection{
+    0x004B253D,
+    [](auto&) {
+        rf::console::print("-- Network debug logging ENABLED (-debug) --");
+        xlog::info("Network debug logging ENABLED via -debug switch");
+    },
+};
+
+void network_debug_apply_patches()
+{
+    // Only install debug hooks when launched with -debug.
+    if (!raw_command_line_has_switch(L"-debug")) {
+        return;
+    }
+    net_rel_send_window_saturated_injection.install();
+    net_rel_send_not_connected_injection.install();
+    net_rel_send_window_high_water_injection.install();
+    net_debug_startup_notice_injection.install();
+}

--- a/game_patch/rf/level.h
+++ b/game_patch/rf/level.h
@@ -147,7 +147,11 @@ namespace rf
     static auto& level_point_in_climb_region = addr_as_ref<ClimbRegion*(Vector3* pos)>(0x0045CCA0);
     static auto& geo_region_test_point = addr_as_ref<bool(const Vector3& pos, GeoRegion* region)>(0x0045d520);
 
-    static auto& level_set_level_to_load = addr_as_ref<void(String filename, String state_filename)>(0x0045E2E0);
+    // The callee takes both Strings by value and String-destroys them (frees their buffers). Use String::Pod
+    // (trivial 8-byte {int max_len; char* buf}, ABI-identical under MSVC and GCC) so ownership transfers correctly.
+    // Passing rf::String by value here breaks on MinGW: GCC passes non-trivial classes by hidden reference while
+    // MSVC passes the 8 bytes inline, so the engine would read garbage and free a garbage pointer.
+    static auto& level_set_level_to_load = addr_as_ref<void(String::Pod filename, String::Pod state_filename)>(0x0045E2E0);
     static auto& game_new_game = addr_as_ref<void()>(0x00436950);
 
 }

--- a/game_patch/rf/multi.h
+++ b/game_patch/rf/multi.h
@@ -241,8 +241,8 @@ namespace rf
         int last_packet_received;
         int last_packet_sent;
         NetReliableSocketStatus status;
-        uint16_t oursequence;
-        uint16_t theirsequence;
+        uint16_t theirsequence; // 0x67e: tracks the remote's sequence (window-checked on receive)
+        uint16_t oursequence;   // 0x680: our outgoing counter, stamped into ssequence and bumped per send
         rf::NetAddr net_addr;
         int pings[10];
         uint8_t ping_pos;

--- a/game_patch/rf/multi.h
+++ b/game_patch/rf/multi.h
@@ -241,8 +241,8 @@ namespace rf
         int last_packet_received;
         int last_packet_sent;
         NetReliableSocketStatus status;
-        uint16_t theirsequence; // 0x67e: tracks the remote's sequence (window-checked on receive)
-        uint16_t oursequence;   // 0x680: our outgoing counter, stamped into ssequence and bumped per send
+        uint16_t theirsequence;
+        uint16_t oursequence;
         rf::NetAddr net_addr;
         int pings[10];
         uint8_t ping_pos;

--- a/game_patch/rf/multi.h
+++ b/game_patch/rf/multi.h
@@ -241,8 +241,8 @@ namespace rf
         int last_packet_received;
         int last_packet_sent;
         NetReliableSocketStatus status;
-        uint16_t theirsequence;
-        uint16_t oursequence;
+        uint16_t theirsequence; // 0x67e: tracks the remote's sequence (window-checked on receive)
+        uint16_t oursequence;   // 0x680: our outgoing counter, stamped into ssequence and bumped per send
         rf::NetAddr net_addr;
         int pings[10];
         uint8_t ping_pos;

--- a/game_patch/rf/os/array.h
+++ b/game_patch/rf/os/array.h
@@ -1,9 +1,14 @@
 #pragma once
 
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
 //#include "string.h"
 
 namespace rf
 {
+    class String;
+
     template<typename T = char>
     class VArray
     {
@@ -143,7 +148,27 @@ namespace rf
 
         void add(T element)
         {
-            AddrCaller{0x00447060}.this_call(this, element);
+            // 0x00447060 takes the 8-byte String BY VALUE on the stack and destroys it
+            // (MSVC x86 callee-destroys ABI). GCC/MinGW passes non-trivial classes by
+            // hidden reference instead, so forwarding `element` through this_call pushed
+            // a pointer where the engine expects the raw struct — storing garbage in the
+            // array and making the engine free() a garbage pointer (this poisoned RF's
+            // CRT heap and crashed MinGW dedicated servers at launch). Pass the raw
+            // 8 bytes explicitly — identical layout under both compilers. The engine
+            // copy-assigns those bytes into its own slot buffer and frees the buffer
+            // the passed String pointed at, taking ownership; the memset then zeroes
+            // `element` so the ABI-designated destruction of the by-value parameter —
+            // MSVC runs it in this function's epilogue, GCC/MinGW in the caller — is a
+            // harmless no-op instead of a double free.
+            static_assert(std::is_same_v<T, String>,
+                "VArray_String::add requires T = rf::String: engine routine 0x00447060 copy-assigns the pushed "
+                "8 bytes via String::operator= and destroys them via ~String (freeing bytes 4-7 as a char* "
+                "buffer), so any other 8-byte T compiles but corrupts the heap at runtime");
+            static_assert(sizeof(T) == 8);
+            uint32_t raw[2];
+            std::memcpy(raw, &element, sizeof(raw));
+            AddrCaller{0x00447060}.this_call(this, raw[0], raw[1]);
+            std::memset(&element, 0, sizeof(raw));
         }
 
         T& operator[](int index)
@@ -159,11 +184,6 @@ namespace rf
         T* end()
         {
             return data + num;
-        }
-
-        ~VArray_String()
-        {
-            delete[] data;
         }
     };
     static_assert(sizeof(VArray_String<>) == 0xC);

--- a/vendor/freetype/CMakeLists.txt
+++ b/vendor/freetype/CMakeLists.txt
@@ -7,7 +7,9 @@ message(STATUS "Configuring FreeType ${FREETYPE_VERSION}")
 
 FetchContent_Declare(
     freetype
-    URL https://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.xz
+    URL
+        https://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.xz
+        https://downloads.sourceforge.net/freetype/freetype-${FREETYPE_VERSION}.tar.xz
     URL_HASH SHA256=${FREETYPE_HASH}
     DOWNLOAD_EXTRACT_TIMESTAMP FALSE
 )


### PR DESCRIPTION
- Add `-debug` command line switch to enable additional debug logging, intended to help identify long-standing netcode issues that are difficult to nail down.