### PR TITLE
Fix std::format_error crash from Windows-1252 bytes in format strings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,10 +35,18 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 if(MSVC)
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
     add_compile_options(/arch:SSE2)
+    # Pin both charsets. Sources are UTF-8; narrow string literals are Windows-1252,
+    # because the .vf bitmap fonts are indexed by Windows-1252 byte value and several
+    # literals embed those bytes directly (\x95 bullet, \xA6 chat prefix, ...).
+    # Without this the ordinary literal encoding follows the build machine's system
+    # code page: on a DBCS locale such as 932 those bytes become invalid multi-byte
+    # sequences and std::format throws std::format_error at runtime.
+    add_compile_options(/source-charset:utf-8 /execution-charset:windows-1252)
     # Statically link Microsoft's CRT.
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 else()
     add_compile_options(-msse2)
+    add_compile_options(-finput-charset=UTF-8 -fexec-charset=WINDOWS-1252)
 endif()
 
 # Macros

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -106,6 +106,9 @@ Version 1.4.0 (Lupin): Not yet released
 [@AL2009man](https://github.com/AL2009man)
 - Fix brief game freeze whenever an `Alt` key is pressed
 
+[@jyh9521](https://github.com/jyh9521)
+- Fix crash on join for builds compiled on Windows systems using a Japanese, Chinese, or Korean locale
+
 Version 1.3.0 (Bakeapple): Released Apr-22-2026
 --------------------------------
 ### Major features


### PR DESCRIPTION
Fixes #399

Four call sites embed raw Windows-1252 bytes (`\x95`, `\xA6`) in `std::format`
format strings, which MSVC's `<format>` validates as UTF-8. Moves the bytes
out of the format strings; rendered output is unchanged.

Details and the diagnosis are in #399.