### PR TITLE
Revamp voting system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,9 @@ endif()
 
 macro(enable_warnings target)
     if(NOT MSVC)
-        target_compile_options(${target} PRIVATE -Wall -Wextra -Wundef)
+        target_compile_options(${target} PRIVATE
+            -Wall -Wextra -Wundef
+            -Wformat -Wformat-security -Werror=format-security)
     else()
         target_compile_options(${target} PRIVATE
             /W3

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -74,6 +74,7 @@ Version 1.4.0 (Lupin): Not yet released
 - No longer allow a player to call a vote to kick themselves
 - Change default inactive time before a player is set as idle to 60 seconds (from 30 seconds)
 - Stop labeling players as inactive if they are unable to spawn due to a server or gameplay rule
+- `vote extend` can now select how long to extend the round by, from 1 to 60 minutes (defaults to 5)
 
 [@is-this-c](https://github.com/is-this-c)
 - Add `Anti-aliasing` option to `ADVANCED` options panel

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,12 @@ Version 1.4.0 (Lupin): Not yet released
   - Instagib
   - Rails
   - Arena
+- Completely rework multiplayer voting to use a GUI-based system instead of chat commands
+  - Servers describe their votable levels, game types, and mutator options to clients
+  - `vote level` and `vote match` can now select a game type and any number of mutators (with their options) for the voted level
+  - Add a vote panel for calling any vote the server allows, opened either from the `CALL VOTE` button (hotkey `V`) in the in-game multiplayer menu or from the bindable `Call Vote Menu` control during gameplay (`F4` by default)
+  - Vote HUD notification now shows the live yes/no tally, the time remaining, and whether you have already voted
+  - Removed `vote gametype` and merged its functionality into `vote level`
 
 ### Minor features, changes, and enhancements
 [@GooberRF](https://github.com/GooberRF)
@@ -62,6 +68,8 @@ Version 1.4.0 (Lupin): Not yet released
 - Default inactivity tracking for players in dedicated servers to `true`, but kicking inactive players to `false`
 - Add `-debug` command line switch to enable additional debug logging, intended to help identify long-standing netcode issues that are difficult to nail down.
 - Add automatic team balance option which handles unbalanced teams mid-game and stops players from switching teams if it would unbalance them
+- Send live vote tallies and the remaining vote time to Alpine Faction 1.4+ clients, and send the current vote state to players who join while a vote is running
+- Deprecate the `vote_gametype` dedicated server config section; it is ignored and logs a warning when present
 
 [@is-this-c](https://github.com/is-this-c)
 - Add `Anti-aliasing` option to `ADVANCED` options panel
@@ -100,6 +108,7 @@ Version 1.4.0 (Lupin): Not yet released
 - Fix a server crash that could be triggered by a zero-length UDP packet in the packet receive pump
 - Fix overlapping decals rendering with the oldest on top instead of the newest
 - Fix crash on MinGW builds when launching a dedicated server
+- Fix server version checks comparing each version field independently, which would have rejected a future major version
 
 [@is-this-c](https://github.com/is-this-c)
 - Clear cached server config output after a shuffle of a server's rotation

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,12 +22,12 @@ Version 1.4.0 (Lupin): Not yet released
   - Instagib
   - Rails
   - Arena
-- Completely rework multiplayer voting to use a GUI-based system instead of chat commands
+  - Vampire
+- Rework multiplayer voting to use a GUI-based system instead of chat commands
   - Servers describe their votable levels, game types, and mutator options to clients
   - `vote level` and `vote match` can now select a game type and any number of mutators (with their options) for the voted level
   - Add a vote panel for calling any vote the server allows, opened either from the `CALL VOTE` button (hotkey `V`) in the in-game multiplayer menu or from the bindable `Call Vote Menu` control during gameplay (`F4` by default)
-  - Vote HUD notification now shows the live yes/no tally, the time remaining, and whether you have already voted
-  - Removed `vote gametype` and merged its functionality into `vote level`
+  - Vote HUD notification now shows live tally, time remaining, and whether you have already voted
 
 ### Minor features, changes, and enhancements
 [@GooberRF](https://github.com/GooberRF)
@@ -69,7 +69,13 @@ Version 1.4.0 (Lupin): Not yet released
 - Add `-debug` command line switch to enable additional debug logging, intended to help identify long-standing netcode issues that are difficult to nail down.
 - Add automatic team balance option which handles unbalanced teams mid-game and stops players from switching teams if it would unbalance them
 - Send live vote tallies and the remaining vote time to Alpine Faction 1.4+ clients, and send the current vote state to players who join while a vote is running
-- Deprecate the `vote_gametype` dedicated server config section; it is ignored and logs a warning when present
+- Cancel any active vote when the level changes, and no longer allow votes to be called between levels
+- Rate limit spawn-denied notifications (Alpine restriction, anti-cheat, match in progress, respawn delay) to one message per 5 seconds per player so repeated spawn attempts no longer flood chat
+- Truncate over-long names from dedicated server config files when they are quoted in console warnings
+- Remove `vote gametype`, game type selection is now part of `vote level`
+- Tell clients which levels a server actually allows votes for, so the vote panel no longer offers levels the server would refuse
+- Change default inactive time before a player is set as idle to 60 seconds (from 30 seconds)
+- Stop labeling players as inactive if they are unable to spawn due to a server or gameplay rule
 
 [@is-this-c](https://github.com/is-this-c)
 - Add `Anti-aliasing` option to `ADVANCED` options panel
@@ -109,6 +115,9 @@ Version 1.4.0 (Lupin): Not yet released
 - Fix overlapping decals rendering with the oldest on top instead of the newest
 - Fix crash on MinGW builds when launching a dedicated server
 - Fix server version checks comparing each version field independently, which would have rejected a future major version
+- Fix out of bounds read when applying level rules if the rotation shrank while a level was running
+- No longer allow a player to call a vote to kick themselves
+- Fix the remote server config display sometimes being treated as complete before all of its content had arrived
 
 [@is-this-c](https://github.com/is-this-c)
 - Clear cached server config output after a shuffle of a server's rotation

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,7 +26,7 @@ Version 1.4.0 (Lupin): Not yet released
 - Rework multiplayer voting to use a GUI-based system instead of chat commands
   - Servers describe their votable levels, game types, and mutator options to clients
   - `vote level` and `vote match` can now select a game type and any number of mutators (with their options) for the voted level
-  - Add a vote panel for calling any vote the server allows, opened either from the `CALL VOTE` button (hotkey `V`) in the in-game multiplayer menu or from the bindable `Call Vote Menu` control during gameplay (`F4` by default)
+  - Add a vote panel for calling any vote the server allows, opened during gameplay with the bindable `Call Vote Menu` control (`F4` by default)
   - Vote HUD notification now shows live tally, time remaining, and whether you have already voted
 
 ### Minor features, changes, and enhancements

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -68,12 +68,10 @@ Version 1.4.0 (Lupin): Not yet released
 - Default inactivity tracking for players in dedicated servers to `true`, but kicking inactive players to `false`
 - Add `-debug` command line switch to enable additional debug logging, intended to help identify long-standing netcode issues that are difficult to nail down.
 - Add automatic team balance option which handles unbalanced teams mid-game and stops players from switching teams if it would unbalance them
-- Send live vote tallies and the remaining vote time to Alpine Faction 1.4+ clients, and send the current vote state to players who join while a vote is running
-- Cancel any active vote when the level changes, and no longer allow votes to be called between levels
 - Rate limit spawn-denied notifications (Alpine restriction, anti-cheat, match in progress, respawn delay) to one message per 5 seconds per player so repeated spawn attempts no longer flood chat
 - Truncate over-long names from dedicated server config files when they are quoted in console warnings
 - Remove `vote gametype`, game type selection is now part of `vote level`
-- Tell clients which levels a server actually allows votes for, so the vote panel no longer offers levels the server would refuse
+- No longer allow a player to call a vote to kick themselves
 - Change default inactive time before a player is set as idle to 60 seconds (from 30 seconds)
 - Stop labeling players as inactive if they are unable to spawn due to a server or gameplay rule
 
@@ -116,7 +114,6 @@ Version 1.4.0 (Lupin): Not yet released
 - Fix crash on MinGW builds when launching a dedicated server
 - Fix server version checks comparing each version field independently, which would have rejected a future major version
 - Fix out of bounds read when applying level rules if the rotation shrank while a level was running
-- No longer allow a player to call a vote to kick themselves
 - Fix the remote server config display sometimes being treated as complete before all of its content had arrived
 
 [@is-this-c](https://github.com/is-this-c)

--- a/game_patch/CMakeLists.txt
+++ b/game_patch/CMakeLists.txt
@@ -168,6 +168,8 @@ set(SRCS
     multi/server.h
     multi/server.cpp
     multi/votes.cpp
+    multi/vote_client.h
+    multi/vote_client.cpp
     multi/commands.cpp
     multi/multi_tdm.cpp
     multi/endgame_votes.cpp
@@ -288,6 +290,8 @@ set(SRCS
     misc/ui.cpp
     misc/spray_picker.cpp
     misc/spray_picker.h
+    misc/vote_panel.cpp
+    misc/vote_panel.h
     misc/game.cpp
     misc/level.cpp
     misc/waypoints.cpp

--- a/game_patch/CMakeLists.txt
+++ b/game_patch/CMakeLists.txt
@@ -108,6 +108,8 @@ set(SRCS
     input/mouse.h
     input/mouse.cpp
     input/key.cpp
+    input/control_input_filter.h
+    input/control_input_filter.cpp
     hud/hud_colors.cpp
     hud/hud_scale.cpp
     hud/hud_personas.cpp

--- a/game_patch/hud/hud.cpp
+++ b/game_patch/hud/hud.cpp
@@ -5,6 +5,7 @@
 #include <xlog/xlog.h>
 #include "hud.h"
 #include "hud_internal.h"
+#include "../misc/vote_panel.h"
 #include "multi_scoreboard.h"
 #include "multi_spectate.h"
 #include "remote_server_cfg_ui.h"
@@ -422,7 +423,8 @@ void hud_render_00437BC0()
     bool limbo = rf::gameseq_get_state() == rf::GS_MULTI_LIMBO;
     bool show_scoreboard = scoreboard_control_pressed || (!multi_spectate_is_spectating() && is_player_dead) || limbo;
 
-    scoreboard_maybe_render(show_scoreboard && !g_remote_server_cfg_popup.is_active());
+    scoreboard_maybe_render(show_scoreboard && !g_remote_server_cfg_popup.is_active()
+        && !vote_panel_is_gameplay_overlay_active());
 }
 
 void hud_apply_patches()

--- a/game_patch/hud/multi_hud.cpp
+++ b/game_patch/hud/multi_hud.cpp
@@ -45,6 +45,8 @@
 #include "remote_server_cfg_ui.h"
 #include "../misc/player.h"
 #include "../multi/alpine_packets.h"
+#include "../multi/vote_client.h"
+#include "../misc/vote_panel.h"
 #include "../multi/network.h"
 #include "../multi/bots/bot_main.h"
 #include "multi_spectate.h"
@@ -430,6 +432,17 @@ static const ChatMenuList random_funny_menu{
         {false, ChatMenuListName::Null, ChatMenuListType::Basic, "Get a load of this!", "Get a load of this!"}
     }
 };
+
+// The parameterless vote entries of the COMMANDS menu, which AF 1.4+ servers
+// take as packets instead of chat.
+static std::optional<AfVoteType> chat_menu_simple_vote_type(std::string_view command)
+{
+    if (command == "/vote next") return AfVoteType::Next;
+    if (command == "/vote previous") return AfVoteType::Previous;
+    if (command == "/vote restart") return AfVoteType::Restart;
+    if (command == "/vote extend") return AfVoteType::Extend;
+    return std::nullopt;
+}
 
 // Command
 static const ChatMenuList command_menu{
@@ -1620,10 +1633,6 @@ void hud_render_vote_notification() {
     const std::string vote_no_key_text =
         get_action_bind_name(get_af_control(rf::AlpineControlConfigAction::AF_ACTION_VOTE_NO));
 
-    const std::string vote_notification_text =
-        "ACTIVE QUESTION: \n" + g_active_vote_type + "\n\nPress " + vote_yes_key_text + " to vote yes\nPress " + vote_no_key_text + " to vote no";
-
-    rf::gr::set_color(255, 255, 255, 225);
     const int font = hud_get_default_font();
     const int font_h = rf::gr::get_font_height(font);
     const int border = g_alpine_game_config.big_hud ? 3 : 2;
@@ -1633,7 +1642,44 @@ void hud_render_vote_notification() {
     if (!g_alpine_game_config.big_hud) {
         notification_y += 9;
     }
-    rf::gr::string_aligned(rf::gr::ALIGN_LEFT, 10, notification_y, vote_notification_text.c_str(), font);
+
+    // Legacy (pre-1.4) servers send no tally, so the title is all we can show.
+    const auto& state = vote_state_get();
+    if (!state) {
+        const std::string vote_notification_text = "ACTIVE QUESTION: \n" + g_active_vote_type
+            + "\n\nPress " + vote_yes_key_text + " to vote yes\nPress " + vote_no_key_text
+            + " to vote no";
+        rf::gr::set_color(255, 255, 255, 225);
+        rf::gr::string_aligned(rf::gr::ALIGN_LEFT, 10, notification_y, vote_notification_text.c_str(), font);
+        return;
+    }
+
+    // Lines are drawn one at a time so the bind prompt can be dimmed separately
+    // once this client has cast its vote.
+    int y = notification_y;
+    const auto draw_line = [&](const std::string& text) {
+        if (!text.empty()) {
+            rf::gr::string_aligned(rf::gr::ALIGN_LEFT, 10, y, text.c_str(), font);
+        }
+        y += font_h;
+    };
+
+    rf::gr::set_color(255, 255, 255, 225);
+    draw_line("ACTIVE QUESTION: ");
+    draw_line(state->title);
+    draw_line("");
+    draw_line(std::format("Yes: {}  No: {}     {}s left", static_cast<int>(state->yes),
+        static_cast<int>(state->no), vote_state_seconds_remaining()));
+    draw_line("");
+
+    if (state->has_voted) {
+        rf::gr::set_color(150, 150, 150, 190);
+        draw_line("You have voted");
+    }
+    else {
+        draw_line("Press " + vote_yes_key_text + " to vote yes");
+        draw_line("Press " + vote_no_key_text + " to vote no");
+    }
 }
 
 void draw_hud_vote_notification(std::string vote_type)
@@ -1749,8 +1795,19 @@ CallHook<void(int *dx, int *dy, int *dz)> control_config_get_mouse_delta_hook{
             }
         }
 
+        // The vote panel overlay owns aiming while it is up.
+        if (vote_panel_is_gameplay_overlay_active()) {
+            if (dx) {
+                *dx = 0;
+            }
+            if (dy) {
+                *dy = 0;
+            }
+        }
+
         // If active, do not use mouse wheel scroll delta.
-        if (g_remote_server_cfg_popup.is_active() && dz) {
+        if ((g_remote_server_cfg_popup.is_active() || vote_panel_is_gameplay_overlay_active())
+            && dz) {
             *dz = 0;
         }
     }
@@ -1759,7 +1816,7 @@ CallHook<void(int *dx, int *dy, int *dz)> control_config_get_mouse_delta_hook{
 FunHook<void()> hud_msg_render_hook{
     0x004382D0,
     [] {
-        if (!g_remote_server_cfg_popup.is_active()) {
+        if (!g_remote_server_cfg_popup.is_active() && !vote_panel_is_gameplay_overlay_active()) {
             hud_msg_render_hook.call_target();
         }
     },
@@ -2063,7 +2120,16 @@ void chat_menu_action_handler(rf::Key key) {
             // Commands do not play a chat sound or display for user
             const std::string msg = selected_element.long_string;
             if (!msg.empty()) {
-                send_chat_line_packet(msg, nullptr);
+                // AF 1.4+ servers no longer accept vote calls over chat.
+                const std::optional<AfVoteType> vote_type = chat_menu_simple_vote_type(msg);
+                if (vote_type && is_server_minimum_af_version(1, 4)) {
+                    AfVoteCallParams params{};
+                    params.type = *vote_type;
+                    af_send_vote_call(params);
+                }
+                else {
+                    send_chat_line_packet(msg, nullptr);
+                }
             }
         }
         else if (g_chat_menu_active == ChatMenuType::Spectate) {

--- a/game_patch/hud/multi_hud.cpp
+++ b/game_patch/hud/multi_hud.cpp
@@ -433,8 +433,6 @@ static const ChatMenuList random_funny_menu{
     }
 };
 
-// The parameterless vote entries of the COMMANDS menu, which AF 1.4+ servers
-// take as packets instead of chat.
 static std::optional<AfVoteType> chat_menu_simple_vote_type(std::string_view command)
 {
     if (command == "/vote next") return AfVoteType::Next;
@@ -2185,6 +2183,9 @@ void chat_menu_action_handler(rf::Key key) {
                 if (vote_type && is_server_minimum_af_version(1, 4)) {
                     AfVoteCallParams params{};
                     params.type = *vote_type;
+                    if (params.type == AfVoteType::Extend) {
+                        params.extend_minutes = af_vote_extend_default_minutes;
+                    }
                     af_send_vote_call(params);
                 }
                 else {

--- a/game_patch/hud/multi_hud.cpp
+++ b/game_patch/hud/multi_hud.cpp
@@ -1626,13 +1626,33 @@ void hud_pit_queue_auto_spectate() {
     multi_spectate_enter_freelook();
 }
 
+// Cache for the structured (AF 1.4+) notification.
+struct VoteHudCache
+{
+    bool valid = false;
+    int font = -1;
+    int title_max_w = -1;
+    std::string title_src;
+    std::string title_fit;
+    std::string prompt_yes;
+    std::string prompt_no;
+
+    bool tally_valid = false;
+    int tally_yes = -1;
+    int tally_no = -1;
+    int tally_secs = -1;
+    std::string tally;
+};
+
+static VoteHudCache g_vote_hud_cache;
+
+static void vote_notification_invalidate_cache()
+{
+    g_vote_hud_cache.valid = false;
+    g_vote_hud_cache.tally_valid = false;
+}
+
 void hud_render_vote_notification() {
-    const std::string vote_yes_key_text =
-        get_action_bind_name(get_af_control(rf::AlpineControlConfigAction::AF_ACTION_VOTE_YES));
-
-    const std::string vote_no_key_text =
-        get_action_bind_name(get_af_control(rf::AlpineControlConfigAction::AF_ACTION_VOTE_NO));
-
     const int font = hud_get_default_font();
     const int font_h = rf::gr::get_font_height(font);
     const int border = g_alpine_game_config.big_hud ? 3 : 2;
@@ -1643,9 +1663,13 @@ void hud_render_vote_notification() {
         notification_y += 9;
     }
 
-    // Legacy (pre-1.4) servers send no tally, so the title is all we can show.
+    // Pre 1.4 servers send no tally, so the title is all we can show.
     const auto& state = vote_state_get();
     if (!state) {
+        const std::string vote_yes_key_text =
+            get_action_bind_name(get_af_control(rf::AlpineControlConfigAction::AF_ACTION_VOTE_YES));
+        const std::string vote_no_key_text =
+            get_action_bind_name(get_af_control(rf::AlpineControlConfigAction::AF_ACTION_VOTE_NO));
         const std::string vote_notification_text = "ACTIVE QUESTION: \n" + g_active_vote_type
             + "\n\nPress " + vote_yes_key_text + " to vote yes\nPress " + vote_no_key_text
             + " to vote no";
@@ -1654,46 +1678,82 @@ void hud_render_vote_notification() {
         return;
     }
 
+    // Server-composed titles can be long, so keep them inside the left half of the screen.
+    const int title_max_w = std::max(120, rf::gr::clip_width() / 2 - 20);
+
+    VoteHudCache& cache = g_vote_hud_cache;
+    if (!cache.valid || cache.font != font || cache.title_max_w != title_max_w
+        || cache.title_src != state->title) {
+        cache.font = font;
+        cache.title_max_w = title_max_w;
+        cache.title_src = state->title;
+        // A server that sends no title still gets a usable notification.
+        cache.title_fit = hud_fit_string(
+            state->title.empty() ? std::string_view{"Vote in progress"}
+                                 : std::string_view{state->title},
+            title_max_w, nullptr, font);
+        const std::string yes_key = get_action_bind_name(
+            get_af_control(rf::AlpineControlConfigAction::AF_ACTION_VOTE_YES));
+        const std::string no_key = get_action_bind_name(
+            get_af_control(rf::AlpineControlConfigAction::AF_ACTION_VOTE_NO));
+        cache.prompt_yes = "Press " + yes_key + " to vote yes";
+        cache.prompt_no = "Press " + no_key + " to vote no";
+        cache.valid = true;
+    }
+
+    const int secs = vote_state_seconds_remaining();
+    if (!cache.tally_valid || cache.tally_yes != state->yes || cache.tally_no != state->no
+        || cache.tally_secs != secs) {
+        cache.tally_yes = state->yes;
+        cache.tally_no = state->no;
+        cache.tally_secs = secs;
+        cache.tally = std::format("Yes: {}  No: {}     {}s left", static_cast<int>(state->yes),
+            static_cast<int>(state->no), secs);
+        cache.tally_valid = true;
+    }
+
+    // Half-height spacers instead of blank lines, and a single-line title, keep
+    // the block to ~5 line heights -- what notification_y above was tuned for.
     // Lines are drawn one at a time so the bind prompt can be dimmed separately
     // once this client has cast its vote.
     int y = notification_y;
-    const auto draw_line = [&](const std::string& text) {
-        if (!text.empty()) {
-            rf::gr::string_aligned(rf::gr::ALIGN_LEFT, 10, y, text.c_str(), font);
-        }
+    const auto draw_line = [&](const char* text) {
+        rf::gr::string_aligned(rf::gr::ALIGN_LEFT, 10, y, text, font);
         y += font_h;
     };
 
     rf::gr::set_color(255, 255, 255, 225);
     draw_line("ACTIVE QUESTION: ");
-    draw_line(state->title);
-    draw_line("");
-    draw_line(std::format("Yes: {}  No: {}     {}s left", static_cast<int>(state->yes),
-        static_cast<int>(state->no), vote_state_seconds_remaining()));
-    draw_line("");
+    draw_line(cache.title_fit.c_str());
+    y += font_h / 2;
+    draw_line(cache.tally.c_str());
+    y += font_h / 2;
 
     if (state->has_voted) {
         rf::gr::set_color(150, 150, 150, 190);
         draw_line("You have voted");
     }
     else {
-        draw_line("Press " + vote_yes_key_text + " to vote yes");
-        draw_line("Press " + vote_no_key_text + " to vote no");
+        draw_line(cache.prompt_yes.c_str());
+        draw_line(cache.prompt_no.c_str());
     }
 }
 
 void draw_hud_vote_notification(std::string vote_type)
 {
-    if (!vote_type.empty()) {
-        g_draw_vote_notification = true;
-        g_active_vote_type = vote_type;
-    }
+    // Use a generic label for vote types we can't resolve.
+    // Typically this would mean we are an older client in a newer server that has a
+    // vote type we don't know about.
+    g_draw_vote_notification = true;
+    g_active_vote_type = vote_type.empty() ? std::string{"Vote in progress"} : std::move(vote_type);
+    vote_notification_invalidate_cache();
 }
 
 void remove_hud_vote_notification()
 {
     g_draw_vote_notification = false;
     g_active_vote_type = "";
+    vote_notification_invalidate_cache();
 }
 
 void build_local_player_spectators_strings() {

--- a/game_patch/hud/multi_hud_chat.cpp
+++ b/game_patch/hud/multi_hud_chat.cpp
@@ -12,6 +12,7 @@
 #include "../misc/player.h"
 #include "hud_internal.h"
 #include "../misc/alpine_settings.h"
+#include "../misc/vote_panel.h"
 #include <patch_common/CallHook.h>
 #include "../multi/alpine_packets.h"
 
@@ -59,7 +60,8 @@ void multi_hud_render_chat()
         fade_out = rf::chat_fade_out_timer.time_until() / 750.0f;
     }
 
-    if (g_remote_server_cfg_popup.is_active() || g_alpine_game_config.hide_chat) {
+    if (g_remote_server_cfg_popup.is_active() || vote_panel_is_gameplay_overlay_active()
+        || g_alpine_game_config.hide_chat) {
         return;
     }
 
@@ -264,7 +266,7 @@ CallHook<void(const char*, bool)> process_rcon_req_packet_chat_say_hook{
 FunHook<void(int)> multi_chat_say_show_hook{
     0x00444A80,
     [] (const int is_team_chat) {
-        if (!g_remote_server_cfg_popup.is_active()) {
+        if (!g_remote_server_cfg_popup.is_active() && !vote_panel_is_gameplay_overlay_active()) {
             multi_chat_say_show_hook.call_target(is_team_chat);
         }
     },

--- a/game_patch/hud/multi_spectate.cpp
+++ b/game_patch/hud/multi_spectate.cpp
@@ -1,4 +1,5 @@
 #include "multi_spectate.h"
+#include "../misc/vote_panel.h"
 #include "hud.h"
 #include "hud_internal.h"
 #include "multi_scoreboard.h"
@@ -1973,7 +1974,7 @@ void multi_spectate_render() {
     spectate_render_bind_dialog();
 
     if (multi_spectate_is_static()) {
-        if (!g_alpine_game_config.spectate_mode_minimal_ui && !g_remote_server_cfg_popup.is_active()) {
+        if (!g_alpine_game_config.spectate_mode_minimal_ui && !g_remote_server_cfg_popup.is_active() && !vote_panel_is_gameplay_overlay_active()) {
             int medium_font = hud_get_default_font();
             int medium_font_h = rf::gr::get_font_height(medium_font);
             int large_font = hud_get_large_font();
@@ -2040,7 +2041,7 @@ void multi_spectate_render() {
     }
 
     if (multi_spectate_is_freelook()) {
-        if (!g_alpine_game_config.spectate_mode_minimal_ui && !g_remote_server_cfg_popup.is_active()) {
+        if (!g_alpine_game_config.spectate_mode_minimal_ui && !g_remote_server_cfg_popup.is_active() && !vote_panel_is_gameplay_overlay_active()) {
             int medium_font = hud_get_default_font();
             int medium_font_h = rf::gr::get_font_height(medium_font);
             int large_font = hud_get_large_font();
@@ -2107,7 +2108,7 @@ void multi_spectate_render() {
 
     if (!g_spectate_mode_enabled) {
         if (rf::player_is_dead(rf::local_player)
-            && !g_remote_server_cfg_popup.is_active()) {
+            && !g_remote_server_cfg_popup.is_active() && !vote_panel_is_gameplay_overlay_active()) {
             const std::string spectate_bind_text = get_action_bind_name(
                 get_af_control(rf::AlpineControlConfigAction::AF_ACTION_SPECTATE_TOGGLE)
             );
@@ -2198,7 +2199,7 @@ void multi_spectate_render() {
         rf::gr::string_aligned(rf::gr::ALIGN_CENTER, title_x, title_y + large_font_h,
             view_subtitle, medium_font);
 
-        if (!g_remote_server_cfg_popup.is_active()) {
+        if (!g_remote_server_cfg_popup.is_active() && !vote_panel_is_gameplay_overlay_active()) {
             int hints_left_x = g_alpine_game_config.big_hud ? 120 : 70;
             int hints_right_x = g_alpine_game_config.big_hud ? 140 : 80;
             std::string attach_text = get_action_bind_name(
@@ -2310,7 +2311,7 @@ void multi_spectate_render() {
     render_spectate_powerup_icons(entity, bar_x, bar_y, bar_h);
 
     // Draw next/prev player hints flanking the nameplate bar
-    if (!g_alpine_game_config.spectate_mode_minimal_ui && !g_remote_server_cfg_popup.is_active()) {
+    if (!g_alpine_game_config.spectate_mode_minimal_ui && !g_remote_server_cfg_popup.is_active() && !vote_panel_is_gameplay_overlay_active()) {
         std::string prev_player_text =
             get_action_bind_name(rf::ControlConfigAction::CC_ACTION_SECONDARY_ATTACK);
         std::string next_player_text =

--- a/game_patch/input/control_input_filter.cpp
+++ b/game_patch/input/control_input_filter.cpp
@@ -1,0 +1,120 @@
+#include <array>
+#include <cstddef>
+#include <patch_common/FunHook.h>
+#include <xlog/xlog.h>
+#include "control_input_filter.h"
+#include "../rf/player/control_config.h"
+
+namespace
+{
+
+// Three participants exist today (vote panel, waypoint editor, client bots). The
+// cap only exists so registration needs no allocation and the hooks stay a flat
+// walk over a fixed array.
+constexpr std::size_t max_participants = 8;
+
+std::array<ControlInputVetoFn, max_participants> g_vetoes{};
+std::size_t g_veto_count = 0;
+
+std::array<ControlInputInjectionFn, max_participants> g_injections{};
+std::size_t g_injection_count = 0;
+
+// Vetoes are OR-ed, so their registration order does not matter.
+bool action_is_vetoed(rf::ControlConfig* ccp, rf::ControlConfigAction action)
+{
+    for (std::size_t i = 0; i < g_veto_count; ++i) {
+        if (g_vetoes[i](ccp, action)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+ControlInputInjection resolve_injection(rf::ControlConfig* ccp, rf::ControlConfigAction action)
+{
+    ControlInputInjection result{};
+    for (std::size_t i = 0; i < g_injection_count; ++i) {
+        const ControlInputInjection injected = g_injections[i](ccp, action);
+        result.down = result.down || injected.down;
+        result.just_pressed = result.just_pressed || injected.just_pressed;
+    }
+    return result;
+}
+
+FunHook<bool(rf::ControlConfig*, rf::ControlConfigAction, bool*)> control_config_check_pressed_hook{
+    0x0043D4F0,
+    [](rf::ControlConfig* ccp, rf::ControlConfigAction action, bool* just_pressed) {
+        // A veto owns the action completely: the engine is not consulted and no
+        // injection can lift it.
+        if (action_is_vetoed(ccp, action)) {
+            if (just_pressed) {
+                *just_pressed = false;
+            }
+            return false;
+        }
+
+        const bool pressed = control_config_check_pressed_hook.call_target(ccp, action, just_pressed);
+
+        const ControlInputInjection injected = resolve_injection(ccp, action);
+        if (!injected.down) {
+            return pressed;
+        }
+        if (just_pressed) {
+            *just_pressed = *just_pressed || injected.just_pressed;
+        }
+        return true;
+    },
+};
+
+FunHook<bool(rf::ControlConfig*, rf::ControlConfigAction)> control_is_control_down_hook{
+    0x00430F40,
+    [](rf::ControlConfig* ccp, rf::ControlConfigAction action) {
+        if (action_is_vetoed(ccp, action)) {
+            return false;
+        }
+        // Deliberately no injection: bots drive fire through
+        // control_config_check_pressed only, which is the one function their own
+        // hook ever covered.
+        return control_is_control_down_hook.call_target(ccp, action);
+    },
+};
+
+} // namespace
+
+void control_input_filter_apply_patch()
+{
+    control_config_check_pressed_hook.install();
+    control_is_control_down_hook.install();
+}
+
+void control_input_filter_add_veto(ControlInputVetoFn veto)
+{
+    if (!veto) {
+        return;
+    }
+    if (g_veto_count >= g_vetoes.size()) {
+        xlog::error("control input filter: veto registration overflow, input policy will be wrong");
+        return;
+    }
+    g_vetoes[g_veto_count++] = veto;
+}
+
+void control_input_filter_add_press_injection(ControlInputInjectionFn injection)
+{
+    if (!injection) {
+        return;
+    }
+    if (g_injection_count >= g_injections.size()) {
+        xlog::error("control input filter: injection registration overflow, input policy will be wrong");
+        return;
+    }
+    g_injections[g_injection_count++] = injection;
+}
+
+bool control_input_filter_check_pressed_unfiltered(
+    rf::ControlConfig* ccp,
+    rf::ControlConfigAction action,
+    bool* just_pressed)
+{
+    return control_config_check_pressed_hook.call_target(ccp, action, just_pressed);
+}

--- a/game_patch/input/control_input_filter.h
+++ b/game_patch/input/control_input_filter.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "../rf/player/control_config.h"
+
+// Returns true if `action` must be reported as not pressed / not down for `ccp`.
+using ControlInputVetoFn = bool (*)(rf::ControlConfig* ccp, rf::ControlConfigAction action);
+
+// Synthetic input laid over the engine's own reading.
+struct ControlInputInjection
+{
+    bool down = false;
+    bool just_pressed = false;
+};
+
+using ControlInputInjectionFn = ControlInputInjection (*)(rf::ControlConfig* ccp, rf::ControlConfigAction action);
+
+// Installs both hooks. Called once at startup like the rest of game_patch/input.
+void control_input_filter_apply_patch();
+
+// Registration is independent of installation: a participant registers when its
+// subsystem first becomes relevant, and the filter simply has nothing to do
+// until then. Callers are responsible for registering only once.
+void control_input_filter_add_veto(ControlInputVetoFn veto);
+
+// Injection applies to control_config_check_pressed only, matching the single
+// function bots used to hook. Nothing injects into control_is_control_down.
+void control_input_filter_add_press_injection(ControlInputInjectionFn injection);
+
+// control_config_check_pressed with every veto and injection bypassed, for a
+// participant that needs the engine's raw reading of an action it itself vetoes.
+bool control_input_filter_check_pressed_unfiltered(
+    rf::ControlConfig* ccp,
+    rf::ControlConfigAction action,
+    bool* just_pressed);

--- a/game_patch/input/input.h
+++ b/game_patch/input/input.h
@@ -12,3 +12,4 @@ rf::ControlConfigAction get_af_control(rf::AlpineControlConfigAction alpine_cont
 rf::String get_action_bind_name(int action);
 void mouse_apply_patch();
 void key_apply_patch();
+void control_input_filter_apply_patch();

--- a/game_patch/input/key.cpp
+++ b/game_patch/input/key.cpp
@@ -389,15 +389,20 @@ CodeInjection player_execute_action_patch2{
         // only intercept alpine controls
         if (action_index >= starting_alpine_control_index) {
             const int alpine_action_index = action_index - starting_alpine_control_index;
+            // Limbo is handled by the endgame (map rating) path in the other
+            // patch; without the state check both run and F1 in limbo would also
+            // send a real vote packet.
             if (alpine_action_index
                 == static_cast<int>(rf::AlpineControlConfigAction::AF_ACTION_VOTE_YES)
                 && rf::is_multi
-                && !rf::is_server) {
+                && !rf::is_server
+                && rf::gameseq_get_state() != rf::GS_MULTI_LIMBO) {
                 cast_local_vote(true);
             } else if (alpine_action_index
                 == static_cast<int>(rf::AlpineControlConfigAction::AF_ACTION_VOTE_NO)
                 && rf::is_multi
-                && !rf::is_server) {
+                && !rf::is_server
+                && rf::gameseq_get_state() != rf::GS_MULTI_LIMBO) {
                 cast_local_vote(false);
             } else if (alpine_action_index
                 == static_cast<int>(rf::AlpineControlConfigAction::AF_ACTION_READY)
@@ -462,6 +467,9 @@ CodeInjection player_execute_action_patch3{
             } else if (alpine_action_index
                 == static_cast<int>(rf::AlpineControlConfigAction::AF_ACTION_REMOTE_SERVER_CFG)
                 && is_server_minimum_af_version(1, 2)) {
+                if (vote_panel_is_gameplay_overlay_active()) {
+                    vote_panel_close();
+                }
                 g_remote_server_cfg_popup.toggle();
             } else if (alpine_action_index
                 == static_cast<int>(rf::AlpineControlConfigAction::AF_ACTION_VOTE_MENU)

--- a/game_patch/input/key.cpp
+++ b/game_patch/input/key.cpp
@@ -286,7 +286,6 @@ CodeInjection control_config_init_patch{
                                        rf::AlpineControlConfigAction::AF_ACTION_SPECTATE_CHANGE_VIEW);
         alpine_control_config_add_item(ccp, "Spray", 0, rf::KEY_Z, -1, -1,
                                        rf::AlpineControlConfigAction::AF_ACTION_SPRAY);
-        // F1/F2/F3/F5 are the existing AF multiplayer cluster; F4 is the free slot.
         alpine_control_config_add_item(ccp, "Call Vote Menu", false, rf::KEY_F4, -1, -1,
                                        rf::AlpineControlConfigAction::AF_ACTION_VOTE_MENU);
     },

--- a/game_patch/input/key.cpp
+++ b/game_patch/input/key.cpp
@@ -23,6 +23,8 @@
 #include "../multi/alpine_packets.h"
 #include "../multi/pit.h"
 #include "../multi/sprays.h"
+#include "../multi/vote_client.h"
+#include "../misc/vote_panel.h"
 #include "../os/console.h"
 #include "input.h"
 
@@ -284,6 +286,9 @@ CodeInjection control_config_init_patch{
                                        rf::AlpineControlConfigAction::AF_ACTION_SPECTATE_CHANGE_VIEW);
         alpine_control_config_add_item(ccp, "Spray", 0, rf::KEY_Z, -1, -1,
                                        rf::AlpineControlConfigAction::AF_ACTION_SPRAY);
+        // F1/F2/F3/F5 are the existing AF multiplayer cluster; F4 is the free slot.
+        alpine_control_config_add_item(ccp, "Call Vote Menu", false, rf::KEY_F4, -1, -1,
+                                       rf::AlpineControlConfigAction::AF_ACTION_VOTE_MENU);
     },
 };
 
@@ -331,6 +336,20 @@ static void execute_alive_alpine_control(int action_index)
     }
 }
 
+// AF 1.4+ servers take votes as packets and keep the HUD notification alive
+// until they send the end event; older servers only understand the chat command.
+static void cast_local_vote(bool is_yes_vote)
+{
+    if (is_server_minimum_af_version(1, 4)) {
+        af_send_vote_cast(is_yes_vote);
+        vote_state_mark_local_voted();
+        return;
+    }
+
+    send_chat_line_packet(is_yes_vote ? "/vote yes" : "/vote no", nullptr);
+    remove_hud_vote_notification(); // optimistic; legacy servers send no tally
+}
+
 CodeInjection player_execute_action_patch{
     0x004A6283,
     [](auto& regs) {
@@ -374,14 +393,12 @@ CodeInjection player_execute_action_patch2{
                 == static_cast<int>(rf::AlpineControlConfigAction::AF_ACTION_VOTE_YES)
                 && rf::is_multi
                 && !rf::is_server) {
-                send_chat_line_packet("/vote yes", nullptr);
-                remove_hud_vote_notification();
+                cast_local_vote(true);
             } else if (alpine_action_index
                 == static_cast<int>(rf::AlpineControlConfigAction::AF_ACTION_VOTE_NO)
                 && rf::is_multi
                 && !rf::is_server) {
-                send_chat_line_packet("/vote no", nullptr);
-                remove_hud_vote_notification();
+                cast_local_vote(false);
             } else if (alpine_action_index
                 == static_cast<int>(rf::AlpineControlConfigAction::AF_ACTION_READY)
                 && rf::is_multi) {
@@ -446,6 +463,12 @@ CodeInjection player_execute_action_patch3{
                 == static_cast<int>(rf::AlpineControlConfigAction::AF_ACTION_REMOTE_SERVER_CFG)
                 && is_server_minimum_af_version(1, 2)) {
                 g_remote_server_cfg_popup.toggle();
+            } else if (alpine_action_index
+                == static_cast<int>(rf::AlpineControlConfigAction::AF_ACTION_VOTE_MENU)
+                && rf::is_multi
+                && !rf::is_server
+                && rf::gameseq_get_state() == rf::GS_GAMEPLAY) {
+                vote_panel_toggle_gameplay();
             } else if (alpine_action_index
                 == static_cast<int>(rf::AlpineControlConfigAction::AF_ACTION_SPECTATE_ATTACH)
                 && !rf::is_dedicated_server

--- a/game_patch/main/main.cpp
+++ b/game_patch/main/main.cpp
@@ -39,7 +39,6 @@
 #include "../misc/misc.h"
 #include "../misc/achievements.h"
 #include "../misc/spray_picker.h"
-#include "../misc/vote_panel.h"
 #include "../misc/alpine_options.h"
 #include "../misc/alpine_settings.h"
 #include "../misc/vpackfile.h"
@@ -206,7 +205,6 @@ CodeInjection after_frame_render_hook{
             fullscreen_overlay_do_frame();
             gas_region_transition_do_frame();
             spray_picker_render();
-            vote_panel_gameplay_render();
 #if !defined(NDEBUG) && defined(HAS_EXPERIMENTAL)
             experimental_render();
 #endif

--- a/game_patch/main/main.cpp
+++ b/game_patch/main/main.cpp
@@ -588,6 +588,7 @@ extern "C" DWORD __declspec(dllexport) Init([[maybe_unused]] void* unused)
     dedi_cfg_init();
     mouse_apply_patch();
     key_apply_patch();
+    control_input_filter_apply_patch();
 #if !defined(NDEBUG) && defined(HAS_EXPERIMENTAL)
     experimental_init();
 #endif

--- a/game_patch/main/main.cpp
+++ b/game_patch/main/main.cpp
@@ -39,6 +39,7 @@
 #include "../misc/misc.h"
 #include "../misc/achievements.h"
 #include "../misc/spray_picker.h"
+#include "../misc/vote_panel.h"
 #include "../misc/alpine_options.h"
 #include "../misc/alpine_settings.h"
 #include "../misc/vpackfile.h"
@@ -205,6 +206,7 @@ CodeInjection after_frame_render_hook{
             fullscreen_overlay_do_frame();
             gas_region_transition_do_frame();
             spray_picker_render();
+            vote_panel_gameplay_render();
 #if !defined(NDEBUG) && defined(HAS_EXPERIMENTAL)
             experimental_render();
 #endif

--- a/game_patch/misc/achievements.cpp
+++ b/game_patch/misc/achievements.cpp
@@ -1547,7 +1547,7 @@ ConsoleCommand2 debug_achievement_cmd{
             //achievement.icon
         );
 
-        rf::console::printf(msg.c_str());
+        rf::console::print("{}", msg);
     },
     "Look up information for an achievement by UID",
     "dbg_achievement <uid>",

--- a/game_patch/misc/misc.cpp
+++ b/game_patch/misc/misc.cpp
@@ -47,6 +47,7 @@ void g_solid_do_patch();
 void destruction_do_patch();
 void camera_do_patch();
 void ui_apply_patch();
+void vote_panel_apply_patch();
 void game_apply_patch();
 void character_apply_patch();
 void level_apply_patch();
@@ -731,6 +732,7 @@ void misc_init()
     register_sound_commands();
     camera_do_patch();
     ui_apply_patch();
+    vote_panel_apply_patch();
     game_apply_patch();
     character_apply_patch();
     level_apply_patch();

--- a/game_patch/misc/player.cpp
+++ b/game_patch/misc/player.cpp
@@ -920,7 +920,13 @@ bool player_is_idle(const rf::Player* const player) {
         const bool is_idle = player->idle.check_timer.valid()
             && player->idle.check_timer.elapsed();
         // Player is idle if timer has elapsed and they're not spawned
-        return is_idle && rf::player_is_dead(player) && !player->is_spectator;
+        if (!is_idle || !rf::player_is_dead(player) || player->is_spectator) {
+            return false;
+        }
+        // ...but never when the game itself is what is keeping them unspawned.
+        // Waiting players are not idle and can vote. Players who fail client
+        // requirements (like not having a sufficient AF version) are not exempt.
+        return !player_spawn_blocked_by_game(player);
     } else {
         return player->received_pf_status
             == std::optional{pf_pure_status::af_idle};

--- a/game_patch/misc/player.cpp
+++ b/game_patch/misc/player.cpp
@@ -106,7 +106,17 @@ bool is_server_minimum_af_version(int version_major, int version_minor) {
         return false;
     }
 
-    return server_info->version_major >= version_major && server_info->version_minor >= version_minor;
+    // Lexicographic, matching is_player_minimum_af_client_version. A per-field
+    // >= comparison would wrongly reject e.g. 2.0 against a (1, 4) requirement.
+    if (server_info->version_major > version_major) {
+        return true;
+    }
+
+    if (server_info->version_major < version_major) {
+        return false;
+    }
+
+    return server_info->version_minor >= version_minor;
 }
 
 std::string build_local_spawn_string(bool can_respawn) {

--- a/game_patch/misc/vote_panel.cpp
+++ b/game_patch/misc/vote_panel.cpp
@@ -1,9 +1,6 @@
 #include <algorithm>
-#include <array>
 #include <cctype>
 #include <cstdint>
-#include <cstdio>
-#include <cstdlib>
 #include <format>
 #include <string>
 #include <string_view>
@@ -18,6 +15,7 @@
 #include "vote_panel.h"
 #include "player.h"
 #include "../hud/hud_internal.h"
+#include "../hud/remote_server_cfg_ui.h"
 #include "../multi/alpine_packets.h"
 #include "../multi/vote_client.h"
 #include "../os/os.h"
@@ -58,14 +56,20 @@ constexpr int multi_menu_button_stride = 0x44;
 constexpr uintptr_t mainmenu_do_frame_addr = 0x00443780;
 constexpr uintptr_t mainmenu_do_return_addr = 0x00443C90;
 
-// Every read of the (already full) stock dispatch array `MOV ECX, 0x0063E090`.
-// The imm32 lives at site+1. The four init-time add calls are left alone, which
-// leaves the stock array populated but unreferenced.
+// Every executable read of the (already full) stock dispatch array
+// `MOV ECX, 0x0063E090`. The imm32 lives at site+1. The four init-time add calls
+// are left alone, which leaves the stock array populated but unreferenced.
+//
+// 0x00448A90 / 0x00448AB0 also load that address but are deliberately NOT here:
+// they are the MSVC static ctor/dtor thunks for the stock VArray, reached only
+// from the CRT initializer table entry at 0x005932FC (0x00448A80 -> CALL ctor,
+// JMP dtor-registration). The ctor already ran during CRT init, long before
+// misc_init() patches anything, and the dtor target (0x0054D9E0) is a bare RET,
+// so retargeting either one is a no-op.
 constexpr uintptr_t dispatch_array_sites[] = {
     0x00448EF1, 0x00448F02, 0x00448F15, 0x00448F58, // do_frame
     0x004491F4, 0x0044920C,                         // mouse handler
     0x00448FD8, 0x00448FF4, 0x0044908A, 0x004490A4, // key handler
-    0x00448A90, 0x00448AB0,                         // highlight helpers
 };
 
 // Set by mainmenu_init from the gameseq state underneath the menu: non-zero
@@ -176,6 +180,58 @@ VotePanelContext g_context = VotePanelContext::None;
 // persisted; ignored (forced on) while the server enforces the prefix.
 bool g_filter_gametype_local = false;
 
+// Description area: hover drives it, a toggle pins it until the next hover.
+bool g_hovered_mutator_this_pass = false;
+bool g_description_pinned = false;
+
+// Filtered + sorted + deduped display rows for the level list, plus the resolved
+// selection row. Both panel passes in a frame reuse this; it is rebuilt only when
+// one of its inputs actually changes (see level_list_fingerprint).
+struct LevelListCache
+{
+    bool valid = false;
+    uint32_t levels_fp = 0;
+    bool filter_active = false;
+    uint8_t gametype = af_vote_gametype_none;
+    bool allow_current = false;
+
+    std::vector<std::string> items; // display rows, pinned "Current level" included
+    int first_level_row = 0;
+    int gametype_hidden = 0;    // dropped by the gametype mask (opt-in or enforced)
+    int not_allowed_hidden = 0; // dropped by allowed_for_vote (always applied)
+
+    // Selection row resolved from the stored name, cached against it.
+    bool sel_valid = false;
+    std::string sel_name;
+    bool sel_manual = false;
+    int sel_row = -1;
+};
+
+LevelListCache g_level_cache;
+
+// Allocation-free hash of everything the level display depends on. Filename
+// length plus its first/last byte stands in for the whole name: a real map-list
+// change cannot preserve all of that alongside the flags.
+uint32_t level_list_fingerprint(const VoteOptionsData& options)
+{
+    uint32_t h = 2166136261u; // FNV-1a
+    const auto mix = [&h](uint32_t v) {
+        h = (h ^ v) * 16777619u;
+    };
+    mix(static_cast<uint32_t>(options.levels.size()));
+    for (const auto& level : options.levels) {
+        mix(level.natural_gametype);
+        mix(level.valid_gametype_mask);
+        mix(level.allowed_for_vote ? 1u : 0u);
+        mix(static_cast<uint32_t>(level.filename.size()));
+        if (!level.filename.empty()) {
+            mix(static_cast<uint8_t>(level.filename.front()));
+            mix(static_cast<uint8_t>(level.filename.back()));
+        }
+    }
+    return h;
+}
+
 // Gameplay overlay needs the cursor back and mouse-look off; both are restored
 // on every close, including the forced ones (level change, disconnect).
 bool g_gameplay_mouse_overridden = false;
@@ -231,10 +287,17 @@ void gameplay_overlay_apply_mouse(bool active)
         return;
     }
 
-    if (player && g_gameplay_mouse_overridden) {
+    // mouse_look is a PERSISTED player setting: only drop the override once the
+    // saved value is actually back. If the player object is gone (disconnect,
+    // kick, level change) keep it pending so the next apply can still restore it
+    // rather than losing the user's setting permanently.
+    if (g_gameplay_mouse_overridden) {
+        if (!player) {
+            return;
+        }
         player->settings.controls.mouse_look = g_gameplay_prev_mouse_look;
+        g_gameplay_mouse_overridden = false;
     }
-    g_gameplay_mouse_overridden = false;
     // Only re-grab the cursor if we are actually still in gameplay; on a level
     // change the engine owns the mouse mode.
     if (rf::gameseq_get_state() == rf::GS_GAMEPLAY && !rf::keep_mouse_centered) {
@@ -263,14 +326,13 @@ struct MutatorDescription
 // against rfpc-medium.vf metrics at the panel's reference scale.
 const MutatorDescription mutator_descriptions[] = {
     {"instagib",
-     "Everyone spawns with the Rail Driver only, and one hit kills. Unlimited ammo, no reloading, "
-     "no weapon switching, no item pickups."},
+     "Spawn with Rail. One-hit kills, unlimited ammo, no reloads, no weapon switching, no pickups."},
     {"rails",
-     "Spawn with only the Riot Stick. All weapon and ammo pickups become the featured weapon and "
-     "never despawn. Other items are hidden."},
+     "Spawn with Baton. Weapon/ammo pickups based on the specified weapon. No other pickups."},
     {"arena",
-     "Spawn with 100 health and 100 armor, a Riot Stick and an Assault Rifle. Each frag refills "
-     "your health, armor and ammo. Weapon pickups only."},
+     "Spawn with AR and 100/100. Auto reload and reset to 100/100 on a frag. Weapon pickups only."},
+    {"vampire",
+     "Damage enemies to regenerate health and armor."},
 };
 
 const char* mutator_description_for(std::string_view name)
@@ -365,9 +427,10 @@ struct PanelMutatorSelection
 struct FormState
 {
     bool built = false;
-    size_t built_gametypes = 0;
-    size_t built_mutators = 0;
-    size_t built_levels = 0;
+    // Identity of the schema this form was built for. Sizes alone miss a blob
+    // that keeps its counts but reorders/renames mutators or changes an option
+    // list, which would leave stale values to be sent against different options.
+    uint32_t built_fingerprint = 0;
 
     int type_index = 0;
     int kick_index = 0;
@@ -390,6 +453,11 @@ struct KickCandidate
     std::string name;
 };
 
+// Player list snapshot for the Kick form: refreshed on the hit-test pass and
+// reused by the draw pass in the same frame.
+std::vector<KickCandidate> g_kick_cache;
+std::vector<std::string> g_kick_names;
+
 bool g_open = false;
 FormState g_form;
 
@@ -397,12 +465,22 @@ FormState g_form;
 // widget that opened it has to be remembered here.
 int g_popup_mutator = -1;
 int g_popup_option = -1;
+// Indices alone are unsafe: a popup can outlive a forced close, or the blob can
+// refresh between opening it and pressing OK, which would write the typed value
+// into a different option. The ids are re-checked on apply.
+uint8_t g_popup_mutator_id = 0;
+uint8_t g_popup_option_id = 0;
+
+void clear_popup_target()
+{
+    g_popup_mutator = -1;
+    g_popup_option = -1;
+}
 
 enum class PanelMode
 {
     NotSupported,
     Loading,
-    ActiveVote,
     Form,
 };
 
@@ -871,12 +949,51 @@ std::vector<const VoteGametypeInfo*> selectable_gametypes(const VoteOptionsData&
     return out;
 }
 
+// Types the panel can actually render. Unknown types are already absent from the
+// parsed schema (the blob's descriptors are length-prefixed and skippable), but a
+// known-yet-unrendered type (String) would otherwise leave a blank row, so the
+// row is skipped entirely -- in both the layout and the height calculation.
+bool option_has_widget(MutatorOptionType type)
+{
+    switch (type) {
+        case MutatorOptionType::Bool:
+        case MutatorOptionType::Choice:
+        case MutatorOptionType::Int:
+        case MutatorOptionType::Float:
+            return true;
+        default:
+            return false;
+    }
+}
+
+// Cheap order-sensitive hash over the parts of the schema the form mirrors:
+// gametype ids, and every mutator id plus each option's id and type.
+uint32_t schema_fingerprint(const VoteOptionsData& options)
+{
+    uint32_t h = 2166136261u; // FNV-1a
+    const auto mix = [&h](uint32_t v) {
+        h = (h ^ v) * 16777619u;
+    };
+    mix(static_cast<uint32_t>(options.gametypes.size()));
+    for (const auto& gametype : options.gametypes) {
+        mix(gametype.id);
+    }
+    mix(static_cast<uint32_t>(options.mutators.size()));
+    for (const auto& mutator : options.mutators) {
+        mix(mutator.id);
+        mix(static_cast<uint32_t>(mutator.options.size()));
+        for (const auto& option : mutator.options) {
+            mix(option.id);
+            mix(static_cast<uint32_t>(option.type));
+        }
+    }
+    return h;
+}
+
 void build_form(const VoteOptionsData& options)
 {
     g_form.built = true;
-    g_form.built_gametypes = options.gametypes.size();
-    g_form.built_mutators = options.mutators.size();
-    g_form.built_levels = options.levels.size();
+    g_form.built_fingerprint = schema_fingerprint(options);
 
     g_form.type_index = 0;
     g_form.kick_index = 0;
@@ -909,9 +1026,10 @@ void build_form(const VoteOptionsData& options)
 
 void ensure_form(const VoteOptionsData& options)
 {
-    if (!g_form.built || g_form.built_gametypes != options.gametypes.size()
-        || g_form.built_mutators != options.mutators.size()
-        || g_form.built_levels != options.levels.size()) {
+    // Deliberately NOT keyed on the level list: the selection is tracked by name,
+    // so a background stale-refresh that only changes levels must not wipe the
+    // player's in-progress form. The level cache below picks that up instead.
+    if (!g_form.built || g_form.built_fingerprint != schema_fingerprint(options)) {
         build_form(options);
     }
 }
@@ -1005,6 +1123,13 @@ void mutator_option_popup_callback()
         || g_popup_option >= static_cast<int>(g_form.mutators[g_popup_mutator].options.size())) {
         return;
     }
+    // Identity check, not just bounds: the slot must still be the option the
+    // popup was opened for.
+    if (schema.id != g_popup_mutator_id
+        || schema.options[g_popup_option].id != g_popup_option_id) {
+        clear_popup_target();
+        return;
+    }
 
     PanelOptionValue& value = g_form.mutators[g_popup_mutator].options[g_popup_option];
     try {
@@ -1018,6 +1143,7 @@ void mutator_option_popup_callback()
     catch (const std::exception& e) {
         xlog::info("vote panel: invalid option input '{}', reason: {}", buffer, e.what());
     }
+    clear_popup_target();
 }
 
 // ---------------------------------------------------------------------------
@@ -1029,9 +1155,9 @@ PanelMode compute_mode()
     if (!is_server_minimum_af_version(1, 4)) {
         return PanelMode::NotSupported;
     }
-    if (vote_state_get().has_value()) {
-        return PanelMode::ActiveVote;
-    }
+    // No ActiveVote mode any more: a running vote leaves the form in place and
+    // is surfaced by the title-row status line plus the footer button states, so
+    // a replacement vote can be set up the moment the current one ends.
     if (!vote_options_are_loaded()) {
         return PanelMode::Loading;
     }
@@ -1045,6 +1171,9 @@ void play_click_sound()
 
 void play_toggle_sound(bool on)
 {
+    // Intentional, do not "fix": this matches the established AF convention in
+    // misc/ui.cpp's ao_play_button_snd, which plays checkbox_off when turning a
+    // setting ON. The .wav names read backwards but the panels must agree.
     rf::snd_play(on ? stock_sound_id::checkbox_off : stock_sound_id::checkbox_on, 0, 0.0f, 1.0f);
 }
 
@@ -1072,6 +1201,28 @@ void close_panel_and_return_to_game()
     AddrCaller{multi_menu_back_on_click_addr}.c_call<void>(0, 0);
     g_auto_return_to_game = true;
     g_auto_return_deadline_ms = timer::get_i64(1000) + auto_return_lifetime_ms;
+}
+
+// Mirrors send_vote_from_form's validation so the button can be greyed out
+// instead of silently doing nothing when pressed.
+bool vote_form_is_sendable(const VoteOptionsData& options)
+{
+    const auto types = enabled_vote_types();
+    if (g_form.type_index < 0 || g_form.type_index >= static_cast<int>(types.size())) {
+        return false;
+    }
+    switch (types[g_form.type_index]->type) {
+        case AfVoteType::Kick: {
+            const auto candidates = build_kick_candidates();
+            return g_form.kick_index >= 0
+                && g_form.kick_index < static_cast<int>(candidates.size());
+        }
+        case AfVoteType::Level:
+            return !selected_level().empty();
+        default:
+            return true; // Match falls back to the current level; rest are parameterless
+    }
+    (void)options;
 }
 
 void send_vote_from_form(const VoteOptionsData& options)
@@ -1136,54 +1287,9 @@ void do_message_block(PanelUi& ui, const Layout& lo, const std::vector<std::stri
     }
 }
 
-void do_active_vote(PanelUi& ui, const Layout& lo)
-{
-    const auto& state = vote_state_get();
-    if (!state) {
-        return;
-    }
-
-    if (ui.draw) {
-        const int line_h = rf::gr::get_font_height(lo.font) + lo.gap;
-        int y = lo.cy + lo.row_h;
-        set_header_color();
-        rf::gr::string_aligned(rf::gr::ALIGN_CENTER, lo.cx + lo.cw / 2, y,
-            "A VOTE IS ALREADY IN PROGRESS", lo.font);
-        y += line_h * 2;
-
-        const auto title_lines = wrap_text(state->title, lo.cw, lo.font);
-        rf::gr::set_color(255, 255, 255, 255);
-        for (const auto& line : title_lines) {
-            rf::gr::string_aligned(rf::gr::ALIGN_CENTER, lo.cx + lo.cw / 2, y, line.c_str(), lo.font);
-            y += line_h;
-        }
-        y += line_h;
-
-        const std::string tally = std::format("Yes: {}    No: {}    Waiting: {}",
-            static_cast<int>(state->yes), static_cast<int>(state->no),
-            static_cast<int>(state->remaining));
-        rf::gr::set_color(160, 255, 190, 255);
-        rf::gr::string_aligned(rf::gr::ALIGN_CENTER, lo.cx + lo.cw / 2, y, tally.c_str(), lo.font);
-        y += line_h;
-
-        const std::string time_left = std::format("{} seconds remaining", vote_state_seconds_remaining());
-        rf::gr::set_color(215, 215, 215, 255);
-        rf::gr::string_aligned(rf::gr::ALIGN_CENTER, lo.cx + lo.cw / 2, y, time_left.c_str(), lo.font);
-    }
-
-    if (state->is_owner) {
-        const int btn_w = std::min(lo.cw / 2, scaled(200.0f));
-        const Rect cancel{lo.cx + (lo.cw - btn_w) / 2, lo.cy + lo.ch - lo.row_h - lo.gap, btn_w, lo.row_h};
-        if (ui_button(ui, cancel, "CANCEL VOTE", lo.font)) {
-            af_send_vote_cancel();
-            play_click_sound();
-        }
-    }
-}
-
 // Total height of every mutator row plus the option rows of expanded mutators.
-// Must match the advance in do_mutator_rows exactly (every option consumes a row
-// whether or not its type has a widget yet).
+// Must match the advance in do_mutator_rows exactly (rows whose option type has
+// no widget consume nothing -- see option_has_widget).
 int mutator_content_height(const Layout& lo, const VoteOptionsData& options)
 {
     int h = 0;
@@ -1192,7 +1298,11 @@ int mutator_content_height(const Layout& lo, const VoteOptionsData& options)
         if (g_form.mutators[i].enabled) {
             const size_t count =
                 std::min(options.mutators[i].options.size(), g_form.mutators[i].options.size());
-            h += static_cast<int>(count) * lo.row_h;
+            for (size_t o = 0; o < count; ++o) {
+                if (option_has_widget(options.mutators[i].options[o].type)) {
+                    h += lo.row_h;
+                }
+            }
         }
     }
     return h;
@@ -1220,10 +1330,12 @@ void do_mutator_rows(PanelUi& ui, const Layout& lo, const VoteOptionsData& optio
             const Rect row{view.x, y, view.w, lo.row_h};
             if (!ui.draw && ui_hover(ui, row)) {
                 g_form.description_mutator = static_cast<int>(i);
+                g_hovered_mutator_this_pass = true;
             }
             if (ui_checkbox(ui, row, selection.enabled, schema.label.c_str(), lo.font)) {
                 selection.enabled = !selection.enabled;
                 g_form.description_mutator = static_cast<int>(i);
+                g_description_pinned = true;
                 play_toggle_sound(selection.enabled);
             }
         }
@@ -1234,6 +1346,9 @@ void do_mutator_rows(PanelUi& ui, const Layout& lo, const VoteOptionsData& optio
         }
 
         for (size_t o = 0; o < schema.options.size() && o < selection.options.size(); ++o) {
+            if (!option_has_widget(schema.options[o].type)) {
+                continue; // consumes no row (see option_has_widget)
+            }
             if (!row_visible(y)) {
                 y += lo.row_h;
                 continue;
@@ -1293,15 +1408,18 @@ void do_mutator_rows(PanelUi& ui, const Layout& lo, const VoteOptionsData& optio
                         ? std::format("{}", value.int_value)
                         : std::format("{:.2f}", value.float_value);
                     if (ui_button(ui, value_rect, text.c_str(), lo.font)) {
-                        // Indices, not positions, so scrolling can't misdirect the popup.
+                        // Indices, not positions, so scrolling can't misdirect the popup;
+                        // ids so a blob refresh before OK can't either.
                         g_popup_mutator = static_cast<int>(i);
                         g_popup_option = static_cast<int>(o);
+                        g_popup_mutator_id = schema.id;
+                        g_popup_option_id = option.id;
                         rf::ui::popup_message(option.label.c_str(), "", mutator_option_popup_callback, 1);
                     }
                     break;
                 }
                 default:
-                    break; // string options have no widget yet
+                    break; // unreachable: filtered by option_has_widget above
             }
             y += lo.row_h;
         }
@@ -1314,6 +1432,9 @@ void do_mutator_rows(PanelUi& ui, const Layout& lo, const VoteOptionsData& optio
 void do_mutator_scroll_region(PanelUi& ui, const Layout& lo, const VoteOptionsData& options,
                               const Rect& view)
 {
+    if (!ui.draw) {
+        g_hovered_mutator_this_pass = false;
+    }
     const int content_h = mutator_content_height(lo, options);
     const float max_scroll = static_cast<float>(std::max(0, content_h - view.h));
 
@@ -1344,6 +1465,12 @@ void do_mutator_scroll_region(PanelUi& ui, const Layout& lo, const VoteOptionsDa
     }
 
     do_mutator_rows(ui, lo, options, view, start_y);
+
+    // Hovering away clears the description unless the mutator was toggled (a
+    // deliberate click keeps its description pinned).
+    if (!ui.draw && !g_hovered_mutator_this_pass && !g_description_pinned) {
+        g_form.description_mutator = -1;
+    }
 
     if (ui.draw) {
         rf::gr::set_clip(save_x, save_y, save_w, save_h);
@@ -1382,7 +1509,12 @@ void do_level_column(PanelUi& ui, const Layout& lo, const VoteOptionsData& optio
     {
         const int header_w = rf::gr::get_string_size("Level", lo.font).first;
         const int cb_x = col.x + header_w + lo.gap * 2;
-        const Rect cb{cb_x, y - 1, std::max(0, col.x + col.w - cb_x), header_h + 2};
+        // ui_checkbox draws at d.x regardless of width, so a clamped-to-zero
+        // width would leave a visible but unclickable control.
+        const int cb_w = std::max(rf::gr::get_string_size("Filter gametype", lo.font).first
+                + header_h + std::max(3, scaled(5.0f)),
+            col.x + col.w - cb_x);
+        const Rect cb{cb_x, y - 1, cb_w, header_h + 2};
         if (ui_checkbox(ui, cb, options.gametype_prefix_restricted || g_filter_gametype_local,
                 "Filter gametype", lo.font, !options.gametype_prefix_restricted)) {
             g_filter_gametype_local = !g_filter_gametype_local;
@@ -1394,47 +1526,119 @@ void do_level_column(PanelUi& ui, const Layout& lo, const VoteOptionsData& optio
     // Read after the checkbox so a toggle takes effect in the same pass.
     const bool filter_active = options.gametype_prefix_restricted || g_filter_gametype_local;
 
-    // Levels the server would accept with the game type currently selected in the
-    // form. valid_gametype_mask always carries real prefix-match data now, so an
-    // unenforced server can still be filtered locally on request.
-    // Alphabetical rather than the blob's order (rotation order, then extras).
-    std::vector<std::string> levels;
-    levels.reserve(options.levels.size());
-    int hidden_count = 0;
-    for (const auto& level : options.levels) {
-        const bool allowed = !filter_active
-            || (gametype == af_vote_gametype_none
-                ? vote_level_allows_default_gametype(level)
-                : vote_level_allows_gametype(level, gametype));
-        if (allowed) {
+    // Rebuild the display rows only when an input changed. allowed_for_vote is an
+    // INDEPENDENT axis from the gametype mask: it is applied ALWAYS, because a
+    // level the server vote_level allow-list refuses is rejected whatever game
+    // type is picked. Hence it is not gated on filter_active.
+    const uint32_t levels_fp = level_list_fingerprint(options);
+    LevelListCache& cache = g_level_cache;
+    if (!cache.valid || cache.levels_fp != levels_fp || cache.filter_active != filter_active
+        || cache.gametype != gametype || cache.allow_current != allow_current) {
+        cache.levels_fp = levels_fp;
+        cache.filter_active = filter_active;
+        cache.gametype = gametype;
+        cache.allow_current = allow_current;
+        cache.gametype_hidden = 0;
+        cache.not_allowed_hidden = 0;
+        cache.sel_valid = false;
+
+        std::vector<std::string> levels;
+        levels.reserve(options.levels.size());
+        for (const auto& level : options.levels) {
+            if (!level.allowed_for_vote) {
+                ++cache.not_allowed_hidden;
+                continue;
+            }
+            if (filter_active) {
+                const bool matches = gametype == af_vote_gametype_none
+                    ? vote_level_allows_default_gametype(level)
+                    : vote_level_allows_gametype(level, gametype);
+                if (!matches) {
+                    ++cache.gametype_hidden;
+                    continue;
+                }
+            }
             levels.push_back(level.filename);
         }
-        else {
-            ++hidden_count;
-        }
-    }
-    std::sort(levels.begin(), levels.end(), level_name_less);
 
-    // A game type change can hide the selected map; drop the selection so it can
-    // never be sent. Match then falls back to the pinned "Current level" row.
+        // Alphabetical rather than the blob order (rotation order, then extras).
+        std::sort(levels.begin(), levels.end(), level_name_less);
+        // The blob can list the same file twice (rotation entry + vote-allowed
+        // extra); two identical rows would both resolve to the first by name.
+        levels.erase(std::unique(levels.begin(), levels.end(),
+                         [](const std::string& a, const std::string& b) {
+                             return !level_name_less(a, b) && !level_name_less(b, a);
+                         }),
+            levels.end());
+
+        cache.items.clear();
+        cache.items.reserve(levels.size() + 1);
+        if (allow_current) {
+            // Pinned and always visible; the server adjudicates it at call time.
+            cache.items.emplace_back("Current level");
+        }
+        for (auto& level : levels) {
+            cache.items.push_back(std::move(level));
+        }
+        cache.first_level_row = allow_current ? 1 : 0;
+        cache.valid = true;
+    }
+
+    const int level_row_count = static_cast<int>(cache.items.size()) - cache.first_level_row;
+
+    // A game type change (or a refreshed allow-list) can hide the selected map;
+    // drop the selection so it can never be sent. Match then falls back to the
+    // pinned "Current level" row.
     if (!g_form.level_selection.empty()
-        && std::find(levels.begin(), levels.end(), g_form.level_selection) == levels.end()) {
+        && std::find(cache.items.begin() + cache.first_level_row, cache.items.end(),
+               g_form.level_selection)
+            == cache.items.end()) {
         g_form.level_selection.clear();
+        cache.sel_valid = false;
     }
     // A Level vote has no pinned row, so keep the top entry active by default.
-    if (!allow_current && g_form.level_selection.empty() && !levels.empty()) {
-        g_form.level_selection = levels.front();
+    if (!allow_current && g_form.level_selection.empty() && level_row_count > 0) {
+        g_form.level_selection = cache.items[cache.first_level_row];
+        cache.sel_valid = false;
+    }
+
+    // Resolve the highlighted row from the stored name so it follows the map
+    // through the sort/filter instead of pointing at whatever sits there now.
+    if (!cache.sel_valid || cache.sel_name != g_form.level_selection
+        || cache.sel_manual != g_form.manual_level) {
+        cache.sel_name = g_form.level_selection;
+        cache.sel_manual = g_form.manual_level;
+        cache.sel_row = -1;
+        if (!g_form.manual_level) {
+            if (g_form.level_selection.empty()) {
+                cache.sel_row = allow_current ? 0 : -1;
+            }
+            else {
+                for (size_t i = cache.first_level_row; i < cache.items.size(); ++i) {
+                    if (cache.items[i] == g_form.level_selection) {
+                        cache.sel_row = static_cast<int>(i);
+                        break;
+                    }
+                }
+            }
+        }
+        cache.sel_valid = true;
     }
 
     const int line_h = rf::gr::get_font_height(lo.font) + 1;
-    const bool show_hint = filter_active && hidden_count > 0;
+    // Attribute the hint correctly: a map hidden by the allow-list has nothing to
+    // do with the game type, and changing the game type will not bring it back.
+    const bool show_hint = cache.gametype_hidden > 0 || cache.not_allowed_hidden > 0;
+    const char* hint_text = cache.gametype_hidden > 0
+        ? "Some maps hidden: not valid for this game type"
+        : "Some maps hidden: not on the server vote list";
     const int hint_h = show_hint ? 2 * line_h + lo.gap : 0;
 
     const int manual_rows = 2 * lo.row_h + lo.gap;
     const int list_h = std::max(lo.row_h * 3, col.y + col.h - y - manual_rows - hint_h - lo.gap);
     const Rect list{col.x, y, col.w, list_h};
 
-    if (!allow_current && levels.empty()) {
+    if (!allow_current && level_row_count == 0) {
         // Nothing votable for this game type. Manual entry stays available and
         // unfiltered; CALL VOTE stays inert because the selection is empty.
         if (ui.draw) {
@@ -1444,43 +1648,19 @@ void do_level_column(PanelUi& ui, const Layout& lo, const VoteOptionsData& optio
             hud_rect_border(list.x, list.y, list.w, list.h, 1);
             const int pad = std::max(3, scaled(6.0f));
             draw_wrapped({list.x + pad, list.y + pad, list.w - 2 * pad, list.h - 2 * pad},
-                "No maps available for this game type", lo.font, line_h);
+                cache.gametype_hidden > 0 ? "No maps available for this game type"
+                                          : "No maps available for voting on this server",
+                lo.font, line_h);
         }
     }
     else {
-        std::vector<std::string> items;
-        items.reserve(levels.size() + 1);
-        if (allow_current) {
-            // Pinned and always visible; the server adjudicates it at call time.
-            items.emplace_back("Current level");
-        }
-        for (const auto& level : levels) {
-            items.push_back(level);
-        }
-
-        // Resolve the highlighted row from the stored name so it follows the map
-        // through the sort/filter instead of pointing at whatever sits there now.
-        const int first_level_row = allow_current ? 1 : 0;
-        int sel = -1;
-        if (!g_form.manual_level) {
-            if (g_form.level_selection.empty()) {
-                sel = allow_current ? 0 : -1;
-            }
-            else {
-                for (size_t i = first_level_row; i < items.size(); ++i) {
-                    if (items[i] == g_form.level_selection) {
-                        sel = static_cast<int>(i);
-                        break;
-                    }
-                }
-            }
-        }
-
-        const int clicked = ui_listbox(ui, list, items, sel, g_form.level_scroll, lo.font);
+        const int clicked =
+            ui_listbox(ui, list, cache.items, cache.sel_row, g_form.level_scroll, lo.font);
         if (clicked >= 0) {
             g_form.level_selection =
-                (allow_current && clicked == 0) ? std::string{} : items[clicked];
+                (allow_current && clicked == 0) ? std::string{} : cache.items[clicked];
             g_form.manual_level = false;
+            cache.sel_valid = false;
             play_click_sound();
         }
     }
@@ -1488,8 +1668,7 @@ void do_level_column(PanelUi& ui, const Layout& lo, const VoteOptionsData& optio
 
     if (show_hint) {
         if (ui.draw) {
-            draw_wrapped({col.x, y, col.w, 2 * line_h},
-                "Some maps hidden: not valid for this game type", lo.font, line_h);
+            draw_wrapped({col.x, y, col.w, 2 * line_h}, hint_text, lo.font, line_h);
         }
         y += hint_h;
     }
@@ -1564,17 +1743,23 @@ void do_form(PanelUi& ui, const Layout& lo, const VoteOptionsData& options)
         }
         y += rf::gr::get_font_height(lo.font) + lo.gap;
 
-        const auto candidates = build_kick_candidates();
-        std::vector<std::string> names;
-        names.reserve(candidates.size());
-        for (const auto& candidate : candidates) {
-            names.push_back(candidate.name);
+        // Still re-read every frame (players join and leave while the panel is
+        // open), but once per frame: the hit-test pass refreshes it and the draw
+        // pass that follows in the same frame reuses it.
+        if (!ui.draw) {
+            g_kick_cache = build_kick_candidates();
+            g_kick_names.clear();
+            g_kick_names.reserve(g_kick_cache.size());
+            for (const auto& candidate : g_kick_cache) {
+                g_kick_names.push_back(candidate.name);
+            }
         }
         g_form.kick_index = std::clamp(g_form.kick_index, 0,
-            std::max(0, static_cast<int>(names.size()) - 1));
+            std::max(0, static_cast<int>(g_kick_names.size()) - 1));
 
         const Rect list{lo.cx, y, lo.cw, body_bottom - y};
-        const int clicked = ui_listbox(ui, list, names, g_form.kick_index, g_form.kick_scroll, lo.font);
+        const int clicked =
+            ui_listbox(ui, list, g_kick_names, g_form.kick_index, g_form.kick_scroll, lo.font);
         if (clicked >= 0) {
             g_form.kick_index = clicked;
             play_click_sound();
@@ -1689,7 +1874,8 @@ void vote_panel_do(PanelUi& ui)
         rf::gr::set_color(120, 120, 120, 255);
         hud_rect_border(lo.px, lo.py, lo.pw, lo.ph, std::max(1, scaled(2.0f)));
 
-        // Title.
+        // Title. Always the panel name: a running vote is conveyed by the HUD
+        // notification and by the footer button states, not in here.
         rf::gr::set_color(255, 255, 255, 255);
         rf::gr::string_aligned(rf::gr::ALIGN_CENTER, lo.px + lo.pw / 2, lo.title_y, "CALL VOTE",
             lo.title_font);
@@ -1709,9 +1895,6 @@ void vote_panel_do(PanelUi& ui)
             }
             do_message_block(ui, lo, {"Loading server vote options..."});
             break;
-        case PanelMode::ActiveVote:
-            do_active_vote(ui, lo);
-            break;
         case PanelMode::Form:
             if (options) {
                 do_form(ui, lo, *options);
@@ -1720,22 +1903,45 @@ void vote_panel_do(PanelUi& ui)
     }
 
     // Footer buttons, sized and centred like the spray picker's Cancel button.
-    const int btn_w = std::min(lo.cw / 2 - lo.gap, scaled(240.0f));
     const int btn_h = std::max(lo.row_h, scaled(40.0f));
     const int btn_y = lo.footer_y + (lo.footer_h - btn_h) / 2;
     if (mode == PanelMode::Form) {
-        const Rect call{lo.cx + lo.cw / 2 - btn_w - lo.gap, btn_y, btn_w, btn_h};
-        if (ui_button(ui, call, "CALL VOTE", lo.font) && options) {
+        // Three equal slots across the content width.
+        const int btn_w = std::min((lo.cw - 2 * lo.gap) / 3, scaled(240.0f));
+        const int row_w = 3 * btn_w + 2 * lo.gap;
+        const int row_x = lo.cx + (lo.cw - row_w) / 2;
+
+        const auto& state = vote_state_get();
+        const bool vote_active = state.has_value();
+        // Cannot call one while one runs; can only cancel one you own.
+        const bool can_send =
+            !vote_active && options != nullptr && vote_form_is_sendable(*options);
+        const bool can_cancel = vote_active && state->is_owner;
+
+        const Rect call{row_x, btn_y, btn_w, btn_h};
+        if (ui_button(ui, call, "CALL VOTE", lo.font, can_send) && can_send) {
             send_vote_from_form(*options);
             return;
         }
-        const Rect close{lo.cx + lo.cw / 2 + lo.gap, btn_y, btn_w, btn_h};
+
+        const Rect cancel{row_x + btn_w + lo.gap, btn_y, btn_w, btn_h};
+        if (ui_button(ui, cancel, "CANCEL VOTE", lo.font, can_cancel) && can_cancel) {
+            // Sent immediately: cancelling changes no level, so none of the
+            // deferred-send or gameseq unwind machinery applies. The panel stays
+            // open so a replacement vote can be set up as soon as the server's
+            // end event flips these buttons back.
+            af_send_vote_cancel();
+            play_click_sound();
+        }
+
+        const Rect close{row_x + 2 * (btn_w + lo.gap), btn_y, btn_w, btn_h};
         if (ui_button(ui, close, "CLOSE (Esc)", lo.font)) {
             vote_panel_close();
             play_click_sound();
         }
     }
     else {
+        const int btn_w = std::min(lo.cw / 2 - lo.gap, scaled(240.0f));
         const Rect close{lo.cx + (lo.cw - btn_w) / 2, btn_y, btn_w, btn_h};
         if (ui_button(ui, close, "CLOSE (Esc)", lo.font)) {
             vote_panel_close();
@@ -1770,11 +1976,23 @@ FunHook<void()> multi_menu_init_hook{
                 "CALL VOTE", rf::ui::medium_font_0);
             g_call_vote_button.key = rf::KEY_V;
             g_call_vote_button.on_click = call_vote_button_on_click;
+            // Park it off-screen: the mouse handler runs before the render that
+            // assigns real coords, so at (0,0) the screen corner would hit-test
+            // as CALL VOTE on the first menu frame.
+            g_call_vote_button.x = -10000;
+            g_call_vote_button.y = -10000;
 
             // Append to the stock hit-test array so the button becomes hit-test
             // index 4; the AF dispatch array must use that same index order.
-            AddrCaller{multi_menu_hit_test_array_add}.this_call<int>(
+            const int hit_test_index = AddrCaller{multi_menu_hit_test_array_add}.this_call<int>(
                 reinterpret_cast<void*>(multi_menu_hit_test_array), &g_call_vote_button);
+            if (hit_test_index != call_vote_gadget_index) {
+                // -1 means the capacity-20 array was full; anything else means the
+                // stock button count changed. Either way our index assumption and
+                // the PUSH 5 below would be wrong.
+                xlog::error("vote panel: CALL VOTE hit-test index {} != {}", hit_test_index,
+                    call_vote_gadget_index);
+            }
 
             for (int i = 0; i < 4; ++i) {
                 g_multi_menu_gadgets.items[i] = &stock_multi_menu_button(i);
@@ -1782,6 +2000,10 @@ FunHook<void()> multi_menu_init_hook{
             g_multi_menu_gadgets.items[call_vote_gadget_index] = &g_call_vote_button;
             g_multi_menu_gadgets.count = 5;
             g_call_vote_button_created = true;
+
+            // Only now is items[4] real: the hardcoded PUSH 4 that feeds
+            // get_gadget_from_pos must not count a slot that is still null.
+            AsmWriter{multi_menu_hit_test_count_push}.push(5);
         }
 
         update_call_vote_button_enabled();
@@ -1794,22 +2016,45 @@ FunHook<void()> multi_menu_init_hook{
 
 // The stock helpers walk the button block by raw address, so they cannot see a
 // fifth button living outside it; they are replaced rather than patched.
+// Dispatch index -> on-screen row order. CALL VOTE sits above BACK on screen but
+// after it in the arrays (hit-test order is fixed by the append at index 4, and
+// the mouse handler feeds that index straight into the dispatch array), so the
+// arrays must not be reordered -- the keyboard walk is mapped instead.
+constexpr int visual_order_of_gadget[] = {0, 1, 2, 4, 3};
+
 void multi_menu_nav(int dir)
 {
     const int count = g_multi_menu_gadgets.count;
     if (count <= 0) {
         return;
     }
+    const int order_count = static_cast<int>(std::size(visual_order_of_gadget));
+
+    // Walk in visual order so DOWN always moves down the screen.
+    int visual = 0;
+    if (g_multi_menu_focus_index >= 0 && g_multi_menu_focus_index < order_count) {
+        visual = visual_order_of_gadget[g_multi_menu_focus_index];
+    }
+
     for (int i = 0; i < count; ++i) {
-        g_multi_menu_focus_index += dir;
-        if (g_multi_menu_focus_index >= count) {
-            g_multi_menu_focus_index = 0;
+        visual += dir;
+        if (visual >= count) {
+            visual = 0;
         }
-        else if (g_multi_menu_focus_index < 0) {
-            g_multi_menu_focus_index = count - 1;
+        else if (visual < 0) {
+            visual = count - 1;
         }
-        const rf::ui::Gadget* gadget = g_multi_menu_gadgets.items[g_multi_menu_focus_index];
+        // Map the visual row back to its dispatch slot.
+        int dispatch = visual;
+        for (int slot = 0; slot < order_count && slot < count; ++slot) {
+            if (visual_order_of_gadget[slot] == visual) {
+                dispatch = slot;
+                break;
+            }
+        }
+        const rf::ui::Gadget* gadget = g_multi_menu_gadgets.items[dispatch];
         if (gadget && gadget->enabled) {
+            g_multi_menu_focus_index = dispatch;
             break;
         }
     }
@@ -1834,6 +2079,7 @@ FunHook<void()> multi_menu_mouse_hook{
 CodeInjection multi_menu_render_injection{
     multi_menu_render_button_loop,
     [](auto& regs) {
+        // Same order the keyboard walk uses (see visual_order_of_gadget).
         static const int visual_order[] = {0, 1, 2, call_vote_gadget_index, 3};
 
         update_call_vote_button_enabled();
@@ -2020,6 +2266,37 @@ FunHook<bool(rf::ControlConfig*, rf::ControlConfigAction)> vote_panel_is_control
     },
 };
 
+// The two hooks above are shared with waypoints_utils and bot_main, which both
+// install lazily; match that so single-player and dedicated servers never carry
+// the chain. Installed on the first gameplay overlay open.
+bool g_control_hooks_installed = false;
+
+void ensure_control_hooks_installed()
+{
+    if (g_control_hooks_installed) {
+        return;
+    }
+    vote_panel_check_pressed_hook.install();
+    vote_panel_is_control_down_hook.install();
+    g_control_hooks_installed = true;
+}
+
+// gameseq_process renders an active popup itself, at 0x004342CD, i.e. INSIDE the
+// call this hook wraps -- so anything drawn from the after-frame hook
+// (0x004B2DC2) lands on top of the popup and hides it. Rendering the overlay
+// here instead puts it before the popup render, so a popup is drawn over the
+// panel and stays usable. The dispatcher recurses for transparent states, hence
+// the outermost-level check.
+FunHook<void(int, int)> gameseq_state_do_frame_hook{
+    0x004343C0,
+    [](int state_index, int no_input) {
+        gameseq_state_do_frame_hook.call_target(state_index, no_input);
+        if (state_index == gameseq_stack_top()) {
+            vote_panel_gameplay_render();
+        }
+    },
+};
+
 } // namespace
 
 bool vote_panel_is_open()
@@ -2038,7 +2315,8 @@ void vote_panel_open()
     g_form.description_mutator = -1;
     g_form.mutator_scroll = 0.0f;
     drop_pending_vote(); // a stash from a previous open can never outlive it
-    vote_options_request_if_needed();
+    clear_popup_target();
+    g_level_cache.valid = false; // never show another blob's rows
 }
 
 void vote_panel_close()
@@ -2050,6 +2328,7 @@ void vote_panel_close()
     }
     g_open = false;
     g_context = VotePanelContext::None;
+    clear_popup_target();
 }
 
 void vote_panel_render()
@@ -2129,13 +2408,21 @@ void vote_panel_toggle_gameplay()
         return;
     }
 
+    // Mutually exclusive with the remote server config overlay: both are
+    // full-screen and both read the same non-consuming mouse state.
+    if (g_remote_server_cfg_popup.is_active()) {
+        g_remote_server_cfg_popup.toggle();
+    }
+
+    ensure_control_hooks_installed();
     g_open = true;
     g_context = VotePanelContext::Gameplay;
     g_form.description_mutator = -1;
     g_form.mutator_scroll = 0.0f;
     drop_pending_vote();
+    clear_popup_target();
+    g_level_cache.valid = false; // never show another blob's rows
     gameplay_overlay_apply_mouse(true);
-    vote_options_request_if_needed(); // shared cache, same as the menu path
     rf::snd_play(stock_sound_id::menu_select, 0, 0.0f, 1.0f);
 }
 
@@ -2218,8 +2505,7 @@ void vote_panel_apply_patch()
     mainmenu_do_frame_hook.install();
     gameseq_process_hook.install();
     gameseq_push_state_hook.install();
-    vote_panel_check_pressed_hook.install();
-    vote_panel_is_control_down_hook.install();
+    gameseq_state_do_frame_hook.install();
 
     // Seed the stock entries so the patched array is never empty, even if
     // something touches the menu before multi_menu_init has run.
@@ -2228,8 +2514,6 @@ void vote_panel_apply_patch()
     }
     g_multi_menu_gadgets.count = 4;
 
-    // Hit-test count is hardcoded; our button is index 4.
-    AsmWriter{multi_menu_hit_test_count_push}.push(5);
 
     // Point every read of the (full) stock dispatch array at the AF array.
     for (uintptr_t site : dispatch_array_sites) {

--- a/game_patch/misc/vote_panel.cpp
+++ b/game_patch/misc/vote_panel.cpp
@@ -284,6 +284,7 @@ struct FormState
     std::string manual_level_name;
     int gametype_index = 0; // 0 = server default
     int team_size = 4;
+    int extend_minutes = af_vote_extend_default_minutes;
     std::vector<PanelMutatorSelection> mutators;
     int description_mutator = -1;
 
@@ -846,6 +847,7 @@ void build_form(const VoteOptionsData& options)
     g_form.manual_level_name.clear();
     g_form.gametype_index = 0;
     g_form.team_size = 4;
+    g_form.extend_minutes = af_vote_extend_default_minutes;
     g_form.description_mutator = -1;
     g_form.level_scroll = 0.0f;
     g_form.kick_scroll = 0.0f;
@@ -950,6 +952,22 @@ void manual_level_popup_callback()
     g_form.manual_level_name = buffer;
 }
 
+// Extend's duration entry.
+void extend_minutes_popup_callback()
+{
+    char buffer[32] = "";
+    rf::ui::popup_get_input(buffer, sizeof(buffer));
+    try {
+        g_form.extend_minutes = std::clamp(std::stoi(buffer),
+            static_cast<int>(af_vote_extend_min_minutes),
+            static_cast<int>(af_vote_extend_max_minutes));
+    }
+    catch (const std::exception& e) {
+        // Non-numeric or out of int range: keep whatever was already selected.
+        xlog::info("vote panel: invalid extend duration '{}', reason: {}", buffer, e.what());
+    }
+}
+
 void mutator_option_popup_callback()
 {
     char buffer[32] = "";
@@ -1035,6 +1053,8 @@ bool vote_form_is_sendable(const VoteOptionsData& options)
         }
         case AfVoteType::Level:
             return !selected_level().empty();
+        case AfVoteType::Extend:
+            return true;
         default:
             return true; // Match falls back to the current level; rest are parameterless
     }
@@ -1076,6 +1096,11 @@ void send_vote_from_form(const VoteOptionsData& options)
             params.mutators = build_mutator_inputs(options);
             break;
         }
+        case AfVoteType::Extend:
+            params.extend_minutes = static_cast<uint8_t>(std::clamp(g_form.extend_minutes,
+                static_cast<int>(af_vote_extend_min_minutes),
+                static_cast<int>(af_vote_extend_max_minutes)));
+            break;
         default:
             break; // parameterless
     }
@@ -1577,6 +1602,39 @@ void do_form(PanelUi& ui, const Layout& lo, const VoteOptionsData& options)
         if (clicked >= 0) {
             g_form.kick_index = clicked;
             play_click_sound();
+        }
+        return;
+    }
+
+    if (type == AfVoteType::Extend) {
+        const int font_h = rf::gr::get_font_height(lo.font);
+        const int line_h = font_h + 1;
+
+        if (ui.draw) {
+            set_header_color();
+            rf::gr::string(lo.cx, y, "Duration", lo.font);
+        }
+        y += font_h + lo.gap;
+
+        // Numeric entry.
+        static constexpr const char* minutes_label = "Minutes (1-60)";
+        const int label_w = rf::gr::get_string_size(minutes_label, lo.font).first + lo.gap * 2;
+        const int value_w =
+            std::min(std::max(scaled(96.0f), lo.row_h * 3), std::max(lo.row_h, lo.cw - label_w));
+        if (ui.draw) {
+            draw_label(ui, {lo.cx, y + (lo.row_h - font_h) / 2, label_w, lo.row_h}, minutes_label,
+                lo.font);
+        }
+        const Rect value_rect{lo.cx + label_w, y, value_w, lo.row_h};
+        const std::string value_text = std::format("{}", g_form.extend_minutes);
+        if (ui_button(ui, value_rect, value_text.c_str(), lo.font)) {
+            rf::ui::popup_message("Minutes to extend (1-60):", "", extend_minutes_popup_callback, 1);
+        }
+        y += lo.row_h + lo.gap * 2;
+
+        if (ui.draw) {
+            draw_wrapped({lo.cx, y, lo.cw, std::max(line_h, body_bottom - y)},
+                types[g_form.type_index]->description, lo.font, line_h);
         }
         return;
     }

--- a/game_patch/misc/vote_panel.cpp
+++ b/game_patch/misc/vote_panel.cpp
@@ -1,0 +1,2241 @@
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <format>
+#include <string>
+#include <string_view>
+#include <vector>
+#include <patch_common/AsmWriter.h>
+#include <patch_common/CallHook.h>
+#include <patch_common/CodeInjection.h>
+#include <patch_common/FunHook.h>
+#include <patch_common/MemUtils.h>
+#include <common/utils/list-utils.h>
+#include <xlog/xlog.h>
+#include "vote_panel.h"
+#include "player.h"
+#include "../hud/hud_internal.h"
+#include "../multi/alpine_packets.h"
+#include "../multi/vote_client.h"
+#include "../os/os.h"
+#include "../rf/gameseq.h"
+#include "../rf/gr/gr.h"
+#include "../rf/gr/gr_font.h"
+#include "../rf/input.h"
+#include "../rf/multi.h"
+#include "../rf/player/control_config.h"
+#include "../rf/player/player.h"
+#include "../rf/sound/sound.h"
+#include "../rf/ui.h"
+#include "../sound/sound.h"
+
+namespace
+{
+
+// ---------------------------------------------------------------------------
+// Frozen RF.exe addresses (multiplayer menu internals, verified in 1.20na).
+// The multi menu does not use rf::ui::Container: it keeps its gadgets in two
+// counted arrays, one for mouse hit-testing and one for everything else.
+// ---------------------------------------------------------------------------
+
+constexpr uintptr_t multi_menu_init_addr = 0x00448C20;
+constexpr uintptr_t multi_menu_back_on_click_addr = 0x00448BF0;
+constexpr uintptr_t multi_menu_key_handler_addr = 0x00448F80;
+constexpr uintptr_t multi_menu_key_handler_push_imm = 0x00448F39;
+constexpr uintptr_t multi_menu_mouse_handler_addr = 0x00449180;
+constexpr uintptr_t multi_menu_hit_test_count_push = 0x004491A0;
+constexpr uintptr_t multi_menu_hit_test_array = 0x0063E1F0;
+constexpr uintptr_t multi_menu_hit_test_array_add = 0x00449500;
+constexpr uintptr_t multi_menu_nav_next_addr = 0x004490F0;
+constexpr uintptr_t multi_menu_nav_prev_addr = 0x00449140;
+constexpr uintptr_t multi_menu_render_button_loop = 0x00449476;
+constexpr uintptr_t multi_menu_render_button_loop_end = 0x004494A0;
+constexpr uintptr_t multi_menu_first_button = 0x0063E0E0;
+constexpr int multi_menu_button_stride = 0x44;
+constexpr uintptr_t mainmenu_do_frame_addr = 0x00443780;
+constexpr uintptr_t mainmenu_do_return_addr = 0x00443C90;
+
+// Every read of the (already full) stock dispatch array `MOV ECX, 0x0063E090`.
+// The imm32 lives at site+1. The four init-time add calls are left alone, which
+// leaves the stock array populated but unreferenced.
+constexpr uintptr_t dispatch_array_sites[] = {
+    0x00448EF1, 0x00448F02, 0x00448F15, 0x00448F58, // do_frame
+    0x004491F4, 0x0044920C,                         // mouse handler
+    0x00448FD8, 0x00448FF4, 0x0044908A, 0x004490A4, // key handler
+    0x00448A90, 0x00448AB0,                         // highlight helpers
+};
+
+// Set by mainmenu_init from the gameseq state underneath the menu: non-zero
+// means the menu was opened from inside a running game (it is what disables the
+// stock JOIN GAME / CREATE GAME buttons).
+auto& g_menu_opened_in_game = addr_as_ref<uint8_t>(0x0063C11C);
+auto& g_multi_menu_focus_index = addr_as_ref<int>(0x0063E0A4);
+
+// Layout-compatible with the stock counted gadget arrays: {count, items[]}.
+struct MultiMenuGadgetArray
+{
+    int32_t count;
+    rf::ui::Gadget* items[8];
+};
+
+MultiMenuGadgetArray g_multi_menu_gadgets{};
+rf::ui::Button g_call_vote_button{};
+bool g_call_vote_button_created = false;
+
+// Index in both the AF dispatch array and the stock hit-test array.
+constexpr int call_vote_gadget_index = 4;
+
+// --- gameseq state stack internals (RF.exe 1.20na) -------------------------
+// gameseq_process applies at most ONE deferred change per frame, and the pop
+// branch of gameseq_process_deferred_change (0x00434310) does a bare `idx--`
+// with no lower bound. A pop issued against a stale view of the stack therefore
+// underflows to idx = -1, where the tail returns states[-1] (BSS, reads 0) and
+// the engine sits in state 0 forever -- state 0 has no case in
+// gameseq_init_state (0x004B1AC0) or gameseq_close_state (0x004B1BF0).
+// Worse, gameseq_set_state (0x00434190) with force = 0 is silently DROPPED
+// while a pop is pending, so a pending pop of ours can also swallow the
+// server-driven level change outright.
+constexpr uintptr_t gameseq_state_stack_addr = 0x00630064;
+constexpr uintptr_t gameseq_state_index_addr = 0x005967A4;
+constexpr uintptr_t gameseq_pop_pending_addr = 0x006300EA;
+constexpr uintptr_t gameseq_push_pending_addr = 0x006300EB;
+
+int gameseq_stack_top()
+{
+    return addr_as_ref<int32_t>(gameseq_state_index_addr);
+}
+
+rf::GameState gameseq_state_at(int index)
+{
+    return static_cast<rf::GameState>(
+        addr_as_ref<int32_t>(gameseq_state_stack_addr + index * 4));
+}
+
+// True while any deferred change is queued: the stack we can observe now is not
+// the stack that will be current once it lands, so no pop may be issued.
+bool gameseq_change_pending()
+{
+    return addr_as_ref<uint8_t>(gameseq_pop_pending_addr) != 0
+        || addr_as_ref<uint8_t>(gameseq_push_pending_addr) != 0
+        || static_cast<int>(rf::gameseq_get_pending_state()) != 0;
+}
+
+// What the stock RETURN TO GAME button unwinds into. Limbo counts: the menu can
+// be opened during the between-levels wait and stock returns there too.
+bool is_returnable_bottom_state(rf::GameState state)
+{
+    return state == rf::GS_GAMEPLAY || state == rf::GS_MULTI_LIMBO;
+}
+
+// One-shot, consumed by the next main menu frame. It also expires on its own:
+// if the engine takes over (instantly passed vote -> level change -> limbo) the
+// main menu may never run again, and a flag left set would otherwise fire
+// minutes later and close the ESC menu out from under the player.
+constexpr int64_t auto_return_lifetime_ms = 1000;
+bool g_auto_return_to_game = false;
+int64_t g_auto_return_deadline_ms = 0;
+
+void clear_auto_return()
+{
+    g_auto_return_to_game = false;
+    g_auto_return_deadline_ms = 0;
+}
+
+// --- deferred vote send ----------------------------------------------------
+// The vote call is stashed on click and only sent once the menu unwind has
+// reached a terminal state. gameseq_set_state (0x00434190) silently drops a
+// non-forced transition while a deferred change is queued, so sending on click
+// let the server's reply race our pops: a vote that passes instantly (sole
+// eligible voter) had its enter-limbo transition discarded, leaving the client
+// in GS_GAMEPLAY with no traffic -- the connection-interrupted overlay -- for
+// the whole limbo. Sending only once the slot is free makes that impossible.
+bool g_pending_vote_valid = false;
+AfVoteCallParams g_pending_vote;
+
+void drop_pending_vote()
+{
+    g_pending_vote_valid = false;
+    g_pending_vote = AfVoteCallParams{};
+}
+
+// --- open context -----------------------------------------------------------
+// Which site owns rendering. Exactly one render call happens per frame.
+enum class VotePanelContext
+{
+    None,
+    MultiMenu,
+    Gameplay,
+};
+
+VotePanelContext g_context = VotePanelContext::None;
+
+// Player's local "filter the map list by gametype" choice. Session only, not
+// persisted; ignored (forced on) while the server enforces the prefix.
+bool g_filter_gametype_local = false;
+
+// Gameplay overlay needs the cursor back and mouse-look off; both are restored
+// on every close, including the forced ones (level change, disconnect).
+bool g_gameplay_mouse_overridden = false;
+bool g_gameplay_prev_mouse_look = false;
+
+// RF latches mouse presses in a per-frame counter (0x018853D4) that
+// control_config_check_pressed reads WITHOUT consuming (0x0051E590 / 0x0051E5D0
+// are plain reads), while control_is_control_down polls live button state. Our
+// attack suppression keys on the panel being open, so the click that dismissed
+// the panel was still pending for the remainder of that same frame and fired the
+// weapon once gameplay polled its controls later in the frame.
+// Armed on every gameplay-context close and held until a later frame sees every
+// button released, so it covers a click-and-hold and a press+release inside one
+// frame alike. Counts frames rather than latching a bool so it cannot stick.
+int g_swallow_attack_frames = 0;
+
+// A stock popup (manual level name, int/float option) takes over input while it
+// is up. gameseq_process passes no_input=1 to the state's own frame, but our
+// gameplay pump runs outside that, so it has to check explicitly.
+bool stock_popup_is_active()
+{
+    return addr_as_ref<bool()>(0x00456680)();
+}
+
+// Only attacks are affected; movement is never blocked.
+void vote_panel_decay_attack_swallow()
+{
+    if (g_swallow_attack_frames <= 0) {
+        return;
+    }
+    if (rf::mouse_button_is_down(0) || rf::mouse_button_is_down(1)) {
+        return; // still held: keep swallowing
+    }
+    --g_swallow_attack_frames;
+}
+
+void gameplay_overlay_apply_mouse(bool active)
+{
+    rf::Player* const player = rf::local_player;
+
+    if (active) {
+        if (player && !g_gameplay_mouse_overridden) {
+            g_gameplay_prev_mouse_look = player->settings.controls.mouse_look;
+            g_gameplay_mouse_overridden = true;
+        }
+        if (player) {
+            player->settings.controls.mouse_look = false;
+        }
+        if (rf::keep_mouse_centered) {
+            rf::mouse_keep_centered_disable();
+        }
+        rf::mouse_set_visible(true);
+        return;
+    }
+
+    if (player && g_gameplay_mouse_overridden) {
+        player->settings.controls.mouse_look = g_gameplay_prev_mouse_look;
+    }
+    g_gameplay_mouse_overridden = false;
+    // Only re-grab the cursor if we are actually still in gameplay; on a level
+    // change the engine owns the mouse mode.
+    if (rf::gameseq_get_state() == rf::GS_GAMEPLAY && !rf::keep_mouse_centered) {
+        rf::mouse_keep_centered_enable();
+        rf::mouse_set_visible(false);
+    }
+}
+
+rf::ui::Button& stock_multi_menu_button(int index)
+{
+    return addr_as_ref<rf::ui::Button>(multi_menu_first_button + index * multi_menu_button_stride);
+}
+
+// ---------------------------------------------------------------------------
+// Mutator descriptions (client-local, keyed by the canonical name the server
+// sends in the vote-options blob).
+// ---------------------------------------------------------------------------
+
+struct MutatorDescription
+{
+    const char* name;
+    const char* text;
+};
+
+// Kept short enough to wrap into the description area's three lines; verified
+// against rfpc-medium.vf metrics at the panel's reference scale.
+const MutatorDescription mutator_descriptions[] = {
+    {"instagib",
+     "Everyone spawns with the Rail Driver only, and one hit kills. Unlimited ammo, no reloading, "
+     "no weapon switching, no item pickups."},
+    {"rails",
+     "Spawn with only the Riot Stick. All weapon and ammo pickups become the featured weapon and "
+     "never despawn. Other items are hidden."},
+    {"arena",
+     "Spawn with 100 health and 100 armor, a Riot Stick and an Assault Rifle. Each frag refills "
+     "your health, armor and ammo. Weapon pickups only."},
+};
+
+const char* mutator_description_for(std::string_view name)
+{
+    for (const auto& entry : mutator_descriptions) {
+        if (name == entry.name) {
+            return entry.text;
+        }
+    }
+    return "No description available.";
+}
+
+// ---------------------------------------------------------------------------
+// Vote types
+// ---------------------------------------------------------------------------
+
+struct VoteTypeInfo
+{
+    AfVoteType type;
+    const char* label;
+    const char* description;
+};
+
+// Display order for the vote type buttons (user-specified); enabled_vote_types()
+// preserves it and the sequence flows up to fill gaps left by disabled types.
+const VoteTypeInfo vote_type_infos[] = {
+    {AfVoteType::Level, "Level", "Load a specific level, optionally with a game type and mutators."},
+    {AfVoteType::Restart, "Restart", "Restart the level that is currently loaded."},
+    {AfVoteType::Next, "Next", "Load the next level in the server's rotation."},
+    {AfVoteType::Previous, "Previous", "Load the previous level in the server's rotation."},
+    {AfVoteType::Random, "Random", "Load a random level from the server's rotation."},
+    {AfVoteType::Extend, "Extend", "Extend the time limit of the round in progress."},
+    {AfVoteType::Match, "Match", "Set up a match on the chosen level with the chosen team size."},
+    {AfVoteType::CancelMatch, "Cancel Match", "Cancel the match that is currently set up."},
+    {AfVoteType::Kick, "Kick", "Kick the selected player from the server."},
+};
+
+// Short tag for the game type selector. The blob carries full display names
+// ("Damage Control") which overflow the selector at menu-native resolutions.
+// Deliberately not multi_game_type_name_short(): that maps every unrecognised id
+// to "TDM" and logs a warning, whereas a game type this build predates has to
+// fall back to the server-sent name.
+const char* gametype_short_name(uint8_t id)
+{
+    switch (static_cast<rf::NetGameType>(id)) {
+        case rf::NG_TYPE_DM: return "DM";
+        case rf::NG_TYPE_CTF: return "CTF";
+        case rf::NG_TYPE_TEAMDM: return "TDM";
+        case rf::NG_TYPE_KOTH: return "KOTH";
+        case rf::NG_TYPE_DC: return "DC";
+        case rf::NG_TYPE_REV: return "REV";
+        case rf::NG_TYPE_RUN: return "RUN";
+        case rf::NG_TYPE_ESC: return "ESC";
+        case rf::NG_TYPE_BAG: return "BAG";
+        case rf::NG_TYPE_TBAG: return "TBAG";
+        case rf::NG_TYPE_PIT: return "PIT";
+        case rf::NG_TYPE_WO: return "WO";
+        case rf::NG_TYPE_GG: return "GG";
+        default: return nullptr; // unknown to this build
+    }
+}
+
+std::vector<const VoteTypeInfo*> enabled_vote_types()
+{
+    std::vector<const VoteTypeInfo*> out;
+    for (const auto& info : vote_type_infos) {
+        if (vote_options_is_type_enabled(info.type)) {
+            out.push_back(&info);
+        }
+    }
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Panel state
+// ---------------------------------------------------------------------------
+
+struct PanelOptionValue
+{
+    bool bool_value = false;
+    uint8_t choice_index = 0;
+    int32_t int_value = 0;
+    float float_value = 0.0f;
+};
+
+struct PanelMutatorSelection
+{
+    bool enabled = false;
+    std::vector<PanelOptionValue> options;
+};
+
+struct FormState
+{
+    bool built = false;
+    size_t built_gametypes = 0;
+    size_t built_mutators = 0;
+    size_t built_levels = 0;
+
+    int type_index = 0;
+    int kick_index = 0;
+    std::string level_selection; // level NAME; empty = the "Current level" row
+    bool manual_level = false;
+    std::string manual_level_name;
+    int gametype_index = 0; // 0 = server default
+    int team_size = 4;
+    std::vector<PanelMutatorSelection> mutators;
+    int description_mutator = -1;
+
+    float level_scroll = 0.0f;
+    float kick_scroll = 0.0f;
+    float mutator_scroll = 0.0f;
+};
+
+struct KickCandidate
+{
+    uint8_t id = 0xFF;
+    std::string name;
+};
+
+bool g_open = false;
+FormState g_form;
+
+// Popup input targets. The stock popup callback takes no arguments, so the
+// widget that opened it has to be remembered here.
+int g_popup_mutator = -1;
+int g_popup_option = -1;
+
+enum class PanelMode
+{
+    NotSupported,
+    Loading,
+    ActiveVote,
+    Form,
+};
+
+// ---------------------------------------------------------------------------
+// Immediate-mode widget helpers. `vote_panel_do` runs twice per frame: once
+// from the mouse handler (draw = false, hit-testing only) and once from the
+// render injection (draw = true), so layout only exists in one place.
+// ---------------------------------------------------------------------------
+
+struct Rect
+{
+    int x = 0;
+    int y = 0;
+    int w = 0;
+    int h = 0;
+};
+
+struct PanelUi
+{
+    bool draw = true;
+    int mx = 0;
+    int my = 0;
+    bool click = false;
+    bool rclick = false; // right-click; only the cyclers act on it
+    int wheel = 0;
+
+    // Active scroll viewport. Widgets are always laid out in absolute screen
+    // space; inside a region the draw pass subtracts the clip origin (set_clip
+    // moves the drawing origin) while hit-testing stays absolute but is gated on
+    // the viewport, so rows scrolled out of sight are not clickable.
+    Rect clip_rect;
+    bool clip_active = false;
+    int origin_x = 0;
+    int origin_y = 0;
+};
+
+struct Layout
+{
+    float scale = 1.0f;
+    int px = 0, py = 0, pw = 0, ph = 0; // panel rect
+    int cx = 0, cy = 0, cw = 0, ch = 0; // content rect (below title, above footer)
+    int title_y = 0;
+    int footer_y = 0;
+    int footer_h = 0;
+    int row_h = 0;
+    int gap = 0;
+    int font = 0;
+    int title_font = 0;
+};
+
+// Panel layout reference size, matching spray_picker.cpp.
+constexpr float REF_WIDTH = 1280.0f;
+constexpr float REF_HEIGHT = 800.0f;
+
+// Uniform panel scale, shared with the widget helpers that only get a Rect.
+float g_panel_scale = 1.0f;
+
+int scaled(float value)
+{
+    return static_cast<int>(value * g_panel_scale);
+}
+
+bool point_in(int px, int py, const Rect& r)
+{
+    return px >= r.x && px < r.x + r.w && py >= r.y && py < r.y + r.h;
+}
+
+// Hover test honouring the active scroll viewport.
+bool ui_hover(const PanelUi& ui, const Rect& r)
+{
+    if (ui.clip_active && !point_in(ui.mx, ui.my, ui.clip_rect)) {
+        return false;
+    }
+    return point_in(ui.mx, ui.my, r);
+}
+
+// Absolute rect -> coordinates to draw at under the active clip window.
+Rect ui_draw_rect(const PanelUi& ui, const Rect& r)
+{
+    return Rect{r.x - ui.origin_x, r.y - ui.origin_y, r.w, r.h};
+}
+
+Layout compute_layout()
+{
+    Layout lo;
+    const int clip_w = rf::gr::clip_width();
+    const int clip_h = rf::gr::clip_height();
+    lo.scale = std::min(clip_w / REF_WIDTH, clip_h / REF_HEIGHT);
+    g_panel_scale = lo.scale;
+
+    // Compact panel that leaves a clear margin at every resolution.
+    lo.pw = std::min(scaled(880.0f), clip_w - 80);
+    lo.ph = std::min(scaled(600.0f), clip_h - 80);
+    lo.px = (clip_w - lo.pw) / 2;
+    lo.py = (clip_h - lo.ph) / 2;
+
+    lo.font = rf::ui::medium_font_0;
+    lo.title_font = rf::ui::medium_font_0;
+
+    const int pad = scaled(16.0f);
+    const int title_h = scaled(46.0f);
+
+    lo.gap = std::max(3, scaled(8.0f));
+    lo.row_h = std::max(rf::gr::get_font_height(lo.font) + 4, scaled(24.0f));
+
+    lo.title_y = lo.py + scaled(14.0f);
+    lo.footer_h = scaled(58.0f);
+    lo.footer_y = lo.py + lo.ph - lo.footer_h;
+
+    lo.cx = lo.px + pad;
+    lo.cw = lo.pw - 2 * pad;
+    lo.cy = lo.py + title_h;
+    lo.ch = lo.footer_y - lo.cy;
+    if (lo.ch < lo.row_h) {
+        lo.ch = lo.row_h;
+    }
+    return lo;
+}
+
+// Colour conventions on the dark panel: gold for section headers, white for
+// widget labels, light grey for secondary/explanatory text.
+void set_header_color()
+{
+    rf::gr::set_color(255, 215, 0, 255);
+}
+
+void set_text_color(bool enabled, bool hovered)
+{
+    if (!enabled) {
+        rf::gr::set_color(130, 130, 130, 255);
+    }
+    else if (hovered) {
+        rf::gr::set_color(255, 255, 255, 255);
+    }
+    else {
+        rf::gr::set_color(230, 230, 230, 255);
+    }
+}
+
+void draw_label(const PanelUi& ui, const Rect& r, const char* text, int font,
+                bool secondary = false)
+{
+    if (secondary) {
+        rf::gr::set_color(210, 210, 210, 255);
+    }
+    else {
+        rf::gr::set_color(255, 255, 255, 255);
+    }
+    const Rect d = ui_draw_rect(ui, r);
+    rf::gr::string(d.x, d.y, text, font);
+}
+
+// A flat clickable box. Returns true only in the hit-test pass, on a click.
+bool ui_button(PanelUi& ui, const Rect& r, const char* text, int font, bool enabled = true,
+               bool active = false)
+{
+    const bool hovered = enabled && ui_hover(ui, r);
+    if (ui.draw) {
+        const Rect d = ui_draw_rect(ui, r);
+        // Active reuses the green the listbox selection and checkbox ticks use.
+        if (active) {
+            rf::gr::set_color(hovered ? 50 : 35, hovered ? 115 : 90, hovered ? 80 : 60, 255);
+        }
+        else {
+            rf::gr::set_color(hovered ? 70 : 45, hovered ? 70 : 45, hovered ? 70 : 45, 255);
+        }
+        rf::gr::rect(d.x, d.y, d.w, d.h);
+        if (active) {
+            rf::gr::set_color(120, 230, 120, 255);
+        }
+        else {
+            rf::gr::set_color(enabled ? 150 : 100, enabled ? 150 : 100, enabled ? 150 : 100, 255);
+        }
+        hud_rect_border(d.x, d.y, d.w, d.h, 1);
+        if (active) {
+            rf::gr::set_color(255, 255, 255, 255);
+        }
+        else {
+            set_text_color(enabled, hovered);
+        }
+        rf::gr::string_aligned(rf::gr::ALIGN_CENTER, d.x + d.w / 2,
+            d.y + (d.h - rf::gr::get_font_height(font)) / 2, text, font);
+        return false;
+    }
+    return hovered && ui.click;
+}
+
+bool ui_checkbox(PanelUi& ui, const Rect& r, bool checked, const char* text, int font,
+                 bool enabled = true)
+{
+    const bool hovered = enabled && ui_hover(ui, r);
+    if (ui.draw) {
+        const Rect d = ui_draw_rect(ui, r);
+        const int box = std::min(d.h - 2, rf::gr::get_font_height(font));
+        const int by = d.y + (d.h - box) / 2;
+        rf::gr::set_color(hovered ? 70 : 45, hovered ? 70 : 45, hovered ? 70 : 45, 255);
+        rf::gr::rect(d.x, by, box, box);
+        rf::gr::set_color(enabled ? 170 : 100, enabled ? 170 : 100, enabled ? 170 : 100, 255);
+        hud_rect_border(d.x, by, box, box, 1);
+        if (checked) {
+            // Muted tick for a pinned/non-interactive checkbox.
+            if (enabled) {
+                rf::gr::set_color(120, 230, 120, 255);
+            }
+            else {
+                rf::gr::set_color(85, 135, 85, 255);
+            }
+            rf::gr::rect(d.x + 2, by + 2, box - 4, box - 4);
+        }
+        set_text_color(enabled, hovered);
+        rf::gr::string(d.x + box + std::max(3, scaled(5.0f)),
+            d.y + (d.h - rf::gr::get_font_height(font)) / 2, text, font);
+        return false;
+    }
+    return hovered && ui.click;
+}
+
+int ui_cycler_arrow_width()
+{
+    return std::max(10, scaled(16.0f));
+}
+
+// Space the cycler has for its value text, between the two arrows.
+int ui_cycler_value_width(const Rect& r)
+{
+    return std::max(0, r.w - 2 * ui_cycler_arrow_width());
+}
+
+// Middle-truncate so both ends of a long name stay readable.
+std::string fit_middle(std::string_view text, int max_w, int font)
+{
+    if (text.empty() || rf::gr::get_string_size(text, font).first <= max_w) {
+        return std::string{text};
+    }
+    for (size_t keep = text.size(); keep > 0; --keep) {
+        const size_t left = (keep + 1) / 2;
+        const size_t right = keep - left;
+        std::string candidate{text.substr(0, left)};
+        candidate += "...";
+        candidate += std::string{text.substr(text.size() - right, right)};
+        if (rf::gr::get_string_size(candidate, font).first <= max_w) {
+            return candidate;
+        }
+    }
+    return std::string{"..."};
+}
+
+// Fake cycler: "< value >" with clickable arrows. Returns -1, 0 or +1.
+int ui_cycler(PanelUi& ui, const Rect& r, const char* value, int font)
+{
+    const int arrow_w = ui_cycler_arrow_width();
+    const Rect left{r.x, r.y, arrow_w, r.h};
+    const Rect right{r.x + r.w - arrow_w, r.y, arrow_w, r.h};
+    const Rect middle{r.x + arrow_w, r.y, r.w - 2 * arrow_w, r.h};
+
+    const bool hover_left = ui_hover(ui, left);
+    const bool hover_right = ui_hover(ui, right);
+    const bool hover_mid = ui_hover(ui, middle);
+
+    if (ui.draw) {
+        const Rect d = ui_draw_rect(ui, r);
+        const Rect dl = ui_draw_rect(ui, left);
+        const Rect dr = ui_draw_rect(ui, right);
+        const Rect dm = ui_draw_rect(ui, middle);
+
+        rf::gr::set_color(hover_mid ? 70 : 45, hover_mid ? 70 : 45, hover_mid ? 70 : 45, 255);
+        rf::gr::rect(d.x, d.y, d.w, d.h);
+        rf::gr::set_color(150, 150, 150, 255);
+        hud_rect_border(d.x, d.y, d.w, d.h, 1);
+
+        const int text_y = d.y + (d.h - rf::gr::get_font_height(font)) / 2;
+        set_text_color(true, hover_left);
+        rf::gr::string_aligned(rf::gr::ALIGN_CENTER, dl.x + dl.w / 2, text_y, "<", font);
+        set_text_color(true, hover_right);
+        rf::gr::string_aligned(rf::gr::ALIGN_CENTER, dr.x + dr.w / 2, text_y, ">", font);
+
+        set_text_color(true, hover_mid);
+        if (ui.clip_active) {
+            // Already inside a scroll region's clip window, and set_clip replaces
+            // rather than nests, so rely on that clip plus the caller's
+            // fit_middle() sizing instead of narrowing to the value box here.
+            rf::gr::string_aligned(rf::gr::ALIGN_CENTER, dm.x + dm.w / 2,
+                dm.y + (dm.h - rf::gr::get_font_height(font)) / 2, value, font);
+        }
+        else {
+            int save_x = 0, save_y = 0, save_w = 0, save_h = 0;
+            rf::gr::get_clip(&save_x, &save_y, &save_w, &save_h);
+            rf::gr::set_clip(dm.x, dm.y, dm.w, dm.h);
+            // set_clip moved the drawing origin, so draw relative to the clip window.
+            rf::gr::string_aligned(rf::gr::ALIGN_CENTER, dm.w / 2,
+                (dm.h - rf::gr::get_font_height(font)) / 2, value, font);
+            rf::gr::set_clip(save_x, save_y, save_w, save_h);
+        }
+        return 0;
+    }
+
+    // Right-click anywhere on the widget steps backwards, so a value can be
+    // walked either way without aiming for the small left arrow.
+    if (ui.rclick && (hover_left || hover_right || hover_mid)) {
+        return -1;
+    }
+    if (!ui.click) {
+        return 0;
+    }
+    if (hover_left) {
+        return -1;
+    }
+    if (hover_right || hover_mid) {
+        return 1;
+    }
+    return 0;
+}
+
+// Scrolling list. Returns the clicked index in the hit-test pass, else -1.
+int ui_listbox(PanelUi& ui, const Rect& r, const std::vector<std::string>& items, int sel,
+               float& scroll, int font)
+{
+    const int row_h = rf::gr::get_font_height(font) + 2;
+    const int total_h = static_cast<int>(items.size()) * row_h;
+    const float max_scroll = static_cast<float>(std::max(0, total_h - r.h));
+    const bool inside = point_in(ui.mx, ui.my, r);
+
+    if (!ui.draw && inside && ui.wheel != 0) {
+        scroll += (ui.wheel > 0 ? -1.0f : 1.0f) * static_cast<float>(row_h * 3);
+    }
+    scroll = std::clamp(scroll, 0.0f, max_scroll);
+
+    if (!ui.draw) {
+        if (inside && ui.click) {
+            const int index = (ui.my - r.y + static_cast<int>(scroll)) / row_h;
+            if (index >= 0 && index < static_cast<int>(items.size())) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    rf::gr::set_color(8, 8, 8, 235);
+    rf::gr::rect(r.x, r.y, r.w, r.h);
+    rf::gr::set_color(120, 120, 120, 255);
+    hud_rect_border(r.x, r.y, r.w, r.h, 1);
+
+    int save_x = 0, save_y = 0, save_w = 0, save_h = 0;
+    rf::gr::get_clip(&save_x, &save_y, &save_w, &save_h);
+    rf::gr::set_clip(r.x, r.y, r.w, r.h);
+    for (int i = 0; i < static_cast<int>(items.size()); ++i) {
+        const int iy = r.y + i * row_h - static_cast<int>(scroll);
+        if (iy + row_h < r.y || iy > r.y + r.h) {
+            continue;
+        }
+        // Drawing coords are relative to the clip window origin.
+        const int dy = iy - r.y;
+        const bool hovered = inside && ui.my >= iy && ui.my < iy + row_h;
+        if (i == sel) {
+            rf::gr::set_color(35, 90, 60, 255);
+            rf::gr::rect(0, dy, r.w, row_h);
+        }
+        else if (hovered) {
+            rf::gr::set_color(70, 70, 70, 255);
+            rf::gr::rect(0, dy, r.w, row_h);
+        }
+        if (i == sel) {
+            rf::gr::set_color(160, 255, 190, 255);
+        }
+        else {
+            rf::gr::set_color(hovered ? 255 : 230, hovered ? 255 : 230, hovered ? 255 : 230, 255);
+        }
+        rf::gr::string(3, dy + 1, items[i].c_str(), font);
+    }
+    rf::gr::set_clip(save_x, save_y, save_w, save_h);
+
+    if (max_scroll > 0.0f) {
+        const float ratio = scroll / max_scroll;
+        const int bar_w = std::max(3, scaled(6.0f));
+        const int bar_h = std::max(bar_w, r.h * r.h / std::max(1, total_h));
+        const int bar_y = r.y + static_cast<int>(ratio * (r.h - bar_h));
+        rf::gr::set_color(100, 255, 200, 255);
+        rf::gr::rect(r.x + r.w - bar_w, bar_y, bar_w, bar_h);
+    }
+    return -1;
+}
+
+std::vector<std::string> wrap_text(std::string_view text, int max_w, int font)
+{
+    std::vector<std::string> lines;
+    std::string current;
+    size_t pos = 0;
+    while (pos <= text.size()) {
+        const size_t space = text.find(' ', pos);
+        const std::string_view word = text.substr(pos, space == std::string_view::npos ? std::string_view::npos
+                                                                                       : space - pos);
+        std::string candidate = current.empty() ? std::string{word} : current + " " + std::string{word};
+        if (!current.empty() && rf::gr::get_string_size(candidate, font).first > max_w) {
+            lines.push_back(current);
+            current = std::string{word};
+        }
+        else {
+            current = std::move(candidate);
+        }
+        if (space == std::string_view::npos) {
+            break;
+        }
+        pos = space + 1;
+    }
+    if (!current.empty()) {
+        lines.push_back(current);
+    }
+    return lines;
+}
+
+void draw_wrapped(const Rect& r, std::string_view text, int font, int line_h)
+{
+    const int max_lines = std::max(1, r.h / line_h);
+    auto lines = wrap_text(text, r.w, font);
+    if (static_cast<int>(lines.size()) > max_lines) {
+        // Mark the cut so an over-long paragraph never just stops mid-sentence.
+        lines.resize(max_lines);
+        std::string& last = lines.back();
+        while (!last.empty() && rf::gr::get_string_size(last + "...", font).first > r.w) {
+            last.pop_back();
+        }
+        last += "...";
+    }
+
+    int y = r.y;
+    rf::gr::set_color(215, 215, 215, 255);
+    for (const auto& line : lines) {
+        rf::gr::string(r.x, y, line.c_str(), font);
+        y += line_h;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Data helpers
+// ---------------------------------------------------------------------------
+
+std::vector<KickCandidate> build_kick_candidates()
+{
+    // Re-read every frame: players join and leave while the panel is open.
+    std::vector<KickCandidate> out;
+    if (!rf::player_list) {
+        return out;
+    }
+    for (rf::Player& player : SinglyLinkedList{rf::player_list}) {
+        if (&player == rf::local_player || !player.net_data) {
+            continue;
+        }
+        KickCandidate candidate;
+        candidate.id = player.net_data->player_id;
+        candidate.name = player.name.c_str();
+        out.push_back(std::move(candidate));
+    }
+    return out;
+}
+
+// Game types offered for the current vote type. Match votes need a team type.
+std::vector<const VoteGametypeInfo*> selectable_gametypes(const VoteOptionsData& options, bool team_only)
+{
+    std::vector<const VoteGametypeInfo*> out;
+    for (const auto& gametype : options.gametypes) {
+        if (team_only && !gametype.is_team_type) {
+            continue;
+        }
+        out.push_back(&gametype);
+    }
+    return out;
+}
+
+void build_form(const VoteOptionsData& options)
+{
+    g_form.built = true;
+    g_form.built_gametypes = options.gametypes.size();
+    g_form.built_mutators = options.mutators.size();
+    g_form.built_levels = options.levels.size();
+
+    g_form.type_index = 0;
+    g_form.kick_index = 0;
+    g_form.level_selection.clear();
+    g_form.manual_level = false;
+    g_form.manual_level_name.clear();
+    g_form.gametype_index = 0;
+    g_form.team_size = 4;
+    g_form.description_mutator = -1;
+    g_form.level_scroll = 0.0f;
+    g_form.kick_scroll = 0.0f;
+    g_form.mutator_scroll = 0.0f;
+
+    g_form.mutators.clear();
+    g_form.mutators.reserve(options.mutators.size());
+    for (const auto& mutator : options.mutators) {
+        PanelMutatorSelection selection;
+        selection.options.reserve(mutator.options.size());
+        for (const auto& option : mutator.options) {
+            PanelOptionValue value;
+            value.bool_value = option.default_bool;
+            value.choice_index = option.default_choice;
+            value.int_value = option.default_int;
+            value.float_value = option.default_float;
+            selection.options.push_back(value);
+        }
+        g_form.mutators.push_back(std::move(selection));
+    }
+}
+
+void ensure_form(const VoteOptionsData& options)
+{
+    if (!g_form.built || g_form.built_gametypes != options.gametypes.size()
+        || g_form.built_mutators != options.mutators.size()
+        || g_form.built_levels != options.levels.size()) {
+        build_form(options);
+    }
+}
+
+// The level string sent on the wire. `allow_current` (Match) maps the leading
+// "Current level" row to the empty string the server reads as "keep the level".
+// Case-insensitive ordering for the level list.
+bool level_name_less(const std::string& a, const std::string& b)
+{
+    return std::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end(),
+        [](unsigned char l, unsigned char r) { return std::tolower(l) < std::tolower(r); });
+}
+
+std::string selected_level()
+{
+    if (g_form.manual_level) {
+        return g_form.manual_level_name;
+    }
+    // Stored by name, so the display sort (and any blob refresh) cannot desync
+    // it. Empty is exactly what the wire wants for Match's "current level".
+    return g_form.level_selection;
+}
+
+uint8_t selected_gametype(const VoteOptionsData& options, bool team_only)
+{
+    if (g_form.gametype_index <= 0) {
+        return af_vote_gametype_none;
+    }
+    const auto gametypes = selectable_gametypes(options, team_only);
+    const int index = g_form.gametype_index - 1;
+    if (index < 0 || index >= static_cast<int>(gametypes.size())) {
+        return af_vote_gametype_none;
+    }
+    return gametypes[index]->id;
+}
+
+std::vector<VoteMutatorInput> build_mutator_inputs(const VoteOptionsData& options)
+{
+    std::vector<VoteMutatorInput> out;
+    for (size_t i = 0; i < options.mutators.size() && i < g_form.mutators.size(); ++i) {
+        if (!g_form.mutators[i].enabled) {
+            continue;
+        }
+        const VoteMutatorSchema& schema = options.mutators[i];
+        VoteMutatorInput input;
+        input.mutator_id = schema.id;
+        for (size_t o = 0; o < schema.options.size() && o < g_form.mutators[i].options.size(); ++o) {
+            const VoteMutatorOptionSchema& option = schema.options[o];
+            const PanelOptionValue& value = g_form.mutators[i].options[o];
+            VoteMutatorOptionInput option_input;
+            option_input.option_id = option.id;
+            option_input.type = option.type;
+            option_input.bool_value = value.bool_value;
+            option_input.choice_index = value.choice_index;
+            option_input.int_value = value.int_value;
+            option_input.float_value = value.float_value;
+            input.options.push_back(std::move(option_input));
+        }
+        out.push_back(std::move(input));
+    }
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Popup text input (stock RF popup; gameseq_process drives it globally, so it
+// works from the multi menu and suppresses our input handlers while it is up)
+// ---------------------------------------------------------------------------
+
+void manual_level_popup_callback()
+{
+    char buffer[32] = "";
+    rf::ui::popup_get_input(buffer, sizeof(buffer));
+    g_form.manual_level_name = buffer;
+}
+
+void mutator_option_popup_callback()
+{
+    char buffer[32] = "";
+    rf::ui::popup_get_input(buffer, sizeof(buffer));
+
+    const VoteOptionsData* options = vote_options_get();
+    if (!options || g_popup_mutator < 0 || g_popup_option < 0) {
+        return;
+    }
+    if (g_popup_mutator >= static_cast<int>(options->mutators.size())
+        || g_popup_mutator >= static_cast<int>(g_form.mutators.size())) {
+        return;
+    }
+    const auto& schema = options->mutators[g_popup_mutator];
+    if (g_popup_option >= static_cast<int>(schema.options.size())
+        || g_popup_option >= static_cast<int>(g_form.mutators[g_popup_mutator].options.size())) {
+        return;
+    }
+
+    PanelOptionValue& value = g_form.mutators[g_popup_mutator].options[g_popup_option];
+    try {
+        if (schema.options[g_popup_option].type == MutatorOptionType::Int) {
+            value.int_value = std::stoi(buffer);
+        }
+        else {
+            value.float_value = std::stof(buffer);
+        }
+    }
+    catch (const std::exception& e) {
+        xlog::info("vote panel: invalid option input '{}', reason: {}", buffer, e.what());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Panel content
+// ---------------------------------------------------------------------------
+
+PanelMode compute_mode()
+{
+    if (!is_server_minimum_af_version(1, 4)) {
+        return PanelMode::NotSupported;
+    }
+    if (vote_state_get().has_value()) {
+        return PanelMode::ActiveVote;
+    }
+    if (!vote_options_are_loaded()) {
+        return PanelMode::Loading;
+    }
+    return PanelMode::Form;
+}
+
+void play_click_sound()
+{
+    rf::snd_play(stock_sound_id::panel_button_click, 0, 0.0f, 1.0f);
+}
+
+void play_toggle_sound(bool on)
+{
+    rf::snd_play(on ? stock_sound_id::checkbox_off : stock_sound_id::checkbox_on, 0, 0.0f, 1.0f);
+}
+
+void close_panel_and_return_to_game()
+{
+    vote_panel_close();
+
+    // Only start the unwind when the stack is exactly what we intend to unwind,
+    // right now, with nothing already queued. A vote that passes instantly (sole
+    // eligible voter) can have the server's level change in flight before we get
+    // here, and the engine's transition must win -- if we popped anyway our pop
+    // would either swallow its gameseq_set_state or, once it collapsed the stack,
+    // underflow the index.
+    if (gameseq_change_pending() || gameseq_stack_top() != 2
+        || gameseq_state_at(2) != rf::GS_MULTI_MENU
+        || gameseq_state_at(1) != rf::GS_MAIN_MENU
+        || !is_returnable_bottom_state(gameseq_state_at(0))) {
+        clear_auto_return();
+        return; // panel is closed; the engine takes it from here
+    }
+
+    // The stock BACK handler pops GS_MULTI_MENU (deferred). The second pop, out
+    // of GS_MAIN_MENU, has to wait for the next frame because gameseq_pop_state
+    // only sets pending flags and is idempotent within one frame.
+    AddrCaller{multi_menu_back_on_click_addr}.c_call<void>(0, 0);
+    g_auto_return_to_game = true;
+    g_auto_return_deadline_ms = timer::get_i64(1000) + auto_return_lifetime_ms;
+}
+
+void send_vote_from_form(const VoteOptionsData& options)
+{
+    const auto types = enabled_vote_types();
+    if (g_form.type_index < 0 || g_form.type_index >= static_cast<int>(types.size())) {
+        return;
+    }
+
+    AfVoteCallParams params;
+    params.type = types[g_form.type_index]->type;
+
+    switch (params.type) {
+        case AfVoteType::Kick: {
+            const auto candidates = build_kick_candidates();
+            if (g_form.kick_index < 0 || g_form.kick_index >= static_cast<int>(candidates.size())) {
+                return;
+            }
+            params.target_player_id = candidates[g_form.kick_index].id;
+            break;
+        }
+        case AfVoteType::Level: {
+            params.level = selected_level();
+            if (params.level.empty()) {
+                return;
+            }
+            params.gametype = selected_gametype(options, false);
+            params.mutators = build_mutator_inputs(options);
+            break;
+        }
+        case AfVoteType::Match: {
+            params.team_size = static_cast<uint8_t>(g_form.team_size);
+            params.level = selected_level();
+            params.gametype = selected_gametype(options, true);
+            params.mutators = build_mutator_inputs(options);
+            break;
+        }
+        default:
+            break; // parameterless
+    }
+
+    // Stashed rather than sent: the packet goes out from vote_send_tick() once
+    // the unwind is done and the deferred-change slot is free again.
+    g_pending_vote = std::move(params);
+    g_pending_vote_valid = true;
+
+    play_click_sound();
+    close_panel_and_return_to_game();
+}
+
+void do_message_block(PanelUi& ui, const Layout& lo, const std::vector<std::string>& lines)
+{
+    if (!ui.draw) {
+        return;
+    }
+    const int line_h = rf::gr::get_font_height(lo.font) + lo.gap;
+    int y = lo.cy + (lo.ch - static_cast<int>(lines.size()) * line_h) / 2;
+    rf::gr::set_color(235, 235, 235, 255);
+    for (const auto& line : lines) {
+        rf::gr::string_aligned(rf::gr::ALIGN_CENTER, lo.cx + lo.cw / 2, y, line.c_str(), lo.font);
+        y += line_h;
+    }
+}
+
+void do_active_vote(PanelUi& ui, const Layout& lo)
+{
+    const auto& state = vote_state_get();
+    if (!state) {
+        return;
+    }
+
+    if (ui.draw) {
+        const int line_h = rf::gr::get_font_height(lo.font) + lo.gap;
+        int y = lo.cy + lo.row_h;
+        set_header_color();
+        rf::gr::string_aligned(rf::gr::ALIGN_CENTER, lo.cx + lo.cw / 2, y,
+            "A VOTE IS ALREADY IN PROGRESS", lo.font);
+        y += line_h * 2;
+
+        const auto title_lines = wrap_text(state->title, lo.cw, lo.font);
+        rf::gr::set_color(255, 255, 255, 255);
+        for (const auto& line : title_lines) {
+            rf::gr::string_aligned(rf::gr::ALIGN_CENTER, lo.cx + lo.cw / 2, y, line.c_str(), lo.font);
+            y += line_h;
+        }
+        y += line_h;
+
+        const std::string tally = std::format("Yes: {}    No: {}    Waiting: {}",
+            static_cast<int>(state->yes), static_cast<int>(state->no),
+            static_cast<int>(state->remaining));
+        rf::gr::set_color(160, 255, 190, 255);
+        rf::gr::string_aligned(rf::gr::ALIGN_CENTER, lo.cx + lo.cw / 2, y, tally.c_str(), lo.font);
+        y += line_h;
+
+        const std::string time_left = std::format("{} seconds remaining", vote_state_seconds_remaining());
+        rf::gr::set_color(215, 215, 215, 255);
+        rf::gr::string_aligned(rf::gr::ALIGN_CENTER, lo.cx + lo.cw / 2, y, time_left.c_str(), lo.font);
+    }
+
+    if (state->is_owner) {
+        const int btn_w = std::min(lo.cw / 2, scaled(200.0f));
+        const Rect cancel{lo.cx + (lo.cw - btn_w) / 2, lo.cy + lo.ch - lo.row_h - lo.gap, btn_w, lo.row_h};
+        if (ui_button(ui, cancel, "CANCEL VOTE", lo.font)) {
+            af_send_vote_cancel();
+            play_click_sound();
+        }
+    }
+}
+
+// Total height of every mutator row plus the option rows of expanded mutators.
+// Must match the advance in do_mutator_rows exactly (every option consumes a row
+// whether or not its type has a widget yet).
+int mutator_content_height(const Layout& lo, const VoteOptionsData& options)
+{
+    int h = 0;
+    for (size_t i = 0; i < options.mutators.size() && i < g_form.mutators.size(); ++i) {
+        h += lo.row_h;
+        if (g_form.mutators[i].enabled) {
+            const size_t count =
+                std::min(options.mutators[i].options.size(), g_form.mutators[i].options.size());
+            h += static_cast<int>(count) * lo.row_h;
+        }
+    }
+    return h;
+}
+
+// One mutator checkbox plus, when it is checked, its option widgets indented
+// underneath. Rects are absolute screen space with the scroll offset already
+// applied by the caller; rows outside `view` are neither drawn nor hit-tested.
+void do_mutator_rows(PanelUi& ui, const Layout& lo, const VoteOptionsData& options,
+                     const Rect& view, int start_y)
+{
+    const int indent = std::max(8, scaled(16.0f));
+    const int view_bottom = view.y + view.h;
+    int y = start_y;
+
+    const auto row_visible = [&](int row_y) {
+        return row_y + lo.row_h > view.y && row_y < view_bottom;
+    };
+
+    for (size_t i = 0; i < options.mutators.size() && i < g_form.mutators.size(); ++i) {
+        const VoteMutatorSchema& schema = options.mutators[i];
+        PanelMutatorSelection& selection = g_form.mutators[i];
+
+        if (row_visible(y)) {
+            const Rect row{view.x, y, view.w, lo.row_h};
+            if (!ui.draw && ui_hover(ui, row)) {
+                g_form.description_mutator = static_cast<int>(i);
+            }
+            if (ui_checkbox(ui, row, selection.enabled, schema.label.c_str(), lo.font)) {
+                selection.enabled = !selection.enabled;
+                g_form.description_mutator = static_cast<int>(i);
+                play_toggle_sound(selection.enabled);
+            }
+        }
+        y += lo.row_h;
+
+        if (!selection.enabled) {
+            continue;
+        }
+
+        for (size_t o = 0; o < schema.options.size() && o < selection.options.size(); ++o) {
+            if (!row_visible(y)) {
+                y += lo.row_h;
+                continue;
+            }
+            const VoteMutatorOptionSchema& option = schema.options[o];
+            PanelOptionValue& value = selection.options[o];
+            const Rect opt_row{view.x + indent, y, view.w - indent, lo.row_h};
+
+            switch (option.type) {
+                case MutatorOptionType::Bool: {
+                    if (ui_checkbox(ui, opt_row, value.bool_value, option.label.c_str(), lo.font)) {
+                        value.bool_value = !value.bool_value;
+                        play_toggle_sound(value.bool_value);
+                    }
+                    break;
+                }
+                case MutatorOptionType::Choice: {
+                    const int label_w = opt_row.w / 2;
+                    if (ui.draw) {
+                        draw_label(ui,
+                            {opt_row.x, opt_row.y + (lo.row_h - rf::gr::get_font_height(lo.font)) / 2,
+                             label_w, lo.row_h}, option.label.c_str(), lo.font, true);
+                    }
+                    const Rect value_rect{opt_row.x + label_w, opt_row.y, opt_row.w - label_w, lo.row_h};
+                    std::string text = "-";
+                    if (value.choice_index < option.choices.size()) {
+                        // Long values from a modded server degrade to an ellipsis
+                        // rather than clipping mid-glyph.
+                        text = fit_middle(option.choices[value.choice_index],
+                            ui_cycler_value_width(value_rect), lo.font);
+                    }
+                    const int delta = ui_cycler(ui, value_rect, text.c_str(), lo.font);
+                    if (delta != 0 && !option.choices.empty()) {
+                        const int count = static_cast<int>(option.choices.size());
+                        int index = static_cast<int>(value.choice_index) + delta;
+                        if (index < 0) {
+                            index = count - 1;
+                        }
+                        else if (index >= count) {
+                            index = 0;
+                        }
+                        value.choice_index = static_cast<uint8_t>(index);
+                        play_click_sound();
+                    }
+                    break;
+                }
+                case MutatorOptionType::Int:
+                case MutatorOptionType::Float: {
+                    const int label_w = opt_row.w / 2;
+                    if (ui.draw) {
+                        draw_label(ui,
+                            {opt_row.x, opt_row.y + (lo.row_h - rf::gr::get_font_height(lo.font)) / 2,
+                             label_w, lo.row_h}, option.label.c_str(), lo.font, true);
+                    }
+                    const Rect value_rect{opt_row.x + label_w, opt_row.y, opt_row.w - label_w, lo.row_h};
+                    const std::string text = option.type == MutatorOptionType::Int
+                        ? std::format("{}", value.int_value)
+                        : std::format("{:.2f}", value.float_value);
+                    if (ui_button(ui, value_rect, text.c_str(), lo.font)) {
+                        // Indices, not positions, so scrolling can't misdirect the popup.
+                        g_popup_mutator = static_cast<int>(i);
+                        g_popup_option = static_cast<int>(o);
+                        rf::ui::popup_message(option.label.c_str(), "", mutator_option_popup_callback, 1);
+                    }
+                    break;
+                }
+                default:
+                    break; // string options have no widget yet
+            }
+            y += lo.row_h;
+        }
+    }
+}
+
+// Mutator list as a clipped scroll region. When the content fits, nothing is
+// clipped, no scrollbar is drawn and the wheel is left alone, so the layout is
+// identical to what it was before scrolling existed.
+void do_mutator_scroll_region(PanelUi& ui, const Layout& lo, const VoteOptionsData& options,
+                              const Rect& view)
+{
+    const int content_h = mutator_content_height(lo, options);
+    const float max_scroll = static_cast<float>(std::max(0, content_h - view.h));
+
+    if (!ui.draw && max_scroll > 0.0f && ui.wheel != 0 && point_in(ui.mx, ui.my, view)) {
+        g_form.mutator_scroll += (ui.wheel > 0 ? -1.0f : 1.0f) * static_cast<float>(lo.row_h * 3);
+    }
+    // Also clamps after a mutator collapses and the content shrinks.
+    g_form.mutator_scroll = std::clamp(g_form.mutator_scroll, 0.0f, max_scroll);
+
+    const int start_y = view.y - static_cast<int>(g_form.mutator_scroll);
+
+    // Gate hit-testing on the viewport in both passes so rows scrolled out of
+    // sight can never be clicked.
+    const Rect saved_clip_rect = ui.clip_rect;
+    const bool saved_clip_active = ui.clip_active;
+    const int saved_origin_x = ui.origin_x;
+    const int saved_origin_y = ui.origin_y;
+    ui.clip_rect = view;
+    ui.clip_active = true;
+
+    int save_x = 0, save_y = 0, save_w = 0, save_h = 0;
+    if (ui.draw) {
+        rf::gr::get_clip(&save_x, &save_y, &save_w, &save_h);
+        rf::gr::set_clip(view.x, view.y, view.w, view.h);
+        // set_clip moves the drawing origin; widgets subtract it via ui_draw_rect.
+        ui.origin_x = view.x;
+        ui.origin_y = view.y;
+    }
+
+    do_mutator_rows(ui, lo, options, view, start_y);
+
+    if (ui.draw) {
+        rf::gr::set_clip(save_x, save_y, save_w, save_h);
+    }
+
+    ui.clip_rect = saved_clip_rect;
+    ui.clip_active = saved_clip_active;
+    ui.origin_x = saved_origin_x;
+    ui.origin_y = saved_origin_y;
+
+    // Scrollbar, drawn after the clip is restored so it uses absolute coords
+    // (same constants as the level/player listboxes).
+    if (ui.draw && max_scroll > 0.0f) {
+        const float ratio = g_form.mutator_scroll / max_scroll;
+        const int bar_w = std::max(3, scaled(6.0f));
+        const int bar_h = std::max(bar_w, view.h * view.h / std::max(1, content_h));
+        const int bar_y = view.y + static_cast<int>(ratio * (view.h - bar_h));
+        rf::gr::set_color(100, 255, 200, 255);
+        rf::gr::rect(view.x + view.w - bar_w, bar_y, bar_w, bar_h);
+    }
+}
+
+void do_level_column(PanelUi& ui, const Layout& lo, const VoteOptionsData& options, const Rect& col,
+                     bool allow_current, uint8_t gametype)
+{
+    const int header_h = rf::gr::get_font_height(lo.font);
+    int y = col.y;
+    if (ui.draw) {
+        set_header_color();
+        rf::gr::string(col.x, y, "Level", lo.font);
+    }
+
+    // Filter toggle on the header line. A server that enforces the gametype
+    // prefix pins it checked and non-interactive; otherwise it is the player's
+    // choice, off by default, and kept for the session only.
+    {
+        const int header_w = rf::gr::get_string_size("Level", lo.font).first;
+        const int cb_x = col.x + header_w + lo.gap * 2;
+        const Rect cb{cb_x, y - 1, std::max(0, col.x + col.w - cb_x), header_h + 2};
+        if (ui_checkbox(ui, cb, options.gametype_prefix_restricted || g_filter_gametype_local,
+                "Filter gametype", lo.font, !options.gametype_prefix_restricted)) {
+            g_filter_gametype_local = !g_filter_gametype_local;
+            play_toggle_sound(g_filter_gametype_local);
+        }
+    }
+    y += header_h + lo.gap;
+
+    // Read after the checkbox so a toggle takes effect in the same pass.
+    const bool filter_active = options.gametype_prefix_restricted || g_filter_gametype_local;
+
+    // Levels the server would accept with the game type currently selected in the
+    // form. valid_gametype_mask always carries real prefix-match data now, so an
+    // unenforced server can still be filtered locally on request.
+    // Alphabetical rather than the blob's order (rotation order, then extras).
+    std::vector<std::string> levels;
+    levels.reserve(options.levels.size());
+    int hidden_count = 0;
+    for (const auto& level : options.levels) {
+        const bool allowed = !filter_active
+            || (gametype == af_vote_gametype_none
+                ? vote_level_allows_default_gametype(level)
+                : vote_level_allows_gametype(level, gametype));
+        if (allowed) {
+            levels.push_back(level.filename);
+        }
+        else {
+            ++hidden_count;
+        }
+    }
+    std::sort(levels.begin(), levels.end(), level_name_less);
+
+    // A game type change can hide the selected map; drop the selection so it can
+    // never be sent. Match then falls back to the pinned "Current level" row.
+    if (!g_form.level_selection.empty()
+        && std::find(levels.begin(), levels.end(), g_form.level_selection) == levels.end()) {
+        g_form.level_selection.clear();
+    }
+    // A Level vote has no pinned row, so keep the top entry active by default.
+    if (!allow_current && g_form.level_selection.empty() && !levels.empty()) {
+        g_form.level_selection = levels.front();
+    }
+
+    const int line_h = rf::gr::get_font_height(lo.font) + 1;
+    const bool show_hint = filter_active && hidden_count > 0;
+    const int hint_h = show_hint ? 2 * line_h + lo.gap : 0;
+
+    const int manual_rows = 2 * lo.row_h + lo.gap;
+    const int list_h = std::max(lo.row_h * 3, col.y + col.h - y - manual_rows - hint_h - lo.gap);
+    const Rect list{col.x, y, col.w, list_h};
+
+    if (!allow_current && levels.empty()) {
+        // Nothing votable for this game type. Manual entry stays available and
+        // unfiltered; CALL VOTE stays inert because the selection is empty.
+        if (ui.draw) {
+            rf::gr::set_color(8, 8, 8, 235);
+            rf::gr::rect(list.x, list.y, list.w, list.h);
+            rf::gr::set_color(120, 120, 120, 255);
+            hud_rect_border(list.x, list.y, list.w, list.h, 1);
+            const int pad = std::max(3, scaled(6.0f));
+            draw_wrapped({list.x + pad, list.y + pad, list.w - 2 * pad, list.h - 2 * pad},
+                "No maps available for this game type", lo.font, line_h);
+        }
+    }
+    else {
+        std::vector<std::string> items;
+        items.reserve(levels.size() + 1);
+        if (allow_current) {
+            // Pinned and always visible; the server adjudicates it at call time.
+            items.emplace_back("Current level");
+        }
+        for (const auto& level : levels) {
+            items.push_back(level);
+        }
+
+        // Resolve the highlighted row from the stored name so it follows the map
+        // through the sort/filter instead of pointing at whatever sits there now.
+        const int first_level_row = allow_current ? 1 : 0;
+        int sel = -1;
+        if (!g_form.manual_level) {
+            if (g_form.level_selection.empty()) {
+                sel = allow_current ? 0 : -1;
+            }
+            else {
+                for (size_t i = first_level_row; i < items.size(); ++i) {
+                    if (items[i] == g_form.level_selection) {
+                        sel = static_cast<int>(i);
+                        break;
+                    }
+                }
+            }
+        }
+
+        const int clicked = ui_listbox(ui, list, items, sel, g_form.level_scroll, lo.font);
+        if (clicked >= 0) {
+            g_form.level_selection =
+                (allow_current && clicked == 0) ? std::string{} : items[clicked];
+            g_form.manual_level = false;
+            play_click_sound();
+        }
+    }
+    y += list_h + lo.gap;
+
+    if (show_hint) {
+        if (ui.draw) {
+            draw_wrapped({col.x, y, col.w, 2 * line_h},
+                "Some maps hidden: not valid for this game type", lo.font, line_h);
+        }
+        y += hint_h;
+    }
+
+    const Rect manual_row{col.x, y, col.w, lo.row_h};
+    if (ui_checkbox(ui, manual_row, g_form.manual_level, "Enter level name manually", lo.font)) {
+        g_form.manual_level = !g_form.manual_level;
+        play_toggle_sound(g_form.manual_level);
+    }
+    y += lo.row_h;
+
+    const Rect manual_value{col.x, y, col.w, lo.row_h};
+    const std::string manual_text = g_form.manual_level_name.empty()
+        ? std::string{"(click to type a level name)"}
+        : g_form.manual_level_name;
+    if (ui_button(ui, manual_value, manual_text.c_str(), lo.font, g_form.manual_level)
+        && g_form.manual_level) {
+        rf::ui::popup_message("Enter level file name:", "", manual_level_popup_callback, 1);
+    }
+}
+
+void do_form(PanelUi& ui, const Layout& lo, const VoteOptionsData& options)
+{
+    ensure_form(options);
+
+    const auto types = enabled_vote_types();
+    if (types.empty()) {
+        do_message_block(ui, lo, {"This server has no votes enabled."});
+        return;
+    }
+    g_form.type_index = std::clamp(g_form.type_index, 0, static_cast<int>(types.size()) - 1);
+
+    int y = lo.cy;
+
+    // Vote type buttons across the top, flowing left-to-right and wrapping. One
+    // uniform width sized to the widest label keeps the grid aligned; the form
+    // below starts under however many rows that produces.
+    {
+        const int hpad = std::max(4, scaled(10.0f));
+        int widest = 0;
+        for (const VoteTypeInfo* info : types) {
+            widest = std::max(widest, rf::gr::get_string_size(info->label, lo.font).first);
+        }
+        const int btn_w = widest + 2 * hpad;
+        const int btn_h = lo.row_h;
+        const int per_row = std::max(1, (lo.cw + lo.gap) / (btn_w + lo.gap));
+
+        for (int i = 0; i < static_cast<int>(types.size()); ++i) {
+            const Rect btn{lo.cx + (i % per_row) * (btn_w + lo.gap),
+                           y + (i / per_row) * (btn_h + lo.gap), btn_w, btn_h};
+            const bool active = i == g_form.type_index;
+            if (ui_button(ui, btn, types[i]->label, lo.font, true, active)) {
+                if (!active) {
+                    g_form.type_index = i;
+                    g_form.mutator_scroll = 0.0f; // the section is rebuilt for the new type
+                }
+                play_click_sound();
+            }
+        }
+
+        const int rows = (static_cast<int>(types.size()) + per_row - 1) / per_row;
+        y += rows * (btn_h + lo.gap) + lo.gap;
+    }
+
+    const AfVoteType type = types[g_form.type_index]->type;
+    const int body_bottom = lo.cy + lo.ch;
+
+    if (type == AfVoteType::Kick) {
+        if (ui.draw) {
+            set_header_color();
+            rf::gr::string(lo.cx, y, "Player to kick", lo.font);
+        }
+        y += rf::gr::get_font_height(lo.font) + lo.gap;
+
+        const auto candidates = build_kick_candidates();
+        std::vector<std::string> names;
+        names.reserve(candidates.size());
+        for (const auto& candidate : candidates) {
+            names.push_back(candidate.name);
+        }
+        g_form.kick_index = std::clamp(g_form.kick_index, 0,
+            std::max(0, static_cast<int>(names.size()) - 1));
+
+        const Rect list{lo.cx, y, lo.cw, body_bottom - y};
+        const int clicked = ui_listbox(ui, list, names, g_form.kick_index, g_form.kick_scroll, lo.font);
+        if (clicked >= 0) {
+            g_form.kick_index = clicked;
+            play_click_sound();
+        }
+        return;
+    }
+
+    if (type != AfVoteType::Level && type != AfVoteType::Match) {
+        do_message_block(ui, lo, {types[g_form.type_index]->description});
+        return;
+    }
+
+    const bool is_match = type == AfVoteType::Match;
+    const int col_gap = std::max(6, scaled(16.0f));
+    const int left_w = (lo.cw - col_gap) / 2;
+    const Rect left_col{lo.cx, y, left_w, body_bottom - y};
+    const Rect right_col{lo.cx + left_w + col_gap, y, lo.cw - left_w - col_gap, body_bottom - y};
+
+    // Filtered live against the game type currently selected in the form; for
+    // Match that cycler already offers only team types, so the two compose.
+    do_level_column(ui, lo, options, left_col, is_match, selected_gametype(options, is_match));
+
+    int ry = right_col.y;
+    if (is_match) {
+        const int label_w = right_col.w / 2;
+        if (ui.draw) {
+            draw_label(ui, {right_col.x, ry + (lo.row_h - rf::gr::get_font_height(lo.font)) / 2, label_w,
+                        lo.row_h}, "Team size", lo.font);
+        }
+        const Rect cycler{right_col.x + label_w, ry, right_col.w - label_w, lo.row_h};
+        const std::string text = std::format("{}v{}", g_form.team_size, g_form.team_size);
+        const int delta = ui_cycler(ui, cycler, text.c_str(), lo.font);
+        if (delta != 0) {
+            g_form.team_size += delta;
+            if (g_form.team_size < 1) {
+                g_form.team_size = 8;
+            }
+            else if (g_form.team_size > 8) {
+                g_form.team_size = 1;
+            }
+            play_click_sound();
+        }
+        ry += lo.row_h + lo.gap;
+    }
+
+    {
+        const auto gametypes = selectable_gametypes(options, is_match);
+        const int count = static_cast<int>(gametypes.size()) + 1; // + "Default"
+        g_form.gametype_index = std::clamp(g_form.gametype_index, 0, count - 1);
+
+        const int label_w = right_col.w / 2;
+        if (ui.draw) {
+            draw_label(ui, {right_col.x, ry + (lo.row_h - rf::gr::get_font_height(lo.font)) / 2, label_w,
+                        lo.row_h}, "Game type", lo.font);
+        }
+        const Rect cycler{right_col.x + label_w, ry, right_col.w - label_w, lo.row_h};
+        std::string text = "Default";
+        if (g_form.gametype_index > 0) {
+            const VoteGametypeInfo& gametype = *gametypes[g_form.gametype_index - 1];
+            const char* short_name = gametype_short_name(gametype.id);
+            text = short_name != nullptr
+                ? std::string{short_name}
+                // A game type this build predates has no short tag, so fall back
+                // to the server-sent display name, truncated to the selector.
+                : fit_middle(gametype.name, ui_cycler_value_width(cycler), lo.font);
+        }
+        const int delta = ui_cycler(ui, cycler, text.c_str(), lo.font);
+        if (delta != 0) {
+            g_form.gametype_index = (g_form.gametype_index + delta + count) % count;
+            play_click_sound();
+        }
+        ry += lo.row_h + lo.gap * 2;
+    }
+
+    if (ui.draw) {
+        set_header_color();
+        rf::gr::string(right_col.x, ry, "Mutators", lo.font);
+    }
+    ry += rf::gr::get_font_height(lo.font) + lo.gap;
+
+    // Reserve exactly three lines at the bottom of the column for the description;
+    // everything between the header and it scrolls.
+    const int desc_line_h = rf::gr::get_font_height(lo.font) + 1;
+    const int desc_h = 3 * desc_line_h;
+    const int mutator_bottom = right_col.y + right_col.h - desc_h - lo.gap;
+    const Rect mutator_view{right_col.x, ry, right_col.w, std::max(lo.row_h, mutator_bottom - ry)};
+    do_mutator_scroll_region(ui, lo, options, mutator_view);
+
+    if (ui.draw) {
+        const Rect desc{right_col.x, right_col.y + right_col.h - desc_h, right_col.w, desc_h};
+        const char* text = "Hover or toggle a mutator to read what it does.";
+        if (g_form.description_mutator >= 0
+            && g_form.description_mutator < static_cast<int>(options.mutators.size())) {
+            text = mutator_description_for(options.mutators[g_form.description_mutator].name);
+        }
+        draw_wrapped(desc, text, lo.font, desc_line_h);
+    }
+}
+
+void vote_panel_do(PanelUi& ui)
+{
+    const Layout lo = compute_layout();
+
+    if (ui.draw) {
+        // Full-screen dim.
+        rf::gr::set_color(0, 0, 0, 192);
+        rf::gr::rect(0, 0, rf::gr::clip_width(), rf::gr::clip_height());
+
+        // Panel background + border.
+        rf::gr::set_color(20, 20, 20, 235);
+        rf::gr::rect(lo.px, lo.py, lo.pw, lo.ph);
+        rf::gr::set_color(120, 120, 120, 255);
+        hud_rect_border(lo.px, lo.py, lo.pw, lo.ph, std::max(1, scaled(2.0f)));
+
+        // Title.
+        rf::gr::set_color(255, 255, 255, 255);
+        rf::gr::string_aligned(rf::gr::ALIGN_CENTER, lo.px + lo.pw / 2, lo.title_y, "CALL VOTE",
+            lo.title_font);
+    }
+
+    const PanelMode mode = compute_mode();
+    const VoteOptionsData* options = vote_options_get();
+
+    switch (mode) {
+        case PanelMode::NotSupported:
+            do_message_block(ui, lo, {"This server does not support menu voting",
+                                      "(requires Alpine Faction 1.4 or newer)"});
+            break;
+        case PanelMode::Loading:
+            if (ui.draw) {
+                vote_options_request_if_needed();
+            }
+            do_message_block(ui, lo, {"Loading server vote options..."});
+            break;
+        case PanelMode::ActiveVote:
+            do_active_vote(ui, lo);
+            break;
+        case PanelMode::Form:
+            if (options) {
+                do_form(ui, lo, *options);
+            }
+            break;
+    }
+
+    // Footer buttons, sized and centred like the spray picker's Cancel button.
+    const int btn_w = std::min(lo.cw / 2 - lo.gap, scaled(240.0f));
+    const int btn_h = std::max(lo.row_h, scaled(40.0f));
+    const int btn_y = lo.footer_y + (lo.footer_h - btn_h) / 2;
+    if (mode == PanelMode::Form) {
+        const Rect call{lo.cx + lo.cw / 2 - btn_w - lo.gap, btn_y, btn_w, btn_h};
+        if (ui_button(ui, call, "CALL VOTE", lo.font) && options) {
+            send_vote_from_form(*options);
+            return;
+        }
+        const Rect close{lo.cx + lo.cw / 2 + lo.gap, btn_y, btn_w, btn_h};
+        if (ui_button(ui, close, "CLOSE (Esc)", lo.font)) {
+            vote_panel_close();
+            play_click_sound();
+        }
+    }
+    else {
+        const Rect close{lo.cx + (lo.cw - btn_w) / 2, btn_y, btn_w, btn_h};
+        if (ui_button(ui, close, "CLOSE (Esc)", lo.font)) {
+            vote_panel_close();
+            play_click_sound();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Multi menu integration
+// ---------------------------------------------------------------------------
+
+void call_vote_button_on_click(int, int)
+{
+    vote_panel_open();
+    rf::snd_play(stock_sound_id::menu_select, 0, 0.0f, 1.0f);
+}
+
+void update_call_vote_button_enabled()
+{
+    g_call_vote_button.enabled = rf::is_multi && !rf::is_server && g_menu_opened_in_game != 0;
+}
+
+FunHook<void()> multi_menu_init_hook{
+    multi_menu_init_addr,
+    []() {
+        multi_menu_init_hook.call_target();
+
+        if (!g_call_vote_button_created) {
+            g_call_vote_button.init();
+            g_call_vote_button.create("button_more.tga", "button_selected.tga", 0, 0, rf::KEY_V,
+                "CALL VOTE", rf::ui::medium_font_0);
+            g_call_vote_button.key = rf::KEY_V;
+            g_call_vote_button.on_click = call_vote_button_on_click;
+
+            // Append to the stock hit-test array so the button becomes hit-test
+            // index 4; the AF dispatch array must use that same index order.
+            AddrCaller{multi_menu_hit_test_array_add}.this_call<int>(
+                reinterpret_cast<void*>(multi_menu_hit_test_array), &g_call_vote_button);
+
+            for (int i = 0; i < 4; ++i) {
+                g_multi_menu_gadgets.items[i] = &stock_multi_menu_button(i);
+            }
+            g_multi_menu_gadgets.items[call_vote_gadget_index] = &g_call_vote_button;
+            g_multi_menu_gadgets.count = 5;
+            g_call_vote_button_created = true;
+        }
+
+        update_call_vote_button_enabled();
+        vote_panel_close();
+        // Re-entering the multi menu means no unwind of ours is in flight.
+        clear_auto_return();
+        drop_pending_vote();
+    },
+};
+
+// The stock helpers walk the button block by raw address, so they cannot see a
+// fifth button living outside it; they are replaced rather than patched.
+void multi_menu_nav(int dir)
+{
+    const int count = g_multi_menu_gadgets.count;
+    if (count <= 0) {
+        return;
+    }
+    for (int i = 0; i < count; ++i) {
+        g_multi_menu_focus_index += dir;
+        if (g_multi_menu_focus_index >= count) {
+            g_multi_menu_focus_index = 0;
+        }
+        else if (g_multi_menu_focus_index < 0) {
+            g_multi_menu_focus_index = count - 1;
+        }
+        const rf::ui::Gadget* gadget = g_multi_menu_gadgets.items[g_multi_menu_focus_index];
+        if (gadget && gadget->enabled) {
+            break;
+        }
+    }
+}
+
+FunHook<void()> multi_menu_nav_next_hook{multi_menu_nav_next_addr, []() { multi_menu_nav(1); }};
+FunHook<void()> multi_menu_nav_prev_hook{multi_menu_nav_prev_addr, []() { multi_menu_nav(-1); }};
+
+FunHook<void()> multi_menu_mouse_hook{
+    multi_menu_mouse_handler_addr,
+    []() {
+        if (vote_panel_is_open()) {
+            vote_panel_handle_mouse();
+            return;
+        }
+        multi_menu_mouse_hook.call_target();
+    },
+};
+
+// Replaces the stock button render loop so the buttons come from the AF array
+// (in visual order) and the vote panel can be drawn before the mouse cursor.
+CodeInjection multi_menu_render_injection{
+    multi_menu_render_button_loop,
+    [](auto& regs) {
+        static const int visual_order[] = {0, 1, 2, call_vote_gadget_index, 3};
+
+        update_call_vote_button_enabled();
+
+        const int x = regs.ebx;
+        int y = regs.edi;
+        for (int index : visual_order) {
+            if (index >= g_multi_menu_gadgets.count) {
+                continue;
+            }
+            auto* button = static_cast<rf::ui::Button*>(g_multi_menu_gadgets.items[index]);
+            if (!button || !button->enabled) {
+                continue; // disabled buttons consume no row, same as stock
+            }
+            button->x = x;
+            button->y = y;
+            button->render();
+            y += rf::ui::menu_button_offset_y;
+        }
+
+        vote_panel_render();
+
+        regs.eip = multi_menu_render_button_loop_end;
+    },
+};
+
+// Registered every frame by the multi menu do_frame via PUSH <handler>.
+void multi_menu_key_handler(int key)
+{
+    if (vote_panel_is_open()) {
+        vote_panel_handle_key(key);
+        return;
+    }
+    // The stock handler forwards every key to the character setup sub-panel
+    // while it is open; don't steal the hotkey from it.
+    const bool sub_panel_open = addr_as_ref<uint8_t>(0x0063E088) != 0;
+    if (!sub_panel_open && key == rf::KEY_V && g_call_vote_button.enabled) {
+        g_multi_menu_focus_index = call_vote_gadget_index;
+        if (g_call_vote_button.on_click) {
+            g_call_vote_button.on_click(0, 0);
+        }
+        return;
+    }
+    AddrCaller{multi_menu_key_handler_addr}.c_call<void>(key);
+}
+
+// True only when popping GS_MAIN_MENU back to gameplay is provably safe this
+// frame. Every other observation abandons the auto-return rather than guessing.
+bool consume_auto_return()
+{
+    if (!g_auto_return_to_game) {
+        return false;
+    }
+
+    // Left the server, or the engine never gave the main menu another frame.
+    if (!rf::is_multi || timer::get_i64(1000) > g_auto_return_deadline_ms) {
+        clear_auto_return();
+        return false;
+    }
+
+    // GS_MULTI_MENU is transparent, so this hook also runs underneath it. The
+    // one legitimate in-flight observation is the frame before our own
+    // GS_MULTI_MENU pop is applied; anything else means the engine took over.
+    const rf::GameState state = rf::gameseq_get_state();
+    if (state != rf::GS_MAIN_MENU) {
+        const bool our_pop_in_flight = state == rf::GS_MULTI_MENU
+            && addr_as_ref<uint8_t>(gameseq_pop_pending_addr) != 0
+            && static_cast<int>(rf::gameseq_get_pending_state()) == 0;
+        if (!our_pop_in_flight) {
+            clear_auto_return();
+        }
+        return false;
+    }
+
+    // Main menu is on top. Require exactly [gameplay, GS_MAIN_MENU] and no
+    // queued change, so the pop cannot underflow and cannot race a transition.
+    if (gameseq_change_pending() || gameseq_stack_top() != 1
+        || gameseq_state_at(1) != rf::GS_MAIN_MENU
+        || !is_returnable_bottom_state(gameseq_state_at(0))) {
+        clear_auto_return();
+        return false;
+    }
+
+    clear_auto_return();
+    return true;
+}
+
+FunHook<void(int)> mainmenu_do_frame_hook{
+    mainmenu_do_frame_addr,
+    [](int no_input) {
+        if (consume_auto_return()) {
+            AddrCaller{mainmenu_do_return_addr}.c_call<void>();
+            return; // skip the main menu frame entirely so it never flashes
+        }
+        mainmenu_do_frame_hook.call_target(no_input);
+    },
+};
+
+// Terminal states of the unwind: no auto-return still owed and nothing queued in
+// the deferred-change slot. That covers "unwind completed" (back in gameplay),
+// "unwind abandoned, still connected" (the server adjudicates and replies), and
+// guarantees our reply can no longer collide with a pop of ours.
+void vote_send_tick()
+{
+    if (!g_pending_vote_valid) {
+        return;
+    }
+    if (!rf::is_multi || rf::is_server) {
+        drop_pending_vote(); // disconnected before we got to send it
+        return;
+    }
+    if (g_auto_return_to_game || gameseq_change_pending()) {
+        return; // unwind still in flight
+    }
+
+    const AfVoteCallParams params = g_pending_vote; // one-shot
+    drop_pending_vote();
+    af_send_vote_call(params);
+}
+
+// Runs every frame regardless of game state, right after the state machine has
+// applied this frame's deferred change.
+CallHook<rf::GameState()> gameseq_process_hook{
+    0x004B2DB1,
+    []() -> rf::GameState {
+        // Before the state runs its frame, so the overlay sees keys/clicks first.
+        vote_panel_decay_attack_swallow();
+        vote_panel_gameplay_input();
+        const rf::GameState state = gameseq_process_hook.call_target();
+        vote_send_tick();
+        return state;
+    },
+};
+
+// ESC during gameplay pushes GS_MAIN_MENU. While the overlay is up, treat that
+// as "close the modal" and swallow the push, so ESC behaves like it does in the
+// menu context and the ESC menu can never open on top of the overlay.
+FunHook<void(rf::GameState, bool, bool)> gameseq_push_state_hook{
+    0x00434410,
+    [](rf::GameState state, bool transparent, bool pause_beneath) {
+        if (state == rf::GS_MAIN_MENU && g_open && g_context == VotePanelContext::Gameplay) {
+            vote_panel_close();
+            play_click_sound();
+            return;
+        }
+        gameseq_push_state_hook.call_target(state, transparent, pause_beneath);
+    },
+};
+
+// Clicking in the panel must not also fire the weapon. Movement is left alone
+// (the panel does not pause a multiplayer game), matching the waypoint editor.
+bool gameplay_overlay_blocks_action(rf::ControlConfig* ccp, rf::ControlConfigAction action)
+{
+    const bool overlay_up = g_open && g_context == VotePanelContext::Gameplay;
+    if (!overlay_up && g_swallow_attack_frames <= 0) {
+        return false;
+    }
+    if (!rf::local_player || ccp != &rf::local_player->settings.controls) {
+        return false;
+    }
+    return action == rf::CC_ACTION_PRIMARY_ATTACK || action == rf::CC_ACTION_SECONDARY_ATTACK;
+}
+
+FunHook<bool(rf::ControlConfig*, rf::ControlConfigAction, bool*)> vote_panel_check_pressed_hook{
+    0x0043D4F0,
+    [](rf::ControlConfig* ccp, rf::ControlConfigAction action, bool* just_pressed) {
+        if (gameplay_overlay_blocks_action(ccp, action)) {
+            if (just_pressed) {
+                *just_pressed = false;
+            }
+            return false;
+        }
+        return vote_panel_check_pressed_hook.call_target(ccp, action, just_pressed);
+    },
+};
+
+FunHook<bool(rf::ControlConfig*, rf::ControlConfigAction)> vote_panel_is_control_down_hook{
+    0x00430F40,
+    [](rf::ControlConfig* ccp, rf::ControlConfigAction action) {
+        if (gameplay_overlay_blocks_action(ccp, action)) {
+            return false;
+        }
+        return vote_panel_is_control_down_hook.call_target(ccp, action);
+    },
+};
+
+} // namespace
+
+bool vote_panel_is_open()
+{
+    return g_open;
+}
+
+void vote_panel_open()
+{
+    // Opening from the menu supersedes a gameplay overlay (no double-open).
+    if (g_context == VotePanelContext::Gameplay) {
+        gameplay_overlay_apply_mouse(false);
+    }
+    g_open = true;
+    g_context = VotePanelContext::MultiMenu;
+    g_form.description_mutator = -1;
+    g_form.mutator_scroll = 0.0f;
+    drop_pending_vote(); // a stash from a previous open can never outlive it
+    vote_options_request_if_needed();
+}
+
+void vote_panel_close()
+{
+    if (g_context == VotePanelContext::Gameplay) {
+        gameplay_overlay_apply_mouse(false);
+        // Rest of this frame plus at least one whole frame, extended while held.
+        g_swallow_attack_frames = 2;
+    }
+    g_open = false;
+    g_context = VotePanelContext::None;
+}
+
+void vote_panel_render()
+{
+    if (!g_open || g_context != VotePanelContext::MultiMenu) {
+        return;
+    }
+    if (!rf::is_multi) {
+        vote_panel_close();
+        clear_auto_return(); // left the server mid-unwind
+        drop_pending_vote();
+        return;
+    }
+
+    int x = 0, y = 0, z = 0;
+    rf::mouse_get_pos(x, y, z);
+
+    PanelUi ui;
+    ui.draw = true;
+    ui.mx = x;
+    ui.my = y;
+    vote_panel_do(ui);
+
+    // The menu frame + mouse cursor are drawn right after us; never leave a
+    // narrowed clip window behind.
+    rf::gr::reset_clip();
+}
+
+void vote_panel_handle_mouse()
+{
+    if (!g_open) {
+        return;
+    }
+
+    // Read the wheel accumulator before touching the mouse API.
+    const int wheel = rf::mouse_dz;
+
+    int x = 0, y = 0, z = 0;
+    rf::mouse_get_pos(x, y, z);
+
+    PanelUi ui;
+    ui.draw = false;
+    ui.mx = x;
+    ui.my = y;
+    ui.click = rf::mouse_was_button_pressed(0) != 0;
+    ui.rclick = rf::mouse_was_button_pressed(1) != 0;
+    ui.wheel = wheel;
+    vote_panel_do(ui);
+}
+
+void vote_panel_handle_key(int key)
+{
+    if (!g_open) {
+        return;
+    }
+    if (key == rf::KEY_ESC) {
+        vote_panel_close();
+        play_click_sound();
+    }
+    // Everything else is swallowed while the modal is up.
+}
+
+bool vote_panel_is_gameplay_overlay_active()
+{
+    return g_open && g_context == VotePanelContext::Gameplay;
+}
+
+void vote_panel_toggle_gameplay()
+{
+    if (g_open) {
+        // Also covers "menu instance somehow still open": close whatever is up.
+        vote_panel_close();
+        play_click_sound();
+        return;
+    }
+    if (!rf::is_multi || rf::is_server || rf::gameseq_get_state() != rf::GS_GAMEPLAY) {
+        return;
+    }
+
+    g_open = true;
+    g_context = VotePanelContext::Gameplay;
+    g_form.description_mutator = -1;
+    g_form.mutator_scroll = 0.0f;
+    drop_pending_vote();
+    gameplay_overlay_apply_mouse(true);
+    vote_options_request_if_needed(); // shared cache, same as the menu path
+    rf::snd_play(stock_sound_id::menu_select, 0, 0.0f, 1.0f);
+}
+
+void vote_panel_gameplay_input()
+{
+    if (g_context != VotePanelContext::Gameplay) {
+        return;
+    }
+
+    // Force-close on anything that is not a live multiplayer gameplay frame:
+    // level change / limbo entry, multi_stop, becoming a server.
+    if (!rf::is_multi || rf::is_server || rf::gameseq_get_state() != rf::GS_GAMEPLAY) {
+        vote_panel_close();
+        return;
+    }
+
+    // Re-assert every frame; respawns and camera changes reset mouse mode.
+    gameplay_overlay_apply_mouse(true);
+
+    if (stock_popup_is_active()) {
+        return; // the popup owns input; panel keeps rendering underneath
+    }
+
+    // Read the wheel accumulator before touching the mouse API.
+    const int wheel = rf::mouse_dz;
+
+    int x = 0, y = 0, z = 0;
+    rf::mouse_get_pos(x, y, z);
+
+    PanelUi ui;
+    ui.draw = false;
+    ui.mx = x;
+    ui.my = y;
+    ui.click = rf::mouse_was_button_pressed(0) != 0;
+    ui.rclick = rf::mouse_was_button_pressed(1) != 0;
+    ui.wheel = wheel;
+    vote_panel_do(ui);
+}
+
+void vote_panel_gameplay_render()
+{
+    if (!g_open || g_context != VotePanelContext::Gameplay) {
+        return;
+    }
+    // The input pump runs before gameseq_process, so on the frame a level change
+    // lands it still saw gameplay; re-check here so the overlay never draws over
+    // limbo or a loading screen even once.
+    if (!rf::is_multi || rf::is_server || rf::gameseq_get_state() != rf::GS_GAMEPLAY) {
+        vote_panel_close();
+        return;
+    }
+
+    int x = 0, y = 0, z = 0;
+    rf::mouse_get_pos(x, y, z);
+
+    PanelUi ui;
+    ui.draw = true;
+    ui.mx = x;
+    ui.my = y;
+    vote_panel_do(ui);
+
+    rf::gr::reset_clip();
+
+    // gameseq_process re-hides the cursor every gameplay frame (mouse_set_visible
+    // (false) at 0x004342E6), which undoes what the input pump sets because the
+    // pump runs before it. This hook sits after gameseq_process and before the
+    // stock cursor render (game_do_frame -> 0x004355F0 -> 0x00435460), so
+    // re-asserting here is what actually makes the cursor appear -- and it draws
+    // after us, so it lands on top of the panel for free.
+    rf::mouse_set_visible(true);
+}
+
+void vote_panel_apply_patch()
+{
+    multi_menu_init_hook.install();
+    multi_menu_nav_next_hook.install();
+    multi_menu_nav_prev_hook.install();
+    multi_menu_mouse_hook.install();
+    multi_menu_render_injection.install();
+    mainmenu_do_frame_hook.install();
+    gameseq_process_hook.install();
+    gameseq_push_state_hook.install();
+    vote_panel_check_pressed_hook.install();
+    vote_panel_is_control_down_hook.install();
+
+    // Seed the stock entries so the patched array is never empty, even if
+    // something touches the menu before multi_menu_init has run.
+    for (int i = 0; i < 4; ++i) {
+        g_multi_menu_gadgets.items[i] = &stock_multi_menu_button(i);
+    }
+    g_multi_menu_gadgets.count = 4;
+
+    // Hit-test count is hardcoded; our button is index 4.
+    AsmWriter{multi_menu_hit_test_count_push}.push(5);
+
+    // Point every read of the (full) stock dispatch array at the AF array.
+    for (uintptr_t site : dispatch_array_sites) {
+        write_mem<void*>(site + 1, &g_multi_menu_gadgets);
+    }
+
+    // Retarget the per-frame key handler registration to the AF wrapper.
+    write_mem<void*>(multi_menu_key_handler_push_imm, reinterpret_cast<void*>(&multi_menu_key_handler));
+}

--- a/game_patch/misc/vote_panel.cpp
+++ b/game_patch/misc/vote_panel.cpp
@@ -5,20 +5,17 @@
 #include <string>
 #include <string_view>
 #include <vector>
-#include <patch_common/AsmWriter.h>
 #include <patch_common/CallHook.h>
-#include <patch_common/CodeInjection.h>
 #include <patch_common/FunHook.h>
-#include <patch_common/MemUtils.h>
 #include <common/utils/list-utils.h>
 #include <xlog/xlog.h>
 #include "vote_panel.h"
 #include "player.h"
 #include "../hud/hud_internal.h"
 #include "../hud/remote_server_cfg_ui.h"
+#include "../input/control_input_filter.h"
 #include "../multi/alpine_packets.h"
 #include "../multi/vote_client.h"
-#include "../os/os.h"
 #include "../rf/gameseq.h"
 #include "../rf/gr/gr.h"
 #include "../rf/gr/gr_font.h"
@@ -33,148 +30,9 @@
 namespace
 {
 
-// ---------------------------------------------------------------------------
-// Frozen RF.exe addresses (multiplayer menu internals, verified in 1.20na).
-// The multi menu does not use rf::ui::Container: it keeps its gadgets in two
-// counted arrays, one for mouse hit-testing and one for everything else.
-// ---------------------------------------------------------------------------
-
-constexpr uintptr_t multi_menu_init_addr = 0x00448C20;
-constexpr uintptr_t multi_menu_back_on_click_addr = 0x00448BF0;
-constexpr uintptr_t multi_menu_key_handler_addr = 0x00448F80;
-constexpr uintptr_t multi_menu_key_handler_push_imm = 0x00448F39;
-constexpr uintptr_t multi_menu_mouse_handler_addr = 0x00449180;
-constexpr uintptr_t multi_menu_hit_test_count_push = 0x004491A0;
-constexpr uintptr_t multi_menu_hit_test_array = 0x0063E1F0;
-constexpr uintptr_t multi_menu_hit_test_array_add = 0x00449500;
-constexpr uintptr_t multi_menu_nav_next_addr = 0x004490F0;
-constexpr uintptr_t multi_menu_nav_prev_addr = 0x00449140;
-constexpr uintptr_t multi_menu_render_button_loop = 0x00449476;
-constexpr uintptr_t multi_menu_render_button_loop_end = 0x004494A0;
-constexpr uintptr_t multi_menu_first_button = 0x0063E0E0;
-constexpr int multi_menu_button_stride = 0x44;
-constexpr uintptr_t mainmenu_do_frame_addr = 0x00443780;
-constexpr uintptr_t mainmenu_do_return_addr = 0x00443C90;
-
-// Every executable read of the (already full) stock dispatch array
-// `MOV ECX, 0x0063E090`. The imm32 lives at site+1. The four init-time add calls
-// are left alone, which leaves the stock array populated but unreferenced.
-//
-// 0x00448A90 / 0x00448AB0 also load that address but are deliberately NOT here:
-// they are the MSVC static ctor/dtor thunks for the stock VArray, reached only
-// from the CRT initializer table entry at 0x005932FC (0x00448A80 -> CALL ctor,
-// JMP dtor-registration). The ctor already ran during CRT init, long before
-// misc_init() patches anything, and the dtor target (0x0054D9E0) is a bare RET,
-// so retargeting either one is a no-op.
-constexpr uintptr_t dispatch_array_sites[] = {
-    0x00448EF1, 0x00448F02, 0x00448F15, 0x00448F58, // do_frame
-    0x004491F4, 0x0044920C,                         // mouse handler
-    0x00448FD8, 0x00448FF4, 0x0044908A, 0x004490A4, // key handler
-};
-
-// Set by mainmenu_init from the gameseq state underneath the menu: non-zero
-// means the menu was opened from inside a running game (it is what disables the
-// stock JOIN GAME / CREATE GAME buttons).
-auto& g_menu_opened_in_game = addr_as_ref<uint8_t>(0x0063C11C);
-auto& g_multi_menu_focus_index = addr_as_ref<int>(0x0063E0A4);
-
-// Layout-compatible with the stock counted gadget arrays: {count, items[]}.
-struct MultiMenuGadgetArray
-{
-    int32_t count;
-    rf::ui::Gadget* items[8];
-};
-
-MultiMenuGadgetArray g_multi_menu_gadgets{};
-rf::ui::Button g_call_vote_button{};
-bool g_call_vote_button_created = false;
-
-// Index in both the AF dispatch array and the stock hit-test array.
-constexpr int call_vote_gadget_index = 4;
-
-// --- gameseq state stack internals (RF.exe 1.20na) -------------------------
-// gameseq_process applies at most ONE deferred change per frame, and the pop
-// branch of gameseq_process_deferred_change (0x00434310) does a bare `idx--`
-// with no lower bound. A pop issued against a stale view of the stack therefore
-// underflows to idx = -1, where the tail returns states[-1] (BSS, reads 0) and
-// the engine sits in state 0 forever -- state 0 has no case in
-// gameseq_init_state (0x004B1AC0) or gameseq_close_state (0x004B1BF0).
-// Worse, gameseq_set_state (0x00434190) with force = 0 is silently DROPPED
-// while a pop is pending, so a pending pop of ours can also swallow the
-// server-driven level change outright.
-constexpr uintptr_t gameseq_state_stack_addr = 0x00630064;
-constexpr uintptr_t gameseq_state_index_addr = 0x005967A4;
-constexpr uintptr_t gameseq_pop_pending_addr = 0x006300EA;
-constexpr uintptr_t gameseq_push_pending_addr = 0x006300EB;
-
-int gameseq_stack_top()
-{
-    return addr_as_ref<int32_t>(gameseq_state_index_addr);
-}
-
-rf::GameState gameseq_state_at(int index)
-{
-    return static_cast<rf::GameState>(
-        addr_as_ref<int32_t>(gameseq_state_stack_addr + index * 4));
-}
-
-// True while any deferred change is queued: the stack we can observe now is not
-// the stack that will be current once it lands, so no pop may be issued.
-bool gameseq_change_pending()
-{
-    return addr_as_ref<uint8_t>(gameseq_pop_pending_addr) != 0
-        || addr_as_ref<uint8_t>(gameseq_push_pending_addr) != 0
-        || static_cast<int>(rf::gameseq_get_pending_state()) != 0;
-}
-
-// What the stock RETURN TO GAME button unwinds into. Limbo counts: the menu can
-// be opened during the between-levels wait and stock returns there too.
-bool is_returnable_bottom_state(rf::GameState state)
-{
-    return state == rf::GS_GAMEPLAY || state == rf::GS_MULTI_LIMBO;
-}
-
-// One-shot, consumed by the next main menu frame. It also expires on its own:
-// if the engine takes over (instantly passed vote -> level change -> limbo) the
-// main menu may never run again, and a flag left set would otherwise fire
-// minutes later and close the ESC menu out from under the player.
-constexpr int64_t auto_return_lifetime_ms = 1000;
-bool g_auto_return_to_game = false;
-int64_t g_auto_return_deadline_ms = 0;
-
-void clear_auto_return()
-{
-    g_auto_return_to_game = false;
-    g_auto_return_deadline_ms = 0;
-}
-
-// --- deferred vote send ----------------------------------------------------
-// The vote call is stashed on click and only sent once the menu unwind has
-// reached a terminal state. gameseq_set_state (0x00434190) silently drops a
-// non-forced transition while a deferred change is queued, so sending on click
-// let the server's reply race our pops: a vote that passes instantly (sole
-// eligible voter) had its enter-limbo transition discarded, leaving the client
-// in GS_GAMEPLAY with no traffic -- the connection-interrupted overlay -- for
-// the whole limbo. Sending only once the slot is free makes that impossible.
-bool g_pending_vote_valid = false;
-AfVoteCallParams g_pending_vote;
-
-void drop_pending_vote()
-{
-    g_pending_vote_valid = false;
-    g_pending_vote = AfVoteCallParams{};
-}
-
-// --- open context -----------------------------------------------------------
-// Which site owns rendering. Exactly one render call happens per frame.
-enum class VotePanelContext
-{
-    None,
-    MultiMenu,
-    Gameplay,
-};
-
-VotePanelContext g_context = VotePanelContext::None;
+// True while the overlay is up. The overlay is the only way the panel is ever
+// shown, so this doubles as "the panel owns input and rendering this frame".
+bool g_open = false;
 
 // Player's local "filter the map list by gametype" choice. Session only, not
 // persisted; ignored (forced on) while the server enforces the prefix.
@@ -248,14 +106,6 @@ bool g_gameplay_prev_mouse_look = false;
 // frame alike. Counts frames rather than latching a bool so it cannot stick.
 int g_swallow_attack_frames = 0;
 
-// A stock popup (manual level name, int/float option) takes over input while it
-// is up. gameseq_process passes no_input=1 to the state's own frame, but our
-// gameplay pump runs outside that, so it has to check explicitly.
-bool stock_popup_is_active()
-{
-    return addr_as_ref<bool()>(0x00456680)();
-}
-
 // Only attacks are affected; movement is never blocked.
 void vote_panel_decay_attack_swallow()
 {
@@ -287,7 +137,7 @@ void gameplay_overlay_apply_mouse(bool active)
         return;
     }
 
-    // mouse_look is a PERSISTED player setting: only drop the override once the
+    // mouse_look is a persisted player setting: only drop the override once the
     // saved value is actually back. If the player object is gone (disconnect,
     // kick, level change) keep it pending so the next apply can still restore it
     // rather than losing the user's setting permanently.
@@ -304,11 +154,6 @@ void gameplay_overlay_apply_mouse(bool active)
         rf::mouse_keep_centered_enable();
         rf::mouse_set_visible(false);
     }
-}
-
-rf::ui::Button& stock_multi_menu_button(int index)
-{
-    return addr_as_ref<rf::ui::Button>(multi_menu_first_button + index * multi_menu_button_stride);
 }
 
 // ---------------------------------------------------------------------------
@@ -371,7 +216,7 @@ const VoteTypeInfo vote_type_infos[] = {
 };
 
 // Short tag for the game type selector. The blob carries full display names
-// ("Damage Control") which overflow the selector at menu-native resolutions.
+// ("Damage Control") which overflow the selector at low resolutions.
 // Deliberately not multi_game_type_name_short(): that maps every unrecognised id
 // to "TDM" and logs a warning, whereas a game type this build predates has to
 // fall back to the server-sent name.
@@ -458,7 +303,6 @@ struct KickCandidate
 std::vector<KickCandidate> g_kick_cache;
 std::vector<std::string> g_kick_names;
 
-bool g_open = false;
 FormState g_form;
 
 // Popup input targets. The stock popup callback takes no arguments, so the
@@ -1095,7 +939,8 @@ std::vector<VoteMutatorInput> build_mutator_inputs(const VoteOptionsData& option
 
 // ---------------------------------------------------------------------------
 // Popup text input (stock RF popup; gameseq_process drives it globally, so it
-// works from the multi menu and suppresses our input handlers while it is up)
+// works over the gameplay overlay -- see rf::ui::popup_is_active, which is what
+// suppresses our own input handling while it is up)
 // ---------------------------------------------------------------------------
 
 void manual_level_popup_callback()
@@ -1171,36 +1016,7 @@ void play_click_sound()
 
 void play_toggle_sound(bool on)
 {
-    // Intentional, do not "fix": this matches the established AF convention in
-    // misc/ui.cpp's ao_play_button_snd, which plays checkbox_off when turning a
-    // setting ON. The .wav names read backwards but the panels must agree.
     rf::snd_play(on ? stock_sound_id::checkbox_off : stock_sound_id::checkbox_on, 0, 0.0f, 1.0f);
-}
-
-void close_panel_and_return_to_game()
-{
-    vote_panel_close();
-
-    // Only start the unwind when the stack is exactly what we intend to unwind,
-    // right now, with nothing already queued. A vote that passes instantly (sole
-    // eligible voter) can have the server's level change in flight before we get
-    // here, and the engine's transition must win -- if we popped anyway our pop
-    // would either swallow its gameseq_set_state or, once it collapsed the stack,
-    // underflow the index.
-    if (gameseq_change_pending() || gameseq_stack_top() != 2
-        || gameseq_state_at(2) != rf::GS_MULTI_MENU
-        || gameseq_state_at(1) != rf::GS_MAIN_MENU
-        || !is_returnable_bottom_state(gameseq_state_at(0))) {
-        clear_auto_return();
-        return; // panel is closed; the engine takes it from here
-    }
-
-    // The stock BACK handler pops GS_MULTI_MENU (deferred). The second pop, out
-    // of GS_MAIN_MENU, has to wait for the next frame because gameseq_pop_state
-    // only sets pending flags and is idempotent within one frame.
-    AddrCaller{multi_menu_back_on_click_addr}.c_call<void>(0, 0);
-    g_auto_return_to_game = true;
-    g_auto_return_deadline_ms = timer::get_i64(1000) + auto_return_lifetime_ms;
 }
 
 // Mirrors send_vote_from_form's validation so the button can be greyed out
@@ -1264,13 +1080,11 @@ void send_vote_from_form(const VoteOptionsData& options)
             break; // parameterless
     }
 
-    // Stashed rather than sent: the packet goes out from vote_send_tick() once
-    // the unwind is done and the deferred-change slot is free again.
-    g_pending_vote = std::move(params);
-    g_pending_vote_valid = true;
+    // Sent the vote call.
+    af_send_vote_call(params);
 
     play_click_sound();
-    close_panel_and_return_to_game();
+    vote_panel_close();
 }
 
 void do_message_block(PanelUi& ui, const Layout& lo, const std::vector<std::string>& lines)
@@ -1527,7 +1341,7 @@ void do_level_column(PanelUi& ui, const Layout& lo, const VoteOptionsData& optio
     const bool filter_active = options.gametype_prefix_restricted || g_filter_gametype_local;
 
     // Rebuild the display rows only when an input changed. allowed_for_vote is an
-    // INDEPENDENT axis from the gametype mask: it is applied ALWAYS, because a
+    // independent axis from the gametype mask: it is applied ALWAYS, because a
     // level the server vote_level allow-list refuses is rejected whatever game
     // type is picked. Hence it is not gated on filter_active.
     const uint32_t levels_fp = level_list_fingerprint(options);
@@ -1951,484 +1765,12 @@ void vote_panel_do(PanelUi& ui)
 }
 
 // ---------------------------------------------------------------------------
-// Multi menu integration
+// Gameplay overlay driving
 // ---------------------------------------------------------------------------
-
-void call_vote_button_on_click(int, int)
-{
-    vote_panel_open();
-    rf::snd_play(stock_sound_id::menu_select, 0, 0.0f, 1.0f);
-}
-
-void update_call_vote_button_enabled()
-{
-    g_call_vote_button.enabled = rf::is_multi && !rf::is_server && g_menu_opened_in_game != 0;
-}
-
-FunHook<void()> multi_menu_init_hook{
-    multi_menu_init_addr,
-    []() {
-        multi_menu_init_hook.call_target();
-
-        if (!g_call_vote_button_created) {
-            g_call_vote_button.init();
-            g_call_vote_button.create("button_more.tga", "button_selected.tga", 0, 0, rf::KEY_V,
-                "CALL VOTE", rf::ui::medium_font_0);
-            g_call_vote_button.key = rf::KEY_V;
-            g_call_vote_button.on_click = call_vote_button_on_click;
-            // Park it off-screen: the mouse handler runs before the render that
-            // assigns real coords, so at (0,0) the screen corner would hit-test
-            // as CALL VOTE on the first menu frame.
-            g_call_vote_button.x = -10000;
-            g_call_vote_button.y = -10000;
-
-            // Append to the stock hit-test array so the button becomes hit-test
-            // index 4; the AF dispatch array must use that same index order.
-            const int hit_test_index = AddrCaller{multi_menu_hit_test_array_add}.this_call<int>(
-                reinterpret_cast<void*>(multi_menu_hit_test_array), &g_call_vote_button);
-            if (hit_test_index != call_vote_gadget_index) {
-                // -1 means the capacity-20 array was full; anything else means the
-                // stock button count changed. Either way our index assumption and
-                // the PUSH 5 below would be wrong.
-                xlog::error("vote panel: CALL VOTE hit-test index {} != {}", hit_test_index,
-                    call_vote_gadget_index);
-            }
-
-            for (int i = 0; i < 4; ++i) {
-                g_multi_menu_gadgets.items[i] = &stock_multi_menu_button(i);
-            }
-            g_multi_menu_gadgets.items[call_vote_gadget_index] = &g_call_vote_button;
-            g_multi_menu_gadgets.count = 5;
-            g_call_vote_button_created = true;
-
-            // Only now is items[4] real: the hardcoded PUSH 4 that feeds
-            // get_gadget_from_pos must not count a slot that is still null.
-            AsmWriter{multi_menu_hit_test_count_push}.push(5);
-        }
-
-        update_call_vote_button_enabled();
-        vote_panel_close();
-        // Re-entering the multi menu means no unwind of ours is in flight.
-        clear_auto_return();
-        drop_pending_vote();
-    },
-};
-
-// The stock helpers walk the button block by raw address, so they cannot see a
-// fifth button living outside it; they are replaced rather than patched.
-// Dispatch index -> on-screen row order. CALL VOTE sits above BACK on screen but
-// after it in the arrays (hit-test order is fixed by the append at index 4, and
-// the mouse handler feeds that index straight into the dispatch array), so the
-// arrays must not be reordered -- the keyboard walk is mapped instead.
-constexpr int visual_order_of_gadget[] = {0, 1, 2, 4, 3};
-
-void multi_menu_nav(int dir)
-{
-    const int count = g_multi_menu_gadgets.count;
-    if (count <= 0) {
-        return;
-    }
-    const int order_count = static_cast<int>(std::size(visual_order_of_gadget));
-
-    // Walk in visual order so DOWN always moves down the screen.
-    int visual = 0;
-    if (g_multi_menu_focus_index >= 0 && g_multi_menu_focus_index < order_count) {
-        visual = visual_order_of_gadget[g_multi_menu_focus_index];
-    }
-
-    for (int i = 0; i < count; ++i) {
-        visual += dir;
-        if (visual >= count) {
-            visual = 0;
-        }
-        else if (visual < 0) {
-            visual = count - 1;
-        }
-        // Map the visual row back to its dispatch slot.
-        int dispatch = visual;
-        for (int slot = 0; slot < order_count && slot < count; ++slot) {
-            if (visual_order_of_gadget[slot] == visual) {
-                dispatch = slot;
-                break;
-            }
-        }
-        const rf::ui::Gadget* gadget = g_multi_menu_gadgets.items[dispatch];
-        if (gadget && gadget->enabled) {
-            g_multi_menu_focus_index = dispatch;
-            break;
-        }
-    }
-}
-
-FunHook<void()> multi_menu_nav_next_hook{multi_menu_nav_next_addr, []() { multi_menu_nav(1); }};
-FunHook<void()> multi_menu_nav_prev_hook{multi_menu_nav_prev_addr, []() { multi_menu_nav(-1); }};
-
-FunHook<void()> multi_menu_mouse_hook{
-    multi_menu_mouse_handler_addr,
-    []() {
-        if (vote_panel_is_open()) {
-            vote_panel_handle_mouse();
-            return;
-        }
-        multi_menu_mouse_hook.call_target();
-    },
-};
-
-// Replaces the stock button render loop so the buttons come from the AF array
-// (in visual order) and the vote panel can be drawn before the mouse cursor.
-CodeInjection multi_menu_render_injection{
-    multi_menu_render_button_loop,
-    [](auto& regs) {
-        // Same order the keyboard walk uses (see visual_order_of_gadget).
-        static const int visual_order[] = {0, 1, 2, call_vote_gadget_index, 3};
-
-        update_call_vote_button_enabled();
-
-        const int x = regs.ebx;
-        int y = regs.edi;
-        for (int index : visual_order) {
-            if (index >= g_multi_menu_gadgets.count) {
-                continue;
-            }
-            auto* button = static_cast<rf::ui::Button*>(g_multi_menu_gadgets.items[index]);
-            if (!button || !button->enabled) {
-                continue; // disabled buttons consume no row, same as stock
-            }
-            button->x = x;
-            button->y = y;
-            button->render();
-            y += rf::ui::menu_button_offset_y;
-        }
-
-        vote_panel_render();
-
-        regs.eip = multi_menu_render_button_loop_end;
-    },
-};
-
-// Registered every frame by the multi menu do_frame via PUSH <handler>.
-void multi_menu_key_handler(int key)
-{
-    if (vote_panel_is_open()) {
-        vote_panel_handle_key(key);
-        return;
-    }
-    // The stock handler forwards every key to the character setup sub-panel
-    // while it is open; don't steal the hotkey from it.
-    const bool sub_panel_open = addr_as_ref<uint8_t>(0x0063E088) != 0;
-    if (!sub_panel_open && key == rf::KEY_V && g_call_vote_button.enabled) {
-        g_multi_menu_focus_index = call_vote_gadget_index;
-        if (g_call_vote_button.on_click) {
-            g_call_vote_button.on_click(0, 0);
-        }
-        return;
-    }
-    AddrCaller{multi_menu_key_handler_addr}.c_call<void>(key);
-}
-
-// True only when popping GS_MAIN_MENU back to gameplay is provably safe this
-// frame. Every other observation abandons the auto-return rather than guessing.
-bool consume_auto_return()
-{
-    if (!g_auto_return_to_game) {
-        return false;
-    }
-
-    // Left the server, or the engine never gave the main menu another frame.
-    if (!rf::is_multi || timer::get_i64(1000) > g_auto_return_deadline_ms) {
-        clear_auto_return();
-        return false;
-    }
-
-    // GS_MULTI_MENU is transparent, so this hook also runs underneath it. The
-    // one legitimate in-flight observation is the frame before our own
-    // GS_MULTI_MENU pop is applied; anything else means the engine took over.
-    const rf::GameState state = rf::gameseq_get_state();
-    if (state != rf::GS_MAIN_MENU) {
-        const bool our_pop_in_flight = state == rf::GS_MULTI_MENU
-            && addr_as_ref<uint8_t>(gameseq_pop_pending_addr) != 0
-            && static_cast<int>(rf::gameseq_get_pending_state()) == 0;
-        if (!our_pop_in_flight) {
-            clear_auto_return();
-        }
-        return false;
-    }
-
-    // Main menu is on top. Require exactly [gameplay, GS_MAIN_MENU] and no
-    // queued change, so the pop cannot underflow and cannot race a transition.
-    if (gameseq_change_pending() || gameseq_stack_top() != 1
-        || gameseq_state_at(1) != rf::GS_MAIN_MENU
-        || !is_returnable_bottom_state(gameseq_state_at(0))) {
-        clear_auto_return();
-        return false;
-    }
-
-    clear_auto_return();
-    return true;
-}
-
-FunHook<void(int)> mainmenu_do_frame_hook{
-    mainmenu_do_frame_addr,
-    [](int no_input) {
-        if (consume_auto_return()) {
-            AddrCaller{mainmenu_do_return_addr}.c_call<void>();
-            return; // skip the main menu frame entirely so it never flashes
-        }
-        mainmenu_do_frame_hook.call_target(no_input);
-    },
-};
-
-// Terminal states of the unwind: no auto-return still owed and nothing queued in
-// the deferred-change slot. That covers "unwind completed" (back in gameplay),
-// "unwind abandoned, still connected" (the server adjudicates and replies), and
-// guarantees our reply can no longer collide with a pop of ours.
-void vote_send_tick()
-{
-    if (!g_pending_vote_valid) {
-        return;
-    }
-    if (!rf::is_multi || rf::is_server) {
-        drop_pending_vote(); // disconnected before we got to send it
-        return;
-    }
-    if (g_auto_return_to_game || gameseq_change_pending()) {
-        return; // unwind still in flight
-    }
-
-    const AfVoteCallParams params = g_pending_vote; // one-shot
-    drop_pending_vote();
-    af_send_vote_call(params);
-}
-
-// Runs every frame regardless of game state, right after the state machine has
-// applied this frame's deferred change.
-CallHook<rf::GameState()> gameseq_process_hook{
-    0x004B2DB1,
-    []() -> rf::GameState {
-        // Before the state runs its frame, so the overlay sees keys/clicks first.
-        vote_panel_decay_attack_swallow();
-        vote_panel_gameplay_input();
-        const rf::GameState state = gameseq_process_hook.call_target();
-        vote_send_tick();
-        return state;
-    },
-};
-
-// ESC during gameplay pushes GS_MAIN_MENU. While the overlay is up, treat that
-// as "close the modal" and swallow the push, so ESC behaves like it does in the
-// menu context and the ESC menu can never open on top of the overlay.
-FunHook<void(rf::GameState, bool, bool)> gameseq_push_state_hook{
-    0x00434410,
-    [](rf::GameState state, bool transparent, bool pause_beneath) {
-        if (state == rf::GS_MAIN_MENU && g_open && g_context == VotePanelContext::Gameplay) {
-            vote_panel_close();
-            play_click_sound();
-            return;
-        }
-        gameseq_push_state_hook.call_target(state, transparent, pause_beneath);
-    },
-};
-
-// Clicking in the panel must not also fire the weapon. Movement is left alone
-// (the panel does not pause a multiplayer game), matching the waypoint editor.
-bool gameplay_overlay_blocks_action(rf::ControlConfig* ccp, rf::ControlConfigAction action)
-{
-    const bool overlay_up = g_open && g_context == VotePanelContext::Gameplay;
-    if (!overlay_up && g_swallow_attack_frames <= 0) {
-        return false;
-    }
-    if (!rf::local_player || ccp != &rf::local_player->settings.controls) {
-        return false;
-    }
-    return action == rf::CC_ACTION_PRIMARY_ATTACK || action == rf::CC_ACTION_SECONDARY_ATTACK;
-}
-
-FunHook<bool(rf::ControlConfig*, rf::ControlConfigAction, bool*)> vote_panel_check_pressed_hook{
-    0x0043D4F0,
-    [](rf::ControlConfig* ccp, rf::ControlConfigAction action, bool* just_pressed) {
-        if (gameplay_overlay_blocks_action(ccp, action)) {
-            if (just_pressed) {
-                *just_pressed = false;
-            }
-            return false;
-        }
-        return vote_panel_check_pressed_hook.call_target(ccp, action, just_pressed);
-    },
-};
-
-FunHook<bool(rf::ControlConfig*, rf::ControlConfigAction)> vote_panel_is_control_down_hook{
-    0x00430F40,
-    [](rf::ControlConfig* ccp, rf::ControlConfigAction action) {
-        if (gameplay_overlay_blocks_action(ccp, action)) {
-            return false;
-        }
-        return vote_panel_is_control_down_hook.call_target(ccp, action);
-    },
-};
-
-// The two hooks above are shared with waypoints_utils and bot_main, which both
-// install lazily; match that so single-player and dedicated servers never carry
-// the chain. Installed on the first gameplay overlay open.
-bool g_control_hooks_installed = false;
-
-void ensure_control_hooks_installed()
-{
-    if (g_control_hooks_installed) {
-        return;
-    }
-    vote_panel_check_pressed_hook.install();
-    vote_panel_is_control_down_hook.install();
-    g_control_hooks_installed = true;
-}
-
-// gameseq_process renders an active popup itself, at 0x004342CD, i.e. INSIDE the
-// call this hook wraps -- so anything drawn from the after-frame hook
-// (0x004B2DC2) lands on top of the popup and hides it. Rendering the overlay
-// here instead puts it before the popup render, so a popup is drawn over the
-// panel and stays usable. The dispatcher recurses for transparent states, hence
-// the outermost-level check.
-FunHook<void(int, int)> gameseq_state_do_frame_hook{
-    0x004343C0,
-    [](int state_index, int no_input) {
-        gameseq_state_do_frame_hook.call_target(state_index, no_input);
-        if (state_index == gameseq_stack_top()) {
-            vote_panel_gameplay_render();
-        }
-    },
-};
-
-} // namespace
-
-bool vote_panel_is_open()
-{
-    return g_open;
-}
-
-void vote_panel_open()
-{
-    // Opening from the menu supersedes a gameplay overlay (no double-open).
-    if (g_context == VotePanelContext::Gameplay) {
-        gameplay_overlay_apply_mouse(false);
-    }
-    g_open = true;
-    g_context = VotePanelContext::MultiMenu;
-    g_form.description_mutator = -1;
-    g_form.mutator_scroll = 0.0f;
-    drop_pending_vote(); // a stash from a previous open can never outlive it
-    clear_popup_target();
-    g_level_cache.valid = false; // never show another blob's rows
-}
-
-void vote_panel_close()
-{
-    if (g_context == VotePanelContext::Gameplay) {
-        gameplay_overlay_apply_mouse(false);
-        // Rest of this frame plus at least one whole frame, extended while held.
-        g_swallow_attack_frames = 2;
-    }
-    g_open = false;
-    g_context = VotePanelContext::None;
-    clear_popup_target();
-}
-
-void vote_panel_render()
-{
-    if (!g_open || g_context != VotePanelContext::MultiMenu) {
-        return;
-    }
-    if (!rf::is_multi) {
-        vote_panel_close();
-        clear_auto_return(); // left the server mid-unwind
-        drop_pending_vote();
-        return;
-    }
-
-    int x = 0, y = 0, z = 0;
-    rf::mouse_get_pos(x, y, z);
-
-    PanelUi ui;
-    ui.draw = true;
-    ui.mx = x;
-    ui.my = y;
-    vote_panel_do(ui);
-
-    // The menu frame + mouse cursor are drawn right after us; never leave a
-    // narrowed clip window behind.
-    rf::gr::reset_clip();
-}
-
-void vote_panel_handle_mouse()
-{
-    if (!g_open) {
-        return;
-    }
-
-    // Read the wheel accumulator before touching the mouse API.
-    const int wheel = rf::mouse_dz;
-
-    int x = 0, y = 0, z = 0;
-    rf::mouse_get_pos(x, y, z);
-
-    PanelUi ui;
-    ui.draw = false;
-    ui.mx = x;
-    ui.my = y;
-    ui.click = rf::mouse_was_button_pressed(0) != 0;
-    ui.rclick = rf::mouse_was_button_pressed(1) != 0;
-    ui.wheel = wheel;
-    vote_panel_do(ui);
-}
-
-void vote_panel_handle_key(int key)
-{
-    if (!g_open) {
-        return;
-    }
-    if (key == rf::KEY_ESC) {
-        vote_panel_close();
-        play_click_sound();
-    }
-    // Everything else is swallowed while the modal is up.
-}
-
-bool vote_panel_is_gameplay_overlay_active()
-{
-    return g_open && g_context == VotePanelContext::Gameplay;
-}
-
-void vote_panel_toggle_gameplay()
-{
-    if (g_open) {
-        // Also covers "menu instance somehow still open": close whatever is up.
-        vote_panel_close();
-        play_click_sound();
-        return;
-    }
-    if (!rf::is_multi || rf::is_server || rf::gameseq_get_state() != rf::GS_GAMEPLAY) {
-        return;
-    }
-
-    // Mutually exclusive with the remote server config overlay: both are
-    // full-screen and both read the same non-consuming mouse state.
-    if (g_remote_server_cfg_popup.is_active()) {
-        g_remote_server_cfg_popup.toggle();
-    }
-
-    ensure_control_hooks_installed();
-    g_open = true;
-    g_context = VotePanelContext::Gameplay;
-    g_form.description_mutator = -1;
-    g_form.mutator_scroll = 0.0f;
-    drop_pending_vote();
-    clear_popup_target();
-    g_level_cache.valid = false; // never show another blob's rows
-    gameplay_overlay_apply_mouse(true);
-    rf::snd_play(stock_sound_id::menu_select, 0, 0.0f, 1.0f);
-}
 
 void vote_panel_gameplay_input()
 {
-    if (g_context != VotePanelContext::Gameplay) {
+    if (!g_open) {
         return;
     }
 
@@ -2442,7 +1784,10 @@ void vote_panel_gameplay_input()
     // Re-assert every frame; respawns and camera changes reset mouse mode.
     gameplay_overlay_apply_mouse(true);
 
-    if (stock_popup_is_active()) {
+    // A stock popup (manual level name, int/float option) takes over input while
+    // it is up. gameseq_process passes no_input=1 to the state's own frame, but
+    // this gameplay pump runs outside that, so it has to check explicitly.
+    if (rf::ui::popup_is_active()) {
         return; // the popup owns input; panel keeps rendering underneath
     }
 
@@ -2464,7 +1809,7 @@ void vote_panel_gameplay_input()
 
 void vote_panel_gameplay_render()
 {
-    if (!g_open || g_context != VotePanelContext::Gameplay) {
+    if (!g_open) {
         return;
     }
     // The input pump runs before gameseq_process, so on the frame a level change
@@ -2495,31 +1840,141 @@ void vote_panel_gameplay_render()
     rf::mouse_set_visible(true);
 }
 
+// Runs every frame regardless of game state, right before the state machine
+// applies this frame's deferred change and runs the current state's frame.
+CallHook<rf::GameState()> gameseq_process_hook{
+    0x004B2DB1,
+    []() -> rf::GameState {
+        // Before the state runs its frame, so the overlay sees keys/clicks first.
+        vote_panel_decay_attack_swallow();
+        vote_panel_gameplay_input();
+        return gameseq_process_hook.call_target();
+    },
+};
+
+// ESC during gameplay pushes GS_MAIN_MENU. While the overlay is up, treat that
+// as "close the modal" and swallow the push, so ESC dismisses the panel and the
+// ESC menu can never open on top of the overlay.
+FunHook<void(rf::GameState, bool, bool)> gameseq_push_state_hook{
+    0x00434410,
+    [](rf::GameState state, bool transparent, bool pause_beneath) {
+        if (state == rf::GS_MAIN_MENU && g_open) {
+            vote_panel_close();
+            play_click_sound();
+            return;
+        }
+        gameseq_push_state_hook.call_target(state, transparent, pause_beneath);
+    },
+};
+
+// Clicking in the panel must not also fire the weapon. Movement is left alone
+// (the panel does not pause a multiplayer game), matching the waypoint editor.
+bool gameplay_overlay_blocks_action(rf::ControlConfig* ccp, rf::ControlConfigAction action)
+{
+    if (!g_open && g_swallow_attack_frames <= 0) {
+        return false;
+    }
+    if (!rf::local_player || ccp != &rf::local_player->settings.controls) {
+        return false;
+    }
+    return action == rf::CC_ACTION_PRIMARY_ATTACK || action == rf::CC_ACTION_SECONDARY_ATTACK;
+}
+
+// control_input_filter owns the hooks and installs them at startup; the panel
+// only contributes its veto, and until it does the filter has nothing to do.
+// Registration must happen once, hence the flag: the overlay can be opened any
+// number of times.
+bool g_control_veto_registered = false;
+
+void ensure_control_veto_registered()
+{
+    if (g_control_veto_registered) {
+        return;
+    }
+    control_input_filter_add_veto(&gameplay_overlay_blocks_action);
+    g_control_veto_registered = true;
+}
+
+// The dispatcher recurses into itself (the self-call at 0x004343E4) to draw the
+// states stacked under a transparent one, so the hook below re-enters once per
+// state in that chain. Counting entries and exits picks out the outermost
+// dispatch, which is the one that must render the panel -- exactly once a frame.
+int g_gameseq_dispatch_depth = 0;
+
+struct GameseqDispatchDepth
+{
+    GameseqDispatchDepth() { ++g_gameseq_dispatch_depth; }
+    ~GameseqDispatchDepth() { --g_gameseq_dispatch_depth; }
+    GameseqDispatchDepth(const GameseqDispatchDepth&) = delete;
+    GameseqDispatchDepth& operator=(const GameseqDispatchDepth&) = delete;
+
+    [[nodiscard]] bool is_outermost() const { return g_gameseq_dispatch_depth == 1; }
+};
+
+// gameseq_process renders an active popup itself, at 0x004342CD, i.e. INSIDE the
+// call this hook wraps -- so anything drawn from the after-frame hook
+// (0x004B2DC2) lands on top of the popup and hides it. Rendering the overlay
+// here instead puts it before the popup render, so a popup is drawn over the
+// panel and stays usable.
+FunHook<void(int, int)> gameseq_state_do_frame_hook{
+    0x004343C0,
+    [](int state_index, int no_input) {
+        GameseqDispatchDepth depth;
+        gameseq_state_do_frame_hook.call_target(state_index, no_input);
+        if (depth.is_outermost()) {
+            vote_panel_gameplay_render();
+        }
+    },
+};
+
+} // namespace
+
+void vote_panel_close()
+{
+    if (g_open) {
+        gameplay_overlay_apply_mouse(false);
+        // Rest of this frame plus at least one whole frame, extended while held.
+        g_swallow_attack_frames = 2;
+    }
+    g_open = false;
+    clear_popup_target();
+}
+
+bool vote_panel_is_gameplay_overlay_active()
+{
+    return g_open;
+}
+
+void vote_panel_toggle_gameplay()
+{
+    if (g_open) {
+        vote_panel_close();
+        play_click_sound();
+        return;
+    }
+    if (!rf::is_multi || rf::is_server || rf::gameseq_get_state() != rf::GS_GAMEPLAY) {
+        return;
+    }
+
+    // Mutually exclusive with the remote server config overlay: both are
+    // full-screen and both read the same non-consuming mouse state.
+    if (g_remote_server_cfg_popup.is_active()) {
+        g_remote_server_cfg_popup.toggle();
+    }
+
+    ensure_control_veto_registered();
+    g_open = true;
+    g_form.description_mutator = -1;
+    g_form.mutator_scroll = 0.0f;
+    clear_popup_target();
+    g_level_cache.valid = false; // never show another blob's rows
+    gameplay_overlay_apply_mouse(true);
+    rf::snd_play(stock_sound_id::menu_select, 0, 0.0f, 1.0f);
+}
+
 void vote_panel_apply_patch()
 {
-    multi_menu_init_hook.install();
-    multi_menu_nav_next_hook.install();
-    multi_menu_nav_prev_hook.install();
-    multi_menu_mouse_hook.install();
-    multi_menu_render_injection.install();
-    mainmenu_do_frame_hook.install();
     gameseq_process_hook.install();
     gameseq_push_state_hook.install();
     gameseq_state_do_frame_hook.install();
-
-    // Seed the stock entries so the patched array is never empty, even if
-    // something touches the menu before multi_menu_init has run.
-    for (int i = 0; i < 4; ++i) {
-        g_multi_menu_gadgets.items[i] = &stock_multi_menu_button(i);
-    }
-    g_multi_menu_gadgets.count = 4;
-
-
-    // Point every read of the (full) stock dispatch array at the AF array.
-    for (uintptr_t site : dispatch_array_sites) {
-        write_mem<void*>(site + 1, &g_multi_menu_gadgets);
-    }
-
-    // Retarget the per-frame key handler registration to the AF wrapper.
-    write_mem<void*>(multi_menu_key_handler_push_imm, reinterpret_cast<void*>(&multi_menu_key_handler));
 }

--- a/game_patch/misc/vote_panel.h
+++ b/game_patch/misc/vote_panel.h
@@ -1,0 +1,30 @@
+#pragma once
+
+// Modal "CALL VOTE" panel. Openable two ways: the CALL VOTE button in the
+// multiplayer menu (GS_MULTI_MENU), or a bindable Alpine control during
+// gameplay. Only one instance exists; the open context decides which site
+// renders it, so it is never drawn twice in a frame.
+
+bool vote_panel_is_open();
+void vote_panel_open();
+void vote_panel_close();
+
+// Drawn from the multi menu render injection, after the menu buttons and before
+// the mouse cursor. No-op unless the panel was opened from the multi menu.
+void vote_panel_render();
+
+// Called from the multi menu mouse/key hooks while the panel owns input.
+void vote_panel_handle_mouse();
+void vote_panel_handle_key(int key);
+
+// --- gameplay overlay context ---
+// Bindable control: opens/closes the overlay during a multiplayer game.
+void vote_panel_toggle_gameplay();
+// True while the overlay is up in gameplay; drives HUD/chat/input suppression.
+bool vote_panel_is_gameplay_overlay_active();
+// Per-frame input pump, run before the gameplay state takes its own input.
+void vote_panel_gameplay_input();
+// Drawn from the after-scene render hook so it lands on top of the HUD.
+void vote_panel_gameplay_render();
+
+void vote_panel_apply_patch();

--- a/game_patch/misc/vote_panel.h
+++ b/game_patch/misc/vote_panel.h
@@ -1,30 +1,12 @@
 #pragma once
 
-// Modal "CALL VOTE" panel. Openable two ways: the CALL VOTE button in the
-// multiplayer menu (GS_MULTI_MENU), or a bindable Alpine control during
-// gameplay. Only one instance exists; the open context decides which site
-// renders it, so it is never drawn twice in a frame.
+// Modal "CALL VOTE" panel.
 
-bool vote_panel_is_open();
-void vote_panel_open();
+// Closes the overlay if it is up (restores mouse mode, arms the attack swallow).
 void vote_panel_close();
-
-// Drawn from the multi menu render injection, after the menu buttons and before
-// the mouse cursor. No-op unless the panel was opened from the multi menu.
-void vote_panel_render();
-
-// Called from the multi menu mouse/key hooks while the panel owns input.
-void vote_panel_handle_mouse();
-void vote_panel_handle_key(int key);
-
-// --- gameplay overlay context ---
 // Bindable control: opens/closes the overlay during a multiplayer game.
 void vote_panel_toggle_gameplay();
-// True while the overlay is up in gameplay; drives HUD/chat/input suppression.
+// True while the overlay is up; drives HUD/chat/input suppression.
 bool vote_panel_is_gameplay_overlay_active();
-// Per-frame input pump, run before the gameplay state takes its own input.
-void vote_panel_gameplay_input();
-// Drawn from the after-scene render hook so it lands on top of the HUD.
-void vote_panel_gameplay_render();
 
 void vote_panel_apply_patch();

--- a/game_patch/misc/waypoints_utils.cpp
+++ b/game_patch/misc/waypoints_utils.cpp
@@ -16,6 +16,7 @@
 #include "../rf/player/player.h"
 #include "../rf/trigger.h"
 #include "../graphics/gr.h"
+#include "../input/control_input_filter.h"
 #include <patch_common/FunHook.h>
 #include <algorithm>
 #include <array>
@@ -346,36 +347,15 @@ bool should_block_waypoint_editor_mouse_action(
     return false;
 }
 
-FunHook<bool(rf::ControlConfig*, rf::ControlConfigAction, bool*)> control_config_check_pressed_waypoint_editor_hook{
-    0x0043D4F0,
-    [](rf::ControlConfig* control_config, rf::ControlConfigAction action, bool* just_pressed) {
-        if (should_block_waypoint_editor_mouse_action(control_config, action)) {
-            if (just_pressed) {
-                *just_pressed = false;
-            }
-            return false;
-        }
-        return control_config_check_pressed_waypoint_editor_hook.call_target(control_config, action, just_pressed);
-    },
-};
-
-FunHook<bool(rf::ControlConfig*, rf::ControlConfigAction)> control_is_control_down_waypoint_editor_hook{
-    0x00430F40,
-    [](rf::ControlConfig* control_config, rf::ControlConfigAction action) {
-        if (should_block_waypoint_editor_mouse_action(control_config, action)) {
-            return false;
-        }
-        return control_is_control_down_waypoint_editor_hook.call_target(control_config, action);
-    },
-};
-
+// control_input_filter owns the hooks and installs them at startup; this only
+// contributes the editor's veto. Called from every level init, so the flag keeps
+// registration to one.
 void ensure_waypoint_editor_input_hooks_installed()
 {
     if (g_waypoint_editor_input_hooks_installed) {
         return;
     }
-    control_config_check_pressed_waypoint_editor_hook.install();
-    control_is_control_down_waypoint_editor_hook.install();
+    control_input_filter_add_veto(&should_block_waypoint_editor_mouse_action);
     g_waypoint_editor_input_hooks_installed = true;
 }
 
@@ -405,9 +385,9 @@ void capture_waypoint_editor_mouse_input()
     rf::mouse_get_pos(g_waypoint_editor_mouse_x, g_waypoint_editor_mouse_y, mouse_z);
     g_waypoint_editor_left_click_pressed = rf::mouse_was_button_pressed(0) > 0;
     // Use secondary attack bind (whatever key/button it's bound to) for cursor toggle.
-    // Call the original (unhooked) function since our hook blocks this action.
+    // Read past the filter since our own veto blocks this action.
     bool secondary_just_pressed = false;
-    control_config_check_pressed_waypoint_editor_hook.call_target(
+    control_input_filter_check_pressed_unfiltered(
         &rf::local_player->settings.controls,
         rf::CC_ACTION_SECONDARY_ATTACK,
         &secondary_just_pressed);

--- a/game_patch/multi/alpine_packets.cpp
+++ b/game_patch/multi/alpine_packets.cpp
@@ -1123,6 +1123,9 @@ void af_send_vote_call(const AfVoteCallParams& params)
             w.u8(params.gametype);
             encoded = write_vote_mutators(w, params.mutators);
             break;
+        case AfVoteType::Extend:
+            w.u8(params.extend_minutes);
+            break;
         default:
             break; // parameterless vote types
     }
@@ -1551,6 +1554,9 @@ static void af_process_client_req_packet(const void* data, size_t len, const rf:
                         xlog::warn("af_process_client_req_packet: bad vote match mutators");
                         return;
                     }
+                    break;
+                case AfVoteType::Extend:
+                    params.extend_minutes = r.u8();
                     break;
                 default:
                     break; // parameterless vote types

--- a/game_patch/multi/alpine_packets.cpp
+++ b/game_patch/multi/alpine_packets.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <algorithm>
 #include <array>
+#include <limits>
 #include <ranges>
 #include <unordered_map>
 #include <common/utils/bool-utils.h>
@@ -24,6 +25,7 @@
 #include "sprays.h"
 #include "bagman.h"
 #include "pit.h"
+#include "vote_client.h"
 #include "../misc/player.h"
 #include "../hud/hud.h"
 #include "../hud/multi_spectate.h"
@@ -619,6 +621,12 @@ void serialize_payload(const PitQueueReqPayload& payload, std::byte* buf, size_t
     buf[offset++] = static_cast<std::byte>(payload.action);
 }
 
+// af_req_vote_cast
+void serialize_payload(const VoteCastReqPayload& payload, std::byte* buf, size_t& offset)
+{
+    buf[offset++] = static_cast<std::byte>(payload.is_yes);
+}
+
 // af_sreq_ready_prompt
 void serialize_payload(const ReadyPromptPayload& payload, std::byte* buf, size_t& offset)
 {
@@ -787,6 +795,534 @@ void af_send_pit_queue_request(uint8_t action)
     af_send_client_req_packet(packet, true); // reliable
 }
 
+// ============================================================================
+// Vote system packets
+// ============================================================================
+
+namespace
+{
+
+// Bounds-checked little-endian writers/readers for the variable-length vote
+// payloads. Everything is written into a fixed packet buffer, so a payload that
+// would overflow simply marks the writer failed and the caller drops the packet.
+struct VoteWriter
+{
+    std::byte* buf;
+    size_t cap;
+    size_t off;
+    bool ok = true;
+
+    void u8(uint8_t v)
+    {
+        if (!ok || off + 1 > cap) {
+            ok = false;
+            return;
+        }
+        buf[off++] = static_cast<std::byte>(v);
+    }
+
+    void u16(uint16_t v)
+    {
+        if (!ok || off + sizeof(v) > cap) {
+            ok = false;
+            return;
+        }
+        std::memcpy(buf + off, &v, sizeof(v));
+        off += sizeof(v);
+    }
+
+    void i32(int32_t v)
+    {
+        if (!ok || off + sizeof(v) > cap) {
+            ok = false;
+            return;
+        }
+        std::memcpy(buf + off, &v, sizeof(v));
+        off += sizeof(v);
+    }
+
+    void f32(float v)
+    {
+        if (!ok || off + sizeof(v) > cap) {
+            ok = false;
+            return;
+        }
+        std::memcpy(buf + off, &v, sizeof(v));
+        off += sizeof(v);
+    }
+
+    void str(std::string_view s)
+    {
+        const size_t n = std::min<size_t>(s.size(), 255);
+        u8(static_cast<uint8_t>(n));
+        if (!ok || off + n > cap) {
+            ok = false;
+            return;
+        }
+        std::memcpy(buf + off, s.data(), n);
+        off += n;
+    }
+
+    void bytes(const void* src, size_t n)
+    {
+        if (!ok || off + n > cap) {
+            ok = false;
+            return;
+        }
+        std::memcpy(buf + off, src, n);
+        off += n;
+    }
+};
+
+struct VoteReader
+{
+    const uint8_t* data;
+    size_t len;
+    size_t pos = 0;
+    bool ok = true;
+
+    uint8_t u8()
+    {
+        if (!ok || pos + 1 > len) {
+            ok = false;
+            return 0;
+        }
+        return data[pos++];
+    }
+
+    uint16_t u16()
+    {
+        uint16_t v = 0;
+        if (!ok || pos + sizeof(v) > len) {
+            ok = false;
+            return 0;
+        }
+        std::memcpy(&v, data + pos, sizeof(v));
+        pos += sizeof(v);
+        return v;
+    }
+
+    int32_t i32()
+    {
+        int32_t v = 0;
+        if (!ok || pos + sizeof(v) > len) {
+            ok = false;
+            return 0;
+        }
+        std::memcpy(&v, data + pos, sizeof(v));
+        pos += sizeof(v);
+        return v;
+    }
+
+    float f32()
+    {
+        float v = 0.0f;
+        if (!ok || pos + sizeof(v) > len) {
+            ok = false;
+            return 0.0f;
+        }
+        std::memcpy(&v, data + pos, sizeof(v));
+        pos += sizeof(v);
+        return v;
+    }
+
+    std::string str()
+    {
+        const uint8_t n = u8();
+        if (!ok || pos + n > len) {
+            ok = false;
+            return {};
+        }
+        std::string v(reinterpret_cast<const char*>(data + pos), n);
+        pos += n;
+        return v;
+    }
+};
+
+// The protocol's only limits on a vote call are the u8 count encoding and
+// rf::max_packet_size (enforced by VoteWriter) — there is no separate policy cap.
+//
+// Returns false if the selection cannot be encoded. Never truncates or wraps:
+// silently dropping part of a player's mutator selection would start a vote that
+// isn't the one they asked for.
+bool write_vote_mutators(VoteWriter& w, const std::vector<VoteMutatorInput>& mutators)
+{
+    constexpr size_t u8_max = std::numeric_limits<uint8_t>::max();
+
+    const size_t count = mutators.size();
+    if (count > u8_max) {
+        xlog::warn("af_send_vote_call: {} mutators does not fit the u8 count encoding", count);
+        return false;
+    }
+
+    w.u8(static_cast<uint8_t>(count));
+    for (size_t i = 0; i < count; ++i) {
+        const VoteMutatorInput& mutator = mutators[i];
+        w.u8(mutator.mutator_id);
+        const size_t option_count = mutator.options.size();
+        if (option_count > u8_max) {
+            xlog::warn("af_send_vote_call: mutator {} has {} options, which does not fit the u8 count encoding",
+                       mutator.mutator_id, option_count);
+            return false;
+        }
+        w.u8(static_cast<uint8_t>(option_count));
+        for (size_t o = 0; o < option_count; ++o) {
+            const VoteMutatorOptionInput& opt = mutator.options[o];
+            w.u8(opt.option_id);
+            w.u8(static_cast<uint8_t>(opt.type));
+            switch (opt.type) {
+                case MutatorOptionType::Bool:
+                    w.u8(opt.bool_value ? 1 : 0);
+                    break;
+                case MutatorOptionType::Choice:
+                    w.u8(opt.choice_index);
+                    break;
+                case MutatorOptionType::Int:
+                    w.i32(opt.int_value);
+                    break;
+                case MutatorOptionType::Float:
+                    w.f32(opt.float_value);
+                    break;
+                case MutatorOptionType::String:
+                    w.str(opt.string_value);
+                    break;
+                default:
+                    xlog::warn("af_send_vote_call: mutator {} option {} has unknown type {}",
+                               mutator.mutator_id, opt.option_id, static_cast<int>(opt.type));
+                    w.ok = false;
+                    return false;
+            }
+        }
+    }
+    return true;
+}
+
+bool read_vote_mutators(VoteReader& r, std::vector<VoteMutatorInput>& out)
+{
+    // Both counts are u8 reads, so they are inherently <= 255 and every reserve()
+    // below is bounded by the encoding itself. The real bound on a hostile
+    // payload is the reader's length check against the declared packet size.
+    const uint8_t count = r.u8();
+    if (!r.ok) {
+        return false;
+    }
+    out.reserve(count);
+    for (uint8_t i = 0; i < count; ++i) {
+        VoteMutatorInput mutator;
+        mutator.mutator_id = r.u8();
+        const uint8_t option_count = r.u8();
+        if (!r.ok) {
+            return false;
+        }
+        mutator.options.reserve(option_count);
+        for (uint8_t o = 0; o < option_count; ++o) {
+            VoteMutatorOptionInput opt;
+            opt.option_id = r.u8();
+            const uint8_t type_raw = r.u8();
+            if (!r.ok) {
+                return false;
+            }
+            opt.type = static_cast<MutatorOptionType>(type_raw);
+            switch (opt.type) {
+                case MutatorOptionType::Bool:
+                    opt.bool_value = r.u8() != 0;
+                    break;
+                case MutatorOptionType::Choice:
+                    opt.choice_index = r.u8();
+                    break;
+                case MutatorOptionType::Int:
+                    opt.int_value = r.i32();
+                    break;
+                case MutatorOptionType::Float:
+                    opt.float_value = r.f32();
+                    break;
+                case MutatorOptionType::String:
+                    opt.string_value = r.str();
+                    break;
+                default:
+                    return false;
+            }
+            if (!r.ok) {
+                return false;
+            }
+            mutator.options.push_back(std::move(opt));
+        }
+        out.push_back(std::move(mutator));
+    }
+    return r.ok;
+}
+
+} // namespace
+
+// Call a vote through the structured path (AF 1.4+ servers only).
+void af_send_vote_call(const AfVoteCallParams& params)
+{
+    if (!rf::is_multi || rf::is_server) {
+        return;
+    }
+
+    std::byte buf[rf::max_packet_size];
+    RF_GamePacketHeader header{};
+    header.type = static_cast<uint8_t>(af_packet_type::af_client_req);
+
+    VoteWriter w{buf, sizeof(buf), 0};
+    w.bytes(&header, sizeof(header));
+    w.u8(static_cast<uint8_t>(af_client_req_type::af_req_vote_call));
+    w.u8(static_cast<uint8_t>(params.type));
+
+    bool encoded = true;
+    switch (params.type) {
+        case AfVoteType::Kick:
+            w.u8(params.target_player_id);
+            break;
+        case AfVoteType::Level:
+            w.str(params.level);
+            w.u8(params.gametype);
+            encoded = write_vote_mutators(w, params.mutators);
+            break;
+        case AfVoteType::Match:
+            w.u8(params.team_size);
+            w.str(params.level);
+            w.u8(params.gametype);
+            encoded = write_vote_mutators(w, params.mutators);
+            break;
+        default:
+            break; // parameterless vote types
+    }
+
+    if (!encoded) {
+        return; // write_vote_mutators already logged why
+    }
+
+    if (!w.ok) {
+        // Would have overflowed the packet buffer. Dropping the send is the only
+        // safe option, but never do it silently.
+        xlog::warn("af_send_vote_call: vote type {} payload exceeds the {} byte packet buffer; not sent",
+                   static_cast<int>(params.type), rf::max_packet_size);
+        return;
+    }
+
+    header.size = static_cast<uint16_t>(w.off - sizeof(header));
+    std::memcpy(buf, &header, sizeof(header));
+    af_send_packet(rf::local_player, buf, static_cast<int>(w.off), true);
+}
+
+void af_send_vote_cast(bool is_yes_vote)
+{
+    if (!rf::is_multi || rf::is_server) {
+        return;
+    }
+
+    af_client_req_packet packet{};
+    packet.header.type = static_cast<uint8_t>(af_packet_type::af_client_req);
+    packet.header.size = sizeof(uint8_t) + sizeof(uint8_t); // req_type + yes/no
+    packet.req_type = af_client_req_type::af_req_vote_cast;
+    packet.payload = VoteCastReqPayload{static_cast<uint8_t>(is_yes_vote ? 1 : 0)};
+
+    af_send_client_req_packet(packet, true); // reliable
+}
+
+void af_send_vote_cancel()
+{
+    if (!rf::is_multi || rf::is_server) {
+        return;
+    }
+
+    af_client_req_packet packet{};
+    packet.header.type = static_cast<uint8_t>(af_packet_type::af_client_req);
+    packet.header.size = sizeof(uint8_t); // req_type only
+    packet.req_type = af_client_req_type::af_req_vote_cancel;
+    packet.payload = std::monostate{};
+
+    af_send_client_req_packet(packet, true); // reliable
+}
+
+void af_send_vote_options_request()
+{
+    if (!rf::is_multi || rf::is_server) {
+        return;
+    }
+
+    af_client_req_packet packet{};
+    packet.header.type = static_cast<uint8_t>(af_packet_type::af_client_req);
+    packet.header.size = sizeof(uint8_t); // req_type only
+    packet.req_type = af_client_req_type::af_req_vote_options;
+    packet.payload = std::monostate{};
+
+    af_send_client_req_packet(packet, true); // reliable
+}
+
+// Shared tail for the three af_sreq_vote_state events: `w` already holds the
+// header, req_type and event byte plus the event-specific fields.
+static void af_finish_vote_state_packet(rf::Player* player, std::byte* buf, VoteWriter& w)
+{
+    if (!w.ok) {
+        xlog::warn("af_send_vote_state: payload too large");
+        return;
+    }
+
+    RF_GamePacketHeader header{};
+    header.type = static_cast<uint8_t>(af_packet_type::af_server_req);
+    header.size = static_cast<uint16_t>(w.off - sizeof(header));
+    std::memcpy(buf, &header, sizeof(header));
+    af_send_packet(player, buf, static_cast<int>(w.off), true);
+}
+
+// True if this recipient should be handled locally rather than over the wire
+// (listen-server host) — the caller applies the state directly instead.
+static bool af_vote_state_recipient_is_local(rf::Player* player)
+{
+    return player == rf::local_player;
+}
+
+void af_send_vote_state_start(rf::Player* player, AfVoteType type, uint16_t time_remaining_sec,
+                              uint8_t yes, uint8_t no, uint8_t remaining, bool is_owner,
+                              std::string_view initiator_name, std::string_view title)
+{
+    if (!rf::is_server || !player) {
+        return;
+    }
+    if (af_vote_state_recipient_is_local(player)) {
+        vote_state_on_start(type, time_remaining_sec, yes, no, remaining, is_owner,
+                            std::string{initiator_name}, std::string{title});
+        return;
+    }
+    if (!player->net_data || !is_player_minimum_af_client_version(player, 1, 4, 0)) {
+        return;
+    }
+
+    // Fixed part: header + req_type + event + vote_type + u16 time + yes/no/
+    // remaining + flags + the two string length bytes.
+    constexpr size_t fixed_len = sizeof(RF_GamePacketHeader) + 9 + 2;
+    constexpr size_t str_budget = rf::max_packet_size - fixed_len;
+
+    // A long title (many mutators) must never cost the client its START event,
+    // so both strings are truncated to fit rather than overflowing the packet.
+    const size_t name_len = std::min<size_t>({initiator_name.size(), 255, str_budget});
+    const size_t title_len = std::min<size_t>({title.size(), 255, str_budget - name_len});
+
+    std::byte buf[rf::max_packet_size];
+    VoteWriter w{buf, sizeof(buf), sizeof(RF_GamePacketHeader)};
+    w.u8(static_cast<uint8_t>(af_server_req_type::af_sreq_vote_state));
+    w.u8(static_cast<uint8_t>(AfVoteStateEvent::Start));
+    w.u8(static_cast<uint8_t>(type));
+    w.u16(time_remaining_sec);
+    w.u8(yes);
+    w.u8(no);
+    w.u8(remaining);
+    w.u8(is_owner ? AF_VOTE_STATE_FLAG_OWNER : 0);
+    w.str(initiator_name.substr(0, name_len));
+    w.str(title.substr(0, title_len));
+    af_finish_vote_state_packet(player, buf, w);
+}
+
+void af_send_vote_state_update(rf::Player* player, uint8_t yes, uint8_t no, uint8_t remaining)
+{
+    if (!rf::is_server || !player) {
+        return;
+    }
+    if (af_vote_state_recipient_is_local(player)) {
+        vote_state_on_update(yes, no, remaining);
+        return;
+    }
+    if (!player->net_data || !is_player_minimum_af_client_version(player, 1, 4, 0)) {
+        return;
+    }
+
+    std::byte buf[rf::max_packet_size];
+    VoteWriter w{buf, sizeof(buf), sizeof(RF_GamePacketHeader)};
+    w.u8(static_cast<uint8_t>(af_server_req_type::af_sreq_vote_state));
+    w.u8(static_cast<uint8_t>(AfVoteStateEvent::Update));
+    w.u8(yes);
+    w.u8(no);
+    w.u8(remaining);
+    af_finish_vote_state_packet(player, buf, w);
+}
+
+void af_send_vote_state_end(rf::Player* player, AfVoteResult result)
+{
+    if (!rf::is_server || !player) {
+        return;
+    }
+    if (af_vote_state_recipient_is_local(player)) {
+        vote_state_on_end(result);
+        return;
+    }
+    if (!player->net_data || !is_player_minimum_af_client_version(player, 1, 4, 0)) {
+        return;
+    }
+
+    std::byte buf[rf::max_packet_size];
+    VoteWriter w{buf, sizeof(buf), sizeof(RF_GamePacketHeader)};
+    w.u8(static_cast<uint8_t>(af_server_req_type::af_sreq_vote_state));
+    w.u8(static_cast<uint8_t>(AfVoteStateEvent::End));
+    w.u8(static_cast<uint8_t>(result));
+    af_finish_vote_state_packet(player, buf, w);
+}
+
+// Push the vote-options blob in chunks. Queued on the deferred reliable queue
+// (like af_send_server_cfg) so a multi-chunk blob doesn't blow the burst limit.
+void af_send_vote_options_data(rf::Player* player)
+{
+    if (!rf::is_server || !player) {
+        return;
+    }
+
+    uint8_t generation = 0;
+    const std::vector<uint8_t>& blob = server_vote_get_options_blob(generation);
+
+    // generation + seq + total + data_len
+    constexpr size_t chunk_prefix = 4;
+    // data_len is a single byte on the wire, so a chunk can never exceed 255.
+    constexpr size_t max_chunk_len = std::min<size_t>(
+        255, rf::max_packet_size - sizeof(RF_GamePacketHeader) - sizeof(uint8_t) /*req_type*/ - chunk_prefix);
+
+    const size_t total_chunks = std::max<size_t>(1, (blob.size() + max_chunk_len - 1) / max_chunk_len);
+    if (total_chunks > 255) {
+        xlog::error("af_send_vote_options_data: blob too large ({} bytes)", blob.size());
+        return;
+    }
+
+    const bool is_local = af_vote_state_recipient_is_local(player);
+    if (!is_local && (!player->net_data || !is_player_minimum_af_client_version(player, 1, 4, 0))) {
+        return;
+    }
+
+    for (size_t i = 0; i < total_chunks; ++i) {
+        const size_t begin = i * max_chunk_len;
+        const size_t chunk_len = std::min(max_chunk_len, blob.size() - std::min(begin, blob.size()));
+
+        if (is_local) {
+            // Listen-server host: feed the reassembler directly.
+            vote_options_handle_chunk(generation, static_cast<uint8_t>(i),
+                                      static_cast<uint8_t>(total_chunks),
+                                      blob.data() + begin, chunk_len);
+            continue;
+        }
+
+        std::byte buf[rf::max_packet_size];
+        VoteWriter w{buf, sizeof(buf), sizeof(RF_GamePacketHeader)};
+        w.u8(static_cast<uint8_t>(af_server_req_type::af_sreq_vote_options_data));
+        w.u8(generation);
+        w.u8(static_cast<uint8_t>(i));
+        w.u8(static_cast<uint8_t>(total_chunks));
+        w.u8(static_cast<uint8_t>(chunk_len));
+        w.bytes(blob.data() + begin, chunk_len);
+        if (!w.ok) {
+            xlog::error("af_send_vote_options_data: chunk overflow");
+            return;
+        }
+
+        RF_GamePacketHeader header{};
+        header.type = static_cast<uint8_t>(af_packet_type::af_server_req);
+        header.size = static_cast<uint16_t>(w.off - sizeof(header));
+        std::memcpy(buf, &header, sizeof(header));
+
+        send_queues_rel_add_packet(player->net_data->reliable_socket,
+                                   reinterpret_cast<const uint8_t*>(buf), w.off);
+    }
+}
+
 // process client request packet
 static void af_process_client_req_packet(const void* data, size_t len, const rf::NetAddr& addr)
 {
@@ -922,6 +1458,70 @@ static void af_process_client_req_packet(const void* data, size_t len, const rf:
             if (gt_is_pit()) {
                 pit_handle_queue_request(player, action);
             }
+            break;
+        }
+        case af_client_req_type::af_req_vote_call: {
+            VoteReader r{bytes + offset, remaining};
+
+            AfVoteCallParams params{};
+            const uint8_t type_raw = r.u8();
+            if (!r.ok || type_raw >= af_vote_type_count) {
+                xlog::warn("af_process_client_req_packet: bad vote type {}", type_raw);
+                return;
+            }
+            params.type = static_cast<AfVoteType>(type_raw);
+
+            switch (params.type) {
+                case AfVoteType::Kick:
+                    params.target_player_id = r.u8();
+                    break;
+                case AfVoteType::Level:
+                    params.level = r.str();
+                    params.gametype = r.u8();
+                    if (!read_vote_mutators(r, params.mutators)) {
+                        xlog::warn("af_process_client_req_packet: bad vote level mutators");
+                        return;
+                    }
+                    break;
+                case AfVoteType::Match:
+                    params.team_size = r.u8();
+                    params.level = r.str();
+                    params.gametype = r.u8();
+                    if (!read_vote_mutators(r, params.mutators)) {
+                        xlog::warn("af_process_client_req_packet: bad vote match mutators");
+                        return;
+                    }
+                    break;
+                default:
+                    break; // parameterless vote types
+            }
+
+            if (!r.ok) {
+                xlog::warn("af_process_client_req_packet: truncated vote call payload");
+                return;
+            }
+
+            handle_vote_call_packet(player, std::move(params));
+            break;
+        }
+        case af_client_req_type::af_req_vote_cast: {
+            if (remaining < sizeof(uint8_t)) {
+                xlog::warn("af_process_client_req_packet: vote cast payload too short");
+                return;
+            }
+            handle_vote_cast_packet(player, bytes[offset] != 0);
+            break;
+        }
+        case af_client_req_type::af_req_vote_cancel: {
+            handle_vote_cancel_packet(player);
+            break;
+        }
+        case af_client_req_type::af_req_vote_options: {
+            if (player->vote_options_req_timer.valid() && !player->vote_options_req_timer.elapsed()) {
+                break; // still cooling down
+            }
+            player->vote_options_req_timer.set(2000);
+            af_send_vote_options_data(player);
             break;
         }
         default: {
@@ -1482,6 +2082,72 @@ static void af_process_server_req_packet(const void* data, size_t len, const rf:
             // hud_pit_queue_auto_spectate (the packet can arrive before the
             // local entity finishes dying).
             apply_local_pit_queue_state(flags, position, total);
+            break;
+        }
+        case af_server_req_type::af_sreq_vote_state: {
+            VoteReader r{bytes + offset, remaining};
+            const uint8_t event = r.u8();
+            if (!r.ok) {
+                xlog::warn("af_process_server_req_packet: VoteState payload too short");
+                return;
+            }
+
+            switch (static_cast<AfVoteStateEvent>(event)) {
+                case AfVoteStateEvent::Start: {
+                    const uint8_t type_raw = r.u8();
+                    const uint16_t time_remaining = r.u16();
+                    const uint8_t yes = r.u8();
+                    const uint8_t no = r.u8();
+                    const uint8_t voters_left = r.u8();
+                    const uint8_t flags = r.u8();
+                    std::string initiator_name = r.str();
+                    std::string title = r.str();
+                    if (!r.ok || type_raw >= af_vote_type_count) {
+                        xlog::warn("af_process_server_req_packet: bad VoteState start");
+                        return;
+                    }
+                    vote_state_on_start(static_cast<AfVoteType>(type_raw), time_remaining, yes, no,
+                                        voters_left, (flags & AF_VOTE_STATE_FLAG_OWNER) != 0,
+                                        std::move(initiator_name), std::move(title));
+                    break;
+                }
+                case AfVoteStateEvent::Update: {
+                    const uint8_t yes = r.u8();
+                    const uint8_t no = r.u8();
+                    const uint8_t voters_left = r.u8();
+                    if (!r.ok) {
+                        xlog::warn("af_process_server_req_packet: bad VoteState update");
+                        return;
+                    }
+                    vote_state_on_update(yes, no, voters_left);
+                    break;
+                }
+                case AfVoteStateEvent::End: {
+                    const uint8_t result = r.u8();
+                    if (!r.ok) {
+                        xlog::warn("af_process_server_req_packet: bad VoteState end");
+                        return;
+                    }
+                    vote_state_on_end(static_cast<AfVoteResult>(result));
+                    break;
+                }
+                default:
+                    xlog::debug("af_process_server_req_packet: unknown VoteState event {}", event);
+                    break;
+            }
+            break;
+        }
+        case af_server_req_type::af_sreq_vote_options_data: {
+            VoteReader r{bytes + offset, remaining};
+            const uint8_t generation = r.u8();
+            const uint8_t seq = r.u8();
+            const uint8_t total = r.u8();
+            const uint8_t data_len = r.u8();
+            if (!r.ok || r.pos + data_len > r.len) {
+                xlog::warn("af_process_server_req_packet: truncated VoteOptionsData chunk");
+                return;
+            }
+            vote_options_handle_chunk(generation, seq, total, r.data + r.pos, data_len);
             break;
         }
         default:
@@ -2338,6 +3004,7 @@ static void af_process_server_info_packet(const void* data, size_t len, const rf
 
     if ((pkt.af_flags & af_server_info_flags::SIF_SERVER_CFG_CHANGED) != 0) {
         g_remote_server_cfg_popup.set_cfg_changed();
+        vote_options_mark_stale(); // votable levels / vote toggles may have changed
     }
 
     // Update footstep activation based on new server permissions

--- a/game_patch/multi/alpine_packets.cpp
+++ b/game_patch/multi/alpine_packets.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <array>
 #include <limits>
+#include <optional>
 #include <ranges>
 #include <unordered_map>
 #include <common/utils/bool-utils.h>
@@ -627,6 +628,14 @@ void serialize_payload(const VoteCastReqPayload& payload, std::byte* buf, size_t
     buf[offset++] = static_cast<std::byte>(payload.is_yes);
 }
 
+// af_req_vote_options
+void serialize_payload(const VoteOptionsReqPayload& payload, std::byte* buf, size_t& offset)
+{
+    buf[offset++] = static_cast<std::byte>(payload.flags);
+    std::memcpy(buf + offset, &payload.known_generation, sizeof(payload.known_generation));
+    offset += sizeof(payload.known_generation);
+}
+
 // af_sreq_ready_prompt
 void serialize_payload(const ReadyPromptPayload& payload, std::byte* buf, size_t& offset)
 {
@@ -814,7 +823,7 @@ struct VoteWriter
 
     void u8(uint8_t v)
     {
-        if (!ok || off + 1 > cap) {
+        if (!ok || 1 > cap - off) {
             ok = false;
             return;
         }
@@ -823,7 +832,17 @@ struct VoteWriter
 
     void u16(uint16_t v)
     {
-        if (!ok || off + sizeof(v) > cap) {
+        if (!ok || sizeof(v) > cap - off) {
+            ok = false;
+            return;
+        }
+        std::memcpy(buf + off, &v, sizeof(v));
+        off += sizeof(v);
+    }
+
+    void u32(uint32_t v)
+    {
+        if (!ok || sizeof(v) > cap - off) {
             ok = false;
             return;
         }
@@ -833,7 +852,7 @@ struct VoteWriter
 
     void i32(int32_t v)
     {
-        if (!ok || off + sizeof(v) > cap) {
+        if (!ok || sizeof(v) > cap - off) {
             ok = false;
             return;
         }
@@ -843,7 +862,7 @@ struct VoteWriter
 
     void f32(float v)
     {
-        if (!ok || off + sizeof(v) > cap) {
+        if (!ok || sizeof(v) > cap - off) {
             ok = false;
             return;
         }
@@ -855,17 +874,19 @@ struct VoteWriter
     {
         const size_t n = std::min<size_t>(s.size(), 255);
         u8(static_cast<uint8_t>(n));
-        if (!ok || off + n > cap) {
+        if (!ok || n > cap - off) {
             ok = false;
             return;
         }
-        std::memcpy(buf + off, s.data(), n);
+        if (n) {
+            std::memcpy(buf + off, s.data(), n); // an empty string_view's data() may be null
+        }
         off += n;
     }
 
     void bytes(const void* src, size_t n)
     {
-        if (!ok || off + n > cap) {
+        if (!ok || n > cap - off) {
             ok = false;
             return;
         }
@@ -883,7 +904,7 @@ struct VoteReader
 
     uint8_t u8()
     {
-        if (!ok || pos + 1 > len) {
+        if (!ok || 1 > len - pos) {
             ok = false;
             return 0;
         }
@@ -893,7 +914,19 @@ struct VoteReader
     uint16_t u16()
     {
         uint16_t v = 0;
-        if (!ok || pos + sizeof(v) > len) {
+        if (!ok || sizeof(v) > len - pos) {
+            ok = false;
+            return 0;
+        }
+        std::memcpy(&v, data + pos, sizeof(v));
+        pos += sizeof(v);
+        return v;
+    }
+
+    uint32_t u32()
+    {
+        uint32_t v = 0;
+        if (!ok || sizeof(v) > len - pos) {
             ok = false;
             return 0;
         }
@@ -905,7 +938,7 @@ struct VoteReader
     int32_t i32()
     {
         int32_t v = 0;
-        if (!ok || pos + sizeof(v) > len) {
+        if (!ok || sizeof(v) > len - pos) {
             ok = false;
             return 0;
         }
@@ -917,7 +950,7 @@ struct VoteReader
     float f32()
     {
         float v = 0.0f;
-        if (!ok || pos + sizeof(v) > len) {
+        if (!ok || sizeof(v) > len - pos) {
             ok = false;
             return 0.0f;
         }
@@ -929,7 +962,7 @@ struct VoteReader
     std::string str()
     {
         const uint8_t n = u8();
-        if (!ok || pos + n > len) {
+        if (!ok || n > len - pos) {
             ok = false;
             return {};
         }
@@ -1040,6 +1073,10 @@ bool read_vote_mutators(VoteReader& r, std::vector<VoteMutatorInput>& out)
                     opt.string_value = r.str();
                     break;
                 default:
+                    // A real client/server schema mismatch lands here, so make it
+                    // diagnosable rather than a silent rejection.
+                    xlog::warn("read_vote_mutators: mutator {} option {} has unknown type {}",
+                               mutator.mutator_id, opt.option_id, type_raw);
                     return false;
             }
             if (!r.ok) {
@@ -1137,17 +1174,21 @@ void af_send_vote_cancel()
     af_send_client_req_packet(packet, true); // reliable
 }
 
-void af_send_vote_options_request()
+void af_send_vote_options_request(bool has_cache, uint32_t known_generation)
 {
     if (!rf::is_multi || rf::is_server) {
         return;
     }
 
+    VoteOptionsReqPayload payload{};
+    payload.flags = has_cache ? AF_VOTE_OPTIONS_REQ_HAS_CACHE : uint8_t{0};
+    payload.known_generation = has_cache ? known_generation : 0;
+
     af_client_req_packet packet{};
     packet.header.type = static_cast<uint8_t>(af_packet_type::af_client_req);
-    packet.header.size = sizeof(uint8_t); // req_type only
+    packet.header.size = sizeof(uint8_t) + sizeof(payload.flags) + sizeof(payload.known_generation);
     packet.req_type = af_client_req_type::af_req_vote_options;
-    packet.payload = std::monostate{};
+    packet.payload = payload;
 
     af_send_client_req_packet(packet, true); // reliable
 }
@@ -1168,38 +1209,44 @@ static void af_finish_vote_state_packet(rf::Player* player, std::byte* buf, Vote
     af_send_packet(player, buf, static_cast<int>(w.off), true);
 }
 
-// True if this recipient should be handled locally rather than over the wire
-// (listen-server host) — the caller applies the state directly instead.
-static bool af_vote_state_recipient_is_local(rf::Player* player)
+// Can this recipient receive the structured vote events at all? The
+// listen-server host cannot: it is excluded from the vote system entirely (it can
+// neither call nor cast, see the F1/F2 and vote-panel gates on !rf::is_server),
+// so there is deliberately no local-delivery path here.
+static bool af_vote_recipient_is_structured(rf::Player* player)
 {
-    return player == rf::local_player;
+    return player && player != rf::local_player && player->net_data
+        && is_player_minimum_af_client_version(player, 1, 4, 0);
 }
 
 void af_send_vote_state_start(rf::Player* player, AfVoteType type, uint16_t time_remaining_sec,
-                              uint8_t yes, uint8_t no, uint8_t remaining, bool is_owner,
+                              uint8_t yes, uint8_t no, uint8_t remaining, bool is_owner, bool is_sync,
                               std::string_view initiator_name, std::string_view title)
 {
-    if (!rf::is_server || !player) {
-        return;
-    }
-    if (af_vote_state_recipient_is_local(player)) {
-        vote_state_on_start(type, time_remaining_sec, yes, no, remaining, is_owner,
-                            std::string{initiator_name}, std::string{title});
-        return;
-    }
-    if (!player->net_data || !is_player_minimum_af_client_version(player, 1, 4, 0)) {
+    if (!rf::is_server || !af_vote_recipient_is_structured(player)) {
         return;
     }
 
     // Fixed part: header + req_type + event + vote_type + u16 time + yes/no/
     // remaining + flags + the two string length bytes.
     constexpr size_t fixed_len = sizeof(RF_GamePacketHeader) + 9 + 2;
+    // Guards str_budget against underflowing if fields are ever added here.
+    static_assert(fixed_len < rf::max_packet_size,
+                  "af_sreq_vote_state start fixed fields no longer fit a packet");
     constexpr size_t str_budget = rf::max_packet_size - fixed_len;
 
     // A long title (many mutators) must never cost the client its START event,
     // so both strings are truncated to fit rather than overflowing the packet.
     const size_t name_len = std::min<size_t>({initiator_name.size(), 255, str_budget});
     const size_t title_len = std::min<size_t>({title.size(), 255, str_budget - name_len});
+
+    uint8_t flags = 0;
+    if (is_owner) {
+        flags |= AF_VOTE_STATE_FLAG_OWNER;
+    }
+    if (is_sync) {
+        flags |= AF_VOTE_STATE_FLAG_SYNC;
+    }
 
     std::byte buf[rf::max_packet_size];
     VoteWriter w{buf, sizeof(buf), sizeof(RF_GamePacketHeader)};
@@ -1210,7 +1257,7 @@ void af_send_vote_state_start(rf::Player* player, AfVoteType type, uint16_t time
     w.u8(yes);
     w.u8(no);
     w.u8(remaining);
-    w.u8(is_owner ? AF_VOTE_STATE_FLAG_OWNER : 0);
+    w.u8(flags);
     w.str(initiator_name.substr(0, name_len));
     w.str(title.substr(0, title_len));
     af_finish_vote_state_packet(player, buf, w);
@@ -1218,14 +1265,7 @@ void af_send_vote_state_start(rf::Player* player, AfVoteType type, uint16_t time
 
 void af_send_vote_state_update(rf::Player* player, uint8_t yes, uint8_t no, uint8_t remaining)
 {
-    if (!rf::is_server || !player) {
-        return;
-    }
-    if (af_vote_state_recipient_is_local(player)) {
-        vote_state_on_update(yes, no, remaining);
-        return;
-    }
-    if (!player->net_data || !is_player_minimum_af_client_version(player, 1, 4, 0)) {
+    if (!rf::is_server || !af_vote_recipient_is_structured(player)) {
         return;
     }
 
@@ -1239,78 +1279,80 @@ void af_send_vote_state_update(rf::Player* player, uint8_t yes, uint8_t no, uint
     af_finish_vote_state_packet(player, buf, w);
 }
 
-void af_send_vote_state_end(rf::Player* player, AfVoteResult result)
+void af_send_vote_state_end(rf::Player* player, AfVoteResult result, bool passed,
+                            std::string_view detail)
 {
-    if (!rf::is_server || !player) {
+    if (!rf::is_server || !af_vote_recipient_is_structured(player)) {
         return;
     }
-    if (af_vote_state_recipient_is_local(player)) {
-        vote_state_on_end(result);
-        return;
-    }
-    if (!player->net_data || !is_player_minimum_af_client_version(player, 1, 4, 0)) {
-        return;
-    }
+
+    // header + req_type + event + result + flags + the detail length byte.
+    constexpr size_t fixed_len = sizeof(RF_GamePacketHeader) + 4 + 1;
+    static_assert(fixed_len < rf::max_packet_size,
+                  "af_sreq_vote_state end fixed fields no longer fit a packet");
+    // The detail line is truncated rather than dropped: losing the end event
+    // entirely would strand the client's HUD notification.
+    const size_t detail_len = std::min<size_t>({detail.size(), 255, rf::max_packet_size - fixed_len});
 
     std::byte buf[rf::max_packet_size];
     VoteWriter w{buf, sizeof(buf), sizeof(RF_GamePacketHeader)};
     w.u8(static_cast<uint8_t>(af_server_req_type::af_sreq_vote_state));
     w.u8(static_cast<uint8_t>(AfVoteStateEvent::End));
     w.u8(static_cast<uint8_t>(result));
+    w.u8(passed ? AF_VOTE_END_FLAG_PASSED : uint8_t{0});
+    w.str(detail.substr(0, detail_len));
     af_finish_vote_state_packet(player, buf, w);
 }
 
-// Push the vote-options blob in chunks. Queued on the deferred reliable queue
-// (like af_send_server_cfg) so a multi-chunk blob doesn't blow the burst limit.
+// Stream the vote-options blob as Begin -> Data* -> End on the deferred reliable
+// queue. Everything on that queue is drained FIFO into rf::net_rel_send, which is
+// an ordered reliable channel, so the client sees the three event kinds in the
+// order they were queued and no chunk index or chunk count is needed. Unlike the
+// old u8 seq/total framing there is no size ceiling, and the per-packet payload
+// length comes from the packet header rather than a u8, so a chunk carries ~500
+// bytes instead of 255.
+//
+// Note the End sentinel is QUEUED, not sent with rf::multi_io_send_reliable:
+// mixing an immediate send with queued packets would let the sentinel overtake
+// the data it terminates (af_send_server_cfg used to have exactly that bug).
 void af_send_vote_options_data(rf::Player* player)
 {
-    if (!rf::is_server || !player) {
+    if (!rf::is_server) {
         return;
     }
 
-    uint8_t generation = 0;
+    // Gate on the recipient BEFORE touching the blob: building it bumps the
+    // generation, so an ineligible client must not be able to force a rebuild.
+    if (!af_vote_recipient_is_structured(player)) {
+        return;
+    }
+
+    uint32_t generation = 0;
     const std::vector<uint8_t>& blob = server_vote_get_options_blob(generation);
 
-    // generation + seq + total + data_len
-    constexpr size_t chunk_prefix = 4;
-    // data_len is a single byte on the wire, so a chunk can never exceed 255.
-    constexpr size_t max_chunk_len = std::min<size_t>(
-        255, rf::max_packet_size - sizeof(RF_GamePacketHeader) - sizeof(uint8_t) /*req_type*/ - chunk_prefix);
+    const int socket = player->net_data->reliable_socket;
 
-    const size_t total_chunks = std::max<size_t>(1, (blob.size() + max_chunk_len - 1) / max_chunk_len);
-    if (total_chunks > 255) {
-        xlog::error("af_send_vote_options_data: blob too large ({} bytes)", blob.size());
-        return;
-    }
+    // req_type + stream event + generation
+    constexpr size_t frame_prefix = sizeof(uint8_t) + sizeof(uint8_t) + sizeof(uint32_t);
+    constexpr size_t max_chunk_len = rf::max_packet_size - sizeof(RF_GamePacketHeader) - frame_prefix;
+    static_assert(max_chunk_len > 0, "vote options chunk payload no longer fits a packet");
 
-    const bool is_local = af_vote_state_recipient_is_local(player);
-    if (!is_local && (!player->net_data || !is_player_minimum_af_client_version(player, 1, 4, 0))) {
-        return;
-    }
-
-    for (size_t i = 0; i < total_chunks; ++i) {
-        const size_t begin = i * max_chunk_len;
-        const size_t chunk_len = std::min(max_chunk_len, blob.size() - std::min(begin, blob.size()));
-
-        if (is_local) {
-            // Listen-server host: feed the reassembler directly.
-            vote_options_handle_chunk(generation, static_cast<uint8_t>(i),
-                                      static_cast<uint8_t>(total_chunks),
-                                      blob.data() + begin, chunk_len);
-            continue;
-        }
-
+    const auto queue_frame = [&](AfVoteOptionsStream event, const uint8_t* data, size_t len,
+                                 std::optional<uint32_t> extra) {
         std::byte buf[rf::max_packet_size];
         VoteWriter w{buf, sizeof(buf), sizeof(RF_GamePacketHeader)};
         w.u8(static_cast<uint8_t>(af_server_req_type::af_sreq_vote_options_data));
-        w.u8(generation);
-        w.u8(static_cast<uint8_t>(i));
-        w.u8(static_cast<uint8_t>(total_chunks));
-        w.u8(static_cast<uint8_t>(chunk_len));
-        w.bytes(blob.data() + begin, chunk_len);
+        w.u8(static_cast<uint8_t>(event));
+        w.u32(generation);
+        if (extra) {
+            w.u32(*extra);
+        }
+        if (len) {
+            w.bytes(data, len);
+        }
         if (!w.ok) {
-            xlog::error("af_send_vote_options_data: chunk overflow");
-            return;
+            xlog::error("af_send_vote_options_data: frame overflow (event {})", static_cast<int>(event));
+            return false;
         }
 
         RF_GamePacketHeader header{};
@@ -1318,9 +1360,31 @@ void af_send_vote_options_data(rf::Player* player)
         header.size = static_cast<uint16_t>(w.off - sizeof(header));
         std::memcpy(buf, &header, sizeof(header));
 
-        send_queues_rel_add_packet(player->net_data->reliable_socket,
-                                   reinterpret_cast<const uint8_t*>(buf), w.off);
+        send_queues_rel_add_packet(socket, reinterpret_cast<const uint8_t*>(buf), w.off);
+        return true;
+    };
+
+    if (blob.size() > af_vote_options_max_blob_size) {
+        // Would be rejected by the client's accumulation cap anyway, so don't
+        // spend the bandwidth. This is unreachable in practice.
+        xlog::error("af_send_vote_options_data: blob of {} bytes exceeds the {} byte transport cap",
+                    blob.size(), af_vote_options_max_blob_size);
+        return;
     }
+
+    if (!queue_frame(AfVoteOptionsStream::Begin, nullptr, 0, static_cast<uint32_t>(blob.size()))) {
+        return;
+    }
+    for (size_t sent = 0; sent < blob.size(); sent += max_chunk_len) {
+        const size_t chunk_len = std::min(max_chunk_len, blob.size() - sent);
+        if (!queue_frame(AfVoteOptionsStream::Data, blob.data() + sent, chunk_len, std::nullopt)) {
+            return; // the client discards the unterminated stream
+        }
+    }
+    queue_frame(AfVoteOptionsStream::End, nullptr, 0, std::nullopt);
+
+    xlog::debug("vote options: streamed {} bytes (generation {}) to {}", blob.size(), generation,
+                player->name);
 }
 
 // process client request packet
@@ -1517,11 +1581,21 @@ static void af_process_client_req_packet(const void* data, size_t len, const rf:
             break;
         }
         case af_client_req_type::af_req_vote_options: {
-            if (player->vote_options_req_timer.valid() && !player->vote_options_req_timer.elapsed()) {
-                break; // still cooling down
+            // The payload is optional: a request without it is treated as "I have
+            // no cached blob", so the server always has something to send.
+            bool has_cache = false;
+            uint32_t known_generation = 0;
+            if (remaining >= sizeof(uint8_t)) {
+                has_cache = (bytes[offset] & AF_VOTE_OPTIONS_REQ_HAS_CACHE) != 0;
+                if (has_cache && remaining >= sizeof(uint8_t) + sizeof(uint32_t)) {
+                    std::memcpy(&known_generation, bytes + offset + sizeof(uint8_t),
+                                sizeof(known_generation));
+                }
+                else {
+                    has_cache = false;
+                }
             }
-            player->vote_options_req_timer.set(2000);
-            af_send_vote_options_data(player);
+            server_vote_handle_options_request(player, has_cache, known_generation);
             break;
         }
         default: {
@@ -2102,12 +2176,19 @@ static void af_process_server_req_packet(const void* data, size_t len, const rf:
                     const uint8_t flags = r.u8();
                     std::string initiator_name = r.str();
                     std::string title = r.str();
-                    if (!r.ok || type_raw >= af_vote_type_count) {
+                    // `type_raw` is deliberately NOT bounds-checked: a newer
+                    // server may run a vote type this build predates, and
+                    // dropping the event would leave this client with no HUD, no
+                    // tally and no idea a vote is running while the server still
+                    // counts it as an eligible voter. Only a malformed packet is
+                    // rejected. See ActiveVoteState in vote_client.h.
+                    if (!r.ok) {
                         xlog::warn("af_process_server_req_packet: bad VoteState start");
                         return;
                     }
-                    vote_state_on_start(static_cast<AfVoteType>(type_raw), time_remaining, yes, no,
+                    vote_state_on_start(type_raw, time_remaining, yes, no,
                                         voters_left, (flags & AF_VOTE_STATE_FLAG_OWNER) != 0,
+                                        (flags & AF_VOTE_STATE_FLAG_SYNC) != 0,
                                         std::move(initiator_name), std::move(title));
                     break;
                 }
@@ -2124,11 +2205,14 @@ static void af_process_server_req_packet(const void* data, size_t len, const rf:
                 }
                 case AfVoteStateEvent::End: {
                     const uint8_t result = r.u8();
+                    const uint8_t flags = r.u8();
+                    std::string detail = r.str();
                     if (!r.ok) {
                         xlog::warn("af_process_server_req_packet: bad VoteState end");
                         return;
                     }
-                    vote_state_on_end(static_cast<AfVoteResult>(result));
+                    vote_state_on_end(static_cast<AfVoteResult>(result),
+                                      (flags & AF_VOTE_END_FLAG_PASSED) != 0, std::move(detail));
                     break;
                 }
                 default:
@@ -2139,15 +2223,34 @@ static void af_process_server_req_packet(const void* data, size_t len, const rf:
         }
         case af_server_req_type::af_sreq_vote_options_data: {
             VoteReader r{bytes + offset, remaining};
-            const uint8_t generation = r.u8();
-            const uint8_t seq = r.u8();
-            const uint8_t total = r.u8();
-            const uint8_t data_len = r.u8();
-            if (!r.ok || r.pos + data_len > r.len) {
-                xlog::warn("af_process_server_req_packet: truncated VoteOptionsData chunk");
+            const uint8_t event = r.u8();
+            const uint32_t generation = r.u32();
+            if (!r.ok) {
+                xlog::warn("af_process_server_req_packet: truncated VoteOptionsData frame");
                 return;
             }
-            vote_options_handle_chunk(generation, seq, total, r.data + r.pos, data_len);
+            switch (static_cast<AfVoteOptionsStream>(event)) {
+                case AfVoteOptionsStream::Begin: {
+                    const uint32_t total_bytes = r.u32();
+                    if (!r.ok) {
+                        xlog::warn("af_process_server_req_packet: truncated VoteOptionsData begin");
+                        return;
+                    }
+                    vote_options_stream_begin(generation, total_bytes);
+                    break;
+                }
+                case AfVoteOptionsStream::Data:
+                    // The chunk is whatever is left in the packet: its length comes
+                    // from the packet header, not from a length byte.
+                    vote_options_stream_data(generation, r.data + r.pos, r.len - r.pos);
+                    break;
+                case AfVoteOptionsStream::End:
+                    vote_options_stream_end(generation);
+                    break;
+                default:
+                    xlog::debug("af_process_server_req_packet: unknown VoteOptionsData event {}", event);
+                    break;
+            }
             break;
         }
         default:
@@ -3196,6 +3299,14 @@ void af_send_server_cfg(rf::Player* player) {
     };
 
     // We cannot send multiple server configs at once.
+    //
+    // Hazard: this clear is not scoped to config packets, so it discards
+    // everything queued for this player, including an unrelated stream that
+    // happens to be in flight (today that means an af_sreq_vote_options_data
+    // blob, which the client recovers from by re-requesting the generation it
+    // never finished receiving). Judged too rare to be worth solving here. A
+    // future streamed feature should tag its queued packets and clear by tag
+    // rather than widening this clear.
     send_queues_rel_clear_packets(player->net_data->reliable_socket);
 
     constexpr int chunk_size = rf::max_packet_size - sizeof(af_server_msg_packet);
@@ -3211,11 +3322,17 @@ void af_send_server_cfg(rf::Player* player) {
     );
     server_msg_packet.type = static_cast<uint8_t>(AF_SERVER_MSG_TYPE_REMOTE_SERVER_CFG_EOF);
 
-    rf::multi_io_send_reliable(
-        player,
-        &server_msg_packet,
-        server_msg_packet.header.size + sizeof(server_msg_packet.header),
-        0
+    // The EOF sentinel is QUEUED, not sent with rf::multi_io_send_reliable: the
+    // chunks above sit in the deferred reliable queue and are drained a few per
+    // frame, so an immediate send would overtake the content it terminates and
+    // the client would finalize a config that has barely started arriving. The
+    // queue is FIFO per socket, so queuing puts the sentinel behind the chunks.
+    // No payload follows the sentinel, so the packet struct is the whole wire
+    // buffer and the chunk lambda's separate buffer is unnecessary here.
+    send_queues_rel_add_packet(
+        player->net_data->reliable_socket,
+        reinterpret_cast<const uint8_t*>(&server_msg_packet),
+        server_msg_packet.header.size + sizeof(server_msg_packet.header)
     );
 }
 
@@ -3314,6 +3431,43 @@ void af_broadcast_automated_chat_msg(const std::string_view msg) {
             );
         } else {
             send_chat_line_packet(std::format("\xA6 {}", msg), &player);
+        }
+    }
+}
+
+void af_broadcast_vote_legacy_chat_msg(const std::string_view msg) {
+    if (!rf::is_server) {
+        return;
+    }
+
+    // Matches af_broadcast_automated_chat_msg's console line, so dedicated server
+    // output is identical to what the old per-recipient loop produced.
+    rf::console::print("Server: {}", msg);
+
+    // Built once for the whole broadcast rather than per recipient.
+    const af_server_msg_packet_buf buf = build_automated_chat_msg_packet(msg);
+    std::optional<std::string> pre_1_2_msg;
+
+    for (rf::Player& player : SinglyLinkedList{rf::player_list}) {
+        if (&player == rf::local_player) {
+            continue; // the listen-server host is not part of the vote system
+        }
+        if (is_player_minimum_af_client_version(&player, 1, 4, 0)) {
+            continue; // receives the structured af_sreq_vote_state events instead
+        }
+
+        if (is_player_minimum_af_client_version(&player, 1, 2, 0)) {
+            rf::multi_io_send_reliable(
+                &player,
+                &buf.packet,
+                buf.packet.header.size + sizeof(buf.packet.header),
+                0
+            );
+        } else {
+            if (!pre_1_2_msg) {
+                pre_1_2_msg = std::string("\xA6 ") + std::string(msg);
+            }
+            send_chat_line_packet(*pre_1_2_msg, &player);
         }
     }
 }

--- a/game_patch/multi/alpine_packets.cpp
+++ b/game_patch/multi/alpine_packets.cpp
@@ -1209,10 +1209,7 @@ static void af_finish_vote_state_packet(rf::Player* player, std::byte* buf, Vote
     af_send_packet(player, buf, static_cast<int>(w.off), true);
 }
 
-// Can this recipient receive the structured vote events at all? The
-// listen-server host cannot: it is excluded from the vote system entirely (it can
-// neither call nor cast, see the F1/F2 and vote-panel gates on !rf::is_server),
-// so there is deliberately no local-delivery path here.
+// Can this recipient receive the structured vote events at all?
 static bool af_vote_recipient_is_structured(rf::Player* player)
 {
     return player && player != rf::local_player && player->net_data
@@ -1307,14 +1304,13 @@ void af_send_vote_state_end(rf::Player* player, AfVoteResult result, bool passed
 // Stream the vote-options blob as Begin -> Data* -> End on the deferred reliable
 // queue. Everything on that queue is drained FIFO into rf::net_rel_send, which is
 // an ordered reliable channel, so the client sees the three event kinds in the
-// order they were queued and no chunk index or chunk count is needed. Unlike the
-// old u8 seq/total framing there is no size ceiling, and the per-packet payload
-// length comes from the packet header rather than a u8, so a chunk carries ~500
-// bytes instead of 255.
+// order they were queued and no chunk index or chunk count is needed. No size
+// ceiling, and the per-packet payload length comes from the packet header rather
+// than a u8, so a chunk carries ~500 bytes instead of 255.
 //
 // Note the End sentinel is QUEUED, not sent with rf::multi_io_send_reliable:
 // mixing an immediate send with queued packets would let the sentinel overtake
-// the data it terminates (af_send_server_cfg used to have exactly that bug).
+// the data it terminates.
 void af_send_vote_options_data(rf::Player* player)
 {
     if (!rf::is_server) {
@@ -2181,7 +2177,7 @@ static void af_process_server_req_packet(const void* data, size_t len, const rf:
                     // dropping the event would leave this client with no HUD, no
                     // tally and no idea a vote is running while the server still
                     // counts it as an eligible voter. Only a malformed packet is
-                    // rejected. See ActiveVoteState in vote_client.h.
+                    // rejected.
                     if (!r.ok) {
                         xlog::warn("af_process_server_req_packet: bad VoteState start");
                         return;
@@ -3304,9 +3300,9 @@ void af_send_server_cfg(rf::Player* player) {
     // everything queued for this player, including an unrelated stream that
     // happens to be in flight (today that means an af_sreq_vote_options_data
     // blob, which the client recovers from by re-requesting the generation it
-    // never finished receiving). Judged too rare to be worth solving here. A
-    // future streamed feature should tag its queued packets and clear by tag
-    // rather than widening this clear.
+    // never finished receiving). Too rare to be worth solving here.
+    // A future streamed feature should tag its queued packets and clear by
+    // tag rather than widening this clear.
     send_queues_rel_clear_packets(player->net_data->reliable_socket);
 
     constexpr int chunk_size = rf::max_packet_size - sizeof(af_server_msg_packet);

--- a/game_patch/multi/alpine_packets.h
+++ b/game_patch/multi/alpine_packets.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
+#include <string_view>
 #include <variant>
 #include <vector>
 #include <common/rfproto.h>
@@ -84,8 +86,69 @@ enum class af_client_req_type : uint8_t
     af_req_server_cfg = 0x1,
     af_req_spray = 0x2,
     af_req_character = 0x3,
-    af_req_ready = 0x4,      // Alpine 1.4 (1 byte: action 0=unready,1=ready,2=toggle)
-    af_req_pit_queue = 0x5,  // Alpine 1.4 (1 byte: action 0=leave,1=join,2=toggle)
+    af_req_ready = 0x4,        // Alpine 1.4 (1 byte: action 0=unready,1=ready,2=toggle)
+    af_req_pit_queue = 0x5,    // Alpine 1.4 (1 byte: action 0=leave,1=join,2=toggle)
+    af_req_vote_call = 0x6,    // Alpine 1.4 (variable, see af_build_vote_call_payload)
+    af_req_vote_cast = 0x7,    // Alpine 1.4 (1 byte: 0 = no, 1 = yes)
+    af_req_vote_cancel = 0x8,  // Alpine 1.4 (empty; only the vote owner may cancel)
+    af_req_vote_options = 0x9, // Alpine 1.4 (empty; requests the vote-options blob)
+};
+
+// FROZEN wire constants: the vote type byte of af_req_vote_call and
+// af_sreq_vote_state. Never reorder or reuse values.
+enum class AfVoteType : uint8_t
+{
+    Kick = 0,
+    Level = 1,
+    Match = 2,
+    Extend = 3,
+    Restart = 4,
+    Next = 5,
+    Random = 6,
+    Previous = 7,
+    CancelMatch = 8,
+};
+constexpr uint8_t af_vote_type_count = 9;
+
+// "no gametype override" sentinel in vote-call payloads.
+constexpr uint8_t af_vote_gametype_none = 0xFF;
+
+// af_sreq_vote_state `event` byte. FROZEN wire constants.
+enum class AfVoteStateEvent : uint8_t
+{
+    Start = 0,
+    Update = 1,
+    End = 2,
+};
+
+// af_sreq_vote_state end-event `result` byte. FROZEN wire constants.
+enum class AfVoteResult : uint8_t
+{
+    Passed = 0,
+    Failed = 1,
+    Canceled = 2,
+    TimedOut = 3,
+};
+
+enum af_vote_state_flags : uint8_t
+{
+    AF_VOTE_STATE_FLAG_OWNER = 1 << 0, // the recipient started this vote
+};
+
+// Version byte of the reassembled vote-options blob (see af_build_vote_options_blob).
+constexpr uint8_t af_vote_options_blob_version = 1;
+
+enum af_vote_gametype_flags : uint8_t
+{
+    AF_VOTE_GAMETYPE_FLAG_TEAM = 1 << 0,
+};
+
+// Server-wide vote flags, the `server_flags` byte of the vote-options blob.
+enum af_vote_server_flags : uint8_t
+{
+    // vote_level.only_allow_gametype_prefix is on, so each level's
+    // valid_gametype_mask actually restricts something and the UI may say so.
+    AF_VOTE_SERVER_FLAG_GAMETYPE_PREFIX = 1 << 0,
 };
 
 struct HandicapPayload
@@ -116,8 +179,14 @@ struct PitQueueReqPayload
     uint8_t action = 0; // 0 = leave, 1 = join, 2 = toggle
 };
 
+struct VoteCastReqPayload
+{
+    uint8_t is_yes = 0; // 0 = no, 1 = yes
+};
+
 using af_client_payload = std::variant<HandicapPayload, SprayReqPayload, CharacterPayload,
-                                       ReadyReqPayload, PitQueueReqPayload, std::monostate>;
+                                       ReadyReqPayload, PitQueueReqPayload, VoteCastReqPayload,
+                                       std::monostate>;
 
 struct af_client_req_packet
 {
@@ -129,10 +198,12 @@ struct af_client_req_packet
 enum class af_server_req_type : uint8_t
 {
     af_sreq_should_gib = 0x0,
-    af_sreq_teleport_entity = 0x1,  // Alpine 1.4
-    af_sreq_spray = 0x2,            // Alpine 1.4
-    af_sreq_ready_prompt = 0x3,     // Alpine 1.4 (1 byte: state 0/1/2)
-    af_sreq_pit_queue_state = 0x4,  // Alpine 1.4 (3 bytes: flags, position, total)
+    af_sreq_teleport_entity = 0x1,     // Alpine 1.4
+    af_sreq_spray = 0x2,               // Alpine 1.4
+    af_sreq_ready_prompt = 0x3,        // Alpine 1.4 (1 byte: state 0/1/2)
+    af_sreq_pit_queue_state = 0x4,     // Alpine 1.4 (3 bytes: flags, position, total)
+    af_sreq_vote_state = 0x5,          // Alpine 1.4 (variable, see AfVoteStateEvent)
+    af_sreq_vote_options_data = 0x6,   // Alpine 1.4 (chunked vote-options blob)
 };
 
 struct ShouldGibPayload
@@ -516,6 +587,18 @@ enum class af_skill_field : uint8_t
 inline constexpr uint8_t kBotControlPacketVersion = 1;
 inline constexpr uint8_t kMaxPresetNameLen = 31;
 
+// Decoded af_req_vote_call payload. Not a wire struct — it holds owning types,
+// so it must stay outside the packed region above.
+struct AfVoteCallParams
+{
+    AfVoteType type = AfVoteType::Kick;
+    uint8_t target_player_id = 0xFF;      // Kick
+    uint8_t team_size = 0;                // Match
+    std::string level;                    // Level (required) / Match (empty = current)
+    uint8_t gametype = af_vote_gametype_none;
+    std::vector<VoteMutatorInput> mutators;
+};
+
 bool af_process_packet(const void* data, int len, const rf::NetAddr& addr, rf::Player* player);
 void af_send_packet(rf::Player* player, const void* data, int len, bool is_reliable);
 
@@ -583,6 +666,21 @@ void af_send_server_cfg_request();
 void af_send_spray_request(uint16_t texture_id, const rf::Vector3& pos, const rf::Vector3& normal);
 void af_send_ready_request(uint8_t action);      // 0 = unready, 1 = ready, 2 = toggle
 void af_send_pit_queue_request(uint8_t action);  // 0 = leave, 1 = join, 2 = toggle
+
+// vote system (client -> server)
+void af_send_vote_call(const AfVoteCallParams& params);
+void af_send_vote_cast(bool is_yes_vote);
+void af_send_vote_cancel();
+void af_send_vote_options_request();
+
+// vote system (server -> client)
+// `initiator_name` may be empty when the vote owner is no longer connected.
+void af_send_vote_state_start(rf::Player* player, AfVoteType type, uint16_t time_remaining_sec,
+                              uint8_t yes, uint8_t no, uint8_t remaining, bool is_owner,
+                              std::string_view initiator_name, std::string_view title);
+void af_send_vote_state_update(rf::Player* player, uint8_t yes, uint8_t no, uint8_t remaining);
+void af_send_vote_state_end(rf::Player* player, AfVoteResult result);
+void af_send_vote_options_data(rf::Player* player);
 
 // server -> client state (Pit + match ready system)
 void af_send_ready_prompt(rf::Player* player, uint8_t state); // 0/1/2 (see ReadyPromptPayload)

--- a/game_patch/multi/alpine_packets.h
+++ b/game_patch/multi/alpine_packets.h
@@ -168,7 +168,7 @@ enum class AfVoteOptionsStream : uint8_t
 };
 
 // Hard ceiling on a reassembled vote-options blob.
-// Should never be legitimately reached.
+// Defense in depth, should never be legitimately reached.
 constexpr uint32_t af_vote_options_max_blob_size = 1024 * 1024;
 
 enum af_vote_options_req_flags : uint8_t

--- a/game_patch/multi/alpine_packets.h
+++ b/game_patch/multi/alpine_packets.h
@@ -117,6 +117,13 @@ static_assert(af_vote_type_count <= 32, "enabled_vote_mask is a u32");
 // "no gametype override" sentinel in vote-call payloads.
 constexpr uint8_t af_vote_gametype_none = 0xFF;
 
+// Extend vote duration, in minutes. Shared by the panel's numeric entry, the
+// chat menu's quick entry and the server's validation of the incoming payload,
+// so all three agree on what a legal request looks like.
+constexpr uint8_t af_vote_extend_min_minutes = 1;
+constexpr uint8_t af_vote_extend_max_minutes = 60;
+constexpr uint8_t af_vote_extend_default_minutes = 5;
+
 // af_sreq_vote_state `event` byte. FROZEN wire constants.
 enum class AfVoteStateEvent : uint8_t
 {
@@ -651,6 +658,7 @@ struct AfVoteCallParams
     uint8_t team_size = 0;                // Match
     std::string level;                    // Level (required) / Match (empty = current)
     uint8_t gametype = af_vote_gametype_none;
+    uint8_t extend_minutes = af_vote_extend_default_minutes;
     std::vector<VoteMutatorInput> mutators;
 };
 

--- a/game_patch/multi/alpine_packets.h
+++ b/game_patch/multi/alpine_packets.h
@@ -90,12 +90,11 @@ enum class af_client_req_type : uint8_t
     af_req_pit_queue = 0x5,    // Alpine 1.4 (1 byte: action 0=leave,1=join,2=toggle)
     af_req_vote_call = 0x6,    // Alpine 1.4 (variable, see af_build_vote_call_payload)
     af_req_vote_cast = 0x7,    // Alpine 1.4 (1 byte: 0 = no, 1 = yes)
-    af_req_vote_cancel = 0x8,  // Alpine 1.4 (empty; only the vote owner may cancel)
-    af_req_vote_options = 0x9, // Alpine 1.4 (empty; requests the vote-options blob)
+    af_req_vote_cancel = 0x8,  // Alpine 1.4 (no additional data)
+    af_req_vote_options = 0x9, // Alpine 1.4 (5 bytes: flags + known_generation)
 };
 
-// FROZEN wire constants: the vote type byte of af_req_vote_call and
-// af_sreq_vote_state. Never reorder or reuse values.
+// Frozen wire constants, values can NEVER be reordered or changed.
 enum class AfVoteType : uint8_t
 {
     Kick = 0,
@@ -108,7 +107,12 @@ enum class AfVoteType : uint8_t
     Previous = 7,
     CancelMatch = 8,
 };
+// Number of vote types this build knows about.
+// NOT a wire limit: a newer server may run a type with a higher value,
+// and a client tolerates that. Only the server uses it as a rejection bound,
+// on incoming vote calls.
 constexpr uint8_t af_vote_type_count = 9;
+static_assert(af_vote_type_count <= 32, "enabled_vote_mask is a u32");
 
 // "no gametype override" sentinel in vote-call payloads.
 constexpr uint8_t af_vote_gametype_none = 0xFF;
@@ -132,15 +136,60 @@ enum class AfVoteResult : uint8_t
 
 enum af_vote_state_flags : uint8_t
 {
-    AF_VOTE_STATE_FLAG_OWNER = 1 << 0, // the recipient started this vote
+    // the recipient started this vote
+    AF_VOTE_STATE_FLAG_OWNER = 1 << 0,
+    // the recipient joined while the vote was in progress
+    AF_VOTE_STATE_FLAG_SYNC = 1 << 1,
 };
 
-// Version byte of the reassembled vote-options blob (see af_build_vote_options_blob).
+enum af_vote_end_flags : uint8_t
+{
+    // The vote PASSED and its outcome is being applied.
+    // Independent of result, which is how the vote ended.
+    AF_VOTE_END_FLAG_PASSED = 1 << 0,
+};
+
+// Version of the reassembled vote-options blob. A client accepts any blob
+// whose version is <= the version it was built for and rejects anything greater.
+//
+// Repeated records in the blob are length-prefixed, so additions to the blob
+// are not compatibility breaking. This version should be incremented only if
+// the core format changes - like redefining a field or reordering/removing them.
 constexpr uint8_t af_vote_options_blob_version = 1;
+
+// af_sreq_vote_options_data stream framing. The blob is pushed as
+// Begin -> Data* -> End over the ordered reliable channel, so no chunk index or
+// chunk count is needed and there is no size ceiling.
+enum class AfVoteOptionsStream : uint8_t
+{
+    Begin = 0, // u32 generation, u32 total_bytes
+    Data = 1,  // u32 generation, bytes[]  (length comes from the packet header)
+    End = 2,   // u32 generation
+};
+
+// Hard ceiling on a reassembled vote-options blob.
+// Should never be legitimately reached.
+constexpr uint32_t af_vote_options_max_blob_size = 1024 * 1024;
+
+enum af_vote_options_req_flags : uint8_t
+{
+    // The request carries the generation of a blob the client already parsed, so
+    // the server can skip re-sending an identical one.
+    AF_VOTE_OPTIONS_REQ_HAS_CACHE = 1 << 0,
+};
 
 enum af_vote_gametype_flags : uint8_t
 {
     AF_VOTE_GAMETYPE_FLAG_TEAM = 1 << 0,
+};
+
+// Per-level flags in the vote-options blob's level section.
+enum af_vote_level_flags : uint8_t
+{
+    // The server's vote_level allow-list accepts this level. When clear, a vote
+    // naming this level is rejected outright whatever game type is selected —
+    // the blob still lists it (it is in the rotation) but it is not votable.
+    AF_VOTE_LEVEL_FLAG_ALLOWED = 1 << 0,
 };
 
 // Server-wide vote flags, the `server_flags` byte of the vote-options blob.
@@ -184,9 +233,15 @@ struct VoteCastReqPayload
     uint8_t is_yes = 0; // 0 = no, 1 = yes
 };
 
+struct VoteOptionsReqPayload
+{
+    uint8_t flags = 0;              // af_vote_options_req_flags
+    uint32_t known_generation = 0;  // meaningful only with AF_VOTE_OPTIONS_REQ_HAS_CACHE
+};
+
 using af_client_payload = std::variant<HandicapPayload, SprayReqPayload, CharacterPayload,
                                        ReadyReqPayload, PitQueueReqPayload, VoteCastReqPayload,
-                                       std::monostate>;
+                                       VoteOptionsReqPayload, std::monostate>;
 
 struct af_client_req_packet
 {
@@ -648,6 +703,7 @@ void af_send_server_cfg(rf::Player* player);
 void af_process_server_msg_packet(const void* data, size_t len, const rf::NetAddr&);
 void af_broadcast_automated_chat_msg(std::string_view msg);
 void af_send_automated_chat_msg(std::string_view msg, rf::Player* player, bool tell_server = false);
+void af_broadcast_vote_legacy_chat_msg(std::string_view msg);
 void af_broadcast_hud_notification(
     std::string_view text, int duration_seconds, int notification_type, bool fade_on_expire = true);
 void af_send_hud_notification(
@@ -671,15 +727,19 @@ void af_send_pit_queue_request(uint8_t action);  // 0 = leave, 1 = join, 2 = tog
 void af_send_vote_call(const AfVoteCallParams& params);
 void af_send_vote_cast(bool is_yes_vote);
 void af_send_vote_cancel();
-void af_send_vote_options_request();
+void af_send_vote_options_request(bool has_cache, uint32_t known_generation);
 
 // vote system (server -> client)
 // `initiator_name` may be empty when the vote owner is no longer connected.
+// `is_sync` marks a mid-vote resync for a player who just joined.
 void af_send_vote_state_start(rf::Player* player, AfVoteType type, uint16_t time_remaining_sec,
-                              uint8_t yes, uint8_t no, uint8_t remaining, bool is_owner,
+                              uint8_t yes, uint8_t no, uint8_t remaining, bool is_owner, bool is_sync,
                               std::string_view initiator_name, std::string_view title);
 void af_send_vote_state_update(rf::Player* player, uint8_t yes, uint8_t no, uint8_t remaining);
-void af_send_vote_state_end(rf::Player* player, AfVoteResult result);
+// `passed` is independent of `result` (a timed-out vote can pass); `detail` is
+// the outcome line legacy clients receive as chat, so both see the same wording.
+void af_send_vote_state_end(rf::Player* player, AfVoteResult result, bool passed,
+                            std::string_view detail);
 void af_send_vote_options_data(rf::Player* player);
 
 // server -> client state (Pit + match ready system)

--- a/game_patch/multi/bots/bot_main.cpp
+++ b/game_patch/multi/bots/bot_main.cpp
@@ -28,6 +28,7 @@
 #include <patch_common/FunHook.h>
 #include "../../main/main.h"
 #include "../../graphics/gr.h"
+#include "../../input/control_input_filter.h"
 #include "../../misc/alpine_settings.h"
 #include "../../misc/waypoints.h"
 #include "../../rf/ai.h"
@@ -2523,51 +2524,31 @@ FunHook<void(rf::Player*, rf::ControlConfig*, rf::ControlInfo*, int, int)> contr
     },
 };
 
-FunHook<bool(rf::ControlConfig*, rf::ControlConfigAction, bool*)> control_config_check_pressed_hook{
-    0x0043D4F0,
-    [](rf::ControlConfig* ccp, rf::ControlConfigAction action, bool* just_pressed_out) {
-        bool base_just_pressed = false;
-        bool* base_just_pressed_out = just_pressed_out ? &base_just_pressed : nullptr;
-        const bool base_pressed = control_config_check_pressed_hook.call_target(
-            ccp,
-            action,
-            base_just_pressed_out
-        );
-        if (just_pressed_out) {
-            *just_pressed_out = base_just_pressed;
-        }
+// The bot's fire policy, laid over the engine's reading of the attack binds by
+// control_input_filter.
+ControlInputInjection bot_synthetic_fire_injection(rf::ControlConfig* ccp, rf::ControlConfigAction action)
+{
+    if (!is_client_bot_active()
+        || !rf::gameseq_in_gameplay()
+        || !rf::local_player
+        || ccp != &rf::local_player->settings.controls) {
+        return {};
+    }
 
-        if (!is_client_bot_active()
-            || !rf::gameseq_in_gameplay()
-            || !rf::local_player
-            || ccp != &rf::local_player->settings.controls) {
-            return base_pressed;
-        }
-
-        bool synthetic_pressed = false;
-        bool synthetic_just_pressed = false;
-        if (action == rf::CC_ACTION_PRIMARY_ATTACK) {
-            synthetic_pressed = g_client_bot_state.firing.synthetic_primary_fire_down;
-            synthetic_just_pressed = g_client_bot_state.firing.synthetic_primary_fire_just_pressed;
-        }
-        else if (action == rf::CC_ACTION_SECONDARY_ATTACK) {
-            synthetic_pressed = g_client_bot_state.firing.synthetic_secondary_fire_down;
-            synthetic_just_pressed = g_client_bot_state.firing.synthetic_secondary_fire_just_pressed;
-        }
-        else {
-            return base_pressed;
-        }
-
-        if (!synthetic_pressed) {
-            return base_pressed;
-        }
-
-        if (just_pressed_out) {
-            *just_pressed_out = *just_pressed_out || synthetic_just_pressed;
-        }
-        return true;
-    },
-};
+    if (action == rf::CC_ACTION_PRIMARY_ATTACK) {
+        return {
+            g_client_bot_state.firing.synthetic_primary_fire_down,
+            g_client_bot_state.firing.synthetic_primary_fire_just_pressed,
+        };
+    }
+    if (action == rf::CC_ACTION_SECONDARY_ATTACK) {
+        return {
+            g_client_bot_state.firing.synthetic_secondary_fire_down,
+            g_client_bot_state.firing.synthetic_secondary_fire_just_pressed,
+        };
+    }
+    return {};
+}
 
 void ensure_bot_input_hook_installed()
 {
@@ -2577,7 +2558,7 @@ void ensure_bot_input_hook_installed()
 
     if (!g_bot_input_hook_installed) {
         controls_read_internal2_hook.install();
-        control_config_check_pressed_hook.install();
+        control_input_filter_add_press_injection(&bot_synthetic_fire_injection);
         g_bot_input_hook_installed = true;
     }
 }

--- a/game_patch/multi/commands.cpp
+++ b/game_patch/multi/commands.cpp
@@ -10,6 +10,8 @@
 #include "multi.h"
 #include <patch_common/AsmWriter.h>
 #include <patch_common/CallHook.h>
+#include <algorithm>
+#include <cstdint>
 #include <vector>
 #include <format>
 #include <optional>
@@ -138,22 +140,34 @@ ConsoleCommand2 map_prev_cmd{
 };
 
 void kick_player_delayed(const rf::Player* const player) {
+    if (!player || !player->net_data) {
+        return;
+    }
+    const int player_id = player->net_data->player_id;
+    if (std::find(g_players_to_kick.begin(), g_players_to_kick.end(), player_id) != g_players_to_kick.end()) {
+        return;
+    }
     rf::console::print("{}{}", player->name, rf::strings::was_kicked);
-    g_players_to_kick.push_back(player->net_data->player_id);
+    g_players_to_kick.push_back(player_id);
 }
 
 CallHook<void(const rf::Player*)> multi_kick_player_hook{0x0047B9BD, kick_player_delayed};
 
 void process_delayed_kicks()
 {
-    // Process kicks outside of packet processing loop to avoid crash when a player is suddenly destroyed (00479299)
-    for (int player_id : g_players_to_kick) {
-        rf::Player* player = rf::multi_find_player_by_id(player_id);
-        if (player) {
-            rf::multi_kick_player(player);
+    // Process kicks outside of packet processing loop to avoid crash when a player is suddenly destroyed.
+    // The engine's receive loop caches player_list->next before dispatching each packet, so destroying
+    // a player from inside a packet handler makes the loop walk a freed rf::Player on the next iteration.
+    while (!g_players_to_kick.empty()) {
+        std::vector<int> batch;
+        batch.swap(g_players_to_kick);
+        for (int player_id : batch) {
+            rf::Player* player = rf::multi_find_player_by_id(static_cast<uint8_t>(player_id));
+            if (player) {
+                rf::multi_kick_player(player);
+            }
         }
     }
-    g_players_to_kick.clear();
 }
 
 void ban_cmd_handler_hook()

--- a/game_patch/multi/dedi_cfg.cpp
+++ b/game_patch/multi/dedi_cfg.cpp
@@ -1109,6 +1109,11 @@ static void add_level_entry_from_table(
     std::string context = "level '" + (tmp_filename.empty() ? std::string("<unknown>") : tmp_filename) + "'";
     entry.rule_overrides = apply_rules_presets_and_overrides(
         lvl_tbl, base_dir, cfg.base_rules, context, &cfg.rules_preset_aliases, nullptr, &entry.applied_rules_preset_paths);
+    // Mutator-free variant, used as the starting point for level/match votes
+    // that carry mutators (see load_vote_rules_override).
+    entry.rule_overrides_no_mutators = apply_rules_presets_and_overrides(
+        lvl_tbl, base_dir, cfg.base_rules_no_mutators, context + " (no mutators)",
+        &cfg.rules_preset_aliases, nullptr, nullptr, /*apply_mutators*/ false);
 
     cfg.levels.push_back(std::move(entry));
 }
@@ -1367,8 +1372,15 @@ static void apply_known_table_in_order(
             cfg.vote_level.allowed_maps = parse_allowed_maps(tbl);
         }
     }
-    else if (key == "vote_gametype")
-        cfg.vote_gametype = parse_vote_config(tbl);
+    else if (key == "vote_gametype") {
+        // Removed in AF 1.4 — game type selection is now part of vote level.
+        static bool warned_vote_gametype_deprecated = false;
+        if (!warned_vote_gametype_deprecated) {
+            warned_vote_gametype_deprecated = true;
+            rf::console::print(
+                "  [WARN] vote_gametype is deprecated and ignored; gametype is now part of vote level\n");
+        }
+    }
     else if (key == "vote_extend")
         cfg.vote_extend = parse_vote_config(tbl);
     else if (key == "vote_restart")
@@ -2243,7 +2255,6 @@ void print_alpine_dedicated_server_config_info(std::string& output, bool verbose
     };
 
     print_vote("Vote kick:    ", cfg.vote_kick);
-    print_vote("Vote gametype:", cfg.vote_gametype);
     print_vote("Vote extend:  ", cfg.vote_extend);
     print_vote("Vote restart: ", cfg.vote_restart);
     print_vote("Vote next:    ", cfg.vote_next);
@@ -2364,6 +2375,7 @@ void load_and_print_alpine_dedicated_server_config(std::string ads_config_name, 
         load_ads_server_config(ads_config_name, false);
         g_alpine_server_config.printed_cfg.clear();
         cfg.signal_cfg_changed = true;
+        server_vote_invalidate_options_blob();
     }
 
     initialize_core_alpine_dedicated_server_settings(netgame, cfg, on_launch);
@@ -2490,15 +2502,20 @@ void apply_rules_for_current_level()
         }
     }
     else { // level is in rotation
+        // The rotation can shrink under a running level (sv_loadconfig), so the
+        // index must be validated for the log line too, not just the lookup.
+        const bool idx_valid = (idx >= 0 && idx < static_cast<int>(cfg.levels.size()));
+
         AlpineServerConfigRules const &override_rules =
-            (idx >= 0 && idx < (int)cfg.levels.size())
-              ? cfg.levels[idx].rule_overrides
-              : cfg.base_rules;
+            idx_valid ? cfg.levels[idx].rule_overrides : cfg.base_rules;
 
         g_alpine_server_config_active_rules = override_rules;
 
-        if (!g_ads_minimal_server_info)
-            rf::console::print("Applying level-specific rules for server rotation index {} ({})...\n", idx, cfg.levels[idx].level_filename);
+        if (!g_ads_minimal_server_info) {
+            std::string_view level_name =
+                idx_valid ? std::string_view(cfg.levels[idx].level_filename) : std::string_view("UNKNOWN");
+            rf::console::print("Applying level-specific rules for server rotation index {} ({})...\n", idx, level_name);
+        }
     }
 
     // respect game type specific base rules (eg. koth spawn loadout) for voted or manually loaded maps
@@ -2514,16 +2531,7 @@ void apply_rules_for_current_level()
         apply_defaults_for_game_type(active_game_type, g_alpine_server_config_active_rules);
 
         if (!saved_mutators.empty()) {
-            toml::array mut_arr;
-            for (const auto& decl : saved_mutators) {
-                toml::table tbl;
-                tbl.insert_or_assign("name", decl.name);
-                if (decl.featured_weapon)
-                    tbl.insert_or_assign("featured_weapon", *decl.featured_weapon);
-                if (decl.exclude_thrown)
-                    tbl.insert_or_assign("exclude_thrown", *decl.exclude_thrown);
-                mut_arr.push_back(std::move(tbl));
-            }
+            const toml::array mut_arr = mutator_declarations_to_toml_array(saved_mutators);
             apply_mutators_from_toml(mut_arr, g_alpine_server_config_active_rules);
         }
     }

--- a/game_patch/multi/dedi_cfg.cpp
+++ b/game_patch/multi/dedi_cfg.cpp
@@ -526,6 +526,22 @@ void apply_defaults_for_game_type(rf::NetGameType game_type, AlpineServerConfigR
     }
 }
 
+// Set while a scope is re-parsed to DERIVE a second rules variant (the
+// mutator-free baseline vote overrides start from). That pass walks the same TOML
+// and re-reads the same preset files, so without this every preset warning and
+// error was printed twice per scope — the repeat tagged "(no mutators)", which an
+// admin has no way to interpret. The first pass is the one that reports problems.
+static bool g_rules_parse_quiet = false;
+
+struct RulesParseQuietGuard
+{
+    bool previous;
+    RulesParseQuietGuard() : previous(g_rules_parse_quiet) { g_rules_parse_quiet = true; }
+    ~RulesParseQuietGuard() { g_rules_parse_quiet = previous; }
+    RulesParseQuietGuard(const RulesParseQuietGuard&) = delete;
+    RulesParseQuietGuard& operator=(const RulesParseQuietGuard&) = delete;
+};
+
 // parse toml rules
 // for base rules, load all speciifed. For not specified, defaults are in struct
 // for level-specific rules, start with base rules and load anything specified beyond that
@@ -686,7 +702,7 @@ AlpineServerConfigRules parse_server_rules(const toml::table& t, const AlpineSer
             if (auto tbl = node.as_table()) {
                 auto from = (*tbl)["original"].value_or<std::string>("");
                 auto to = (*tbl)["replacement"].value_or<std::string>("");
-                if (!o.add_item_replacement(from, to))
+                if (!o.add_item_replacement(from, to) && !g_rules_parse_quiet)
                     xlog::warn("Invalid replacement {} -> {}", from, to);
             }
         }
@@ -697,7 +713,7 @@ AlpineServerConfigRules parse_server_rules(const toml::table& t, const AlpineSer
             if (auto tbl = node.as_table()) {
                 auto name = (*tbl)["item_name"].value_or<std::string>("");
                 auto ms = (*tbl)["respawn_ms"].value_or<int>(0);
-                if (!o.set_item_respawn_time(name, ms))
+                if (!o.set_item_respawn_time(name, ms) && !g_rules_parse_quiet)
                     xlog::warn("Invalid respawn override for '{}'", name);
             }
         }
@@ -708,7 +724,7 @@ AlpineServerConfigRules parse_server_rules(const toml::table& t, const AlpineSer
             if (auto tbl = node.as_table()) {
                 if (auto nameOpt = (*tbl)["item_name"].value<std::string>()) {
                     bool added = o.delayed_items.add(*nameOpt);
-                    if (!added && !o.delayed_items.contains(*nameOpt))
+                    if (!added && !o.delayed_items.contains(*nameOpt) && !g_rules_parse_quiet)
                         xlog::warn("Invalid delayed item '{}'", *nameOpt);
                 }
             }
@@ -971,11 +987,14 @@ static AlpineServerConfigRules apply_rules_presets_and_overrides(
             resolved_path = fs::weakly_canonical(resolved_path);
         }
         catch (const fs::filesystem_error& err) {
-            rf::console::print("  [WARN] failed to canonicalize rules preset '{}' in {}: {}\n", resolved_path.generic_string(), context, err.what()); resolved_path = fs::absolute(resolved_path);
+            if (!g_rules_parse_quiet)
+                rf::console::print("  [WARN] failed to canonicalize rules preset '{}' in {}: {}\n", resolved_path.generic_string(), context, err.what());
+            resolved_path = fs::absolute(resolved_path);
         }
 
         if (std::find(preset_stack->begin(), preset_stack->end(), resolved_path) != preset_stack->end()) {
-            rf::console::print("  [ERROR] rules preset cycle detected at '{}' in {}\n", resolved_path.generic_string(), context);
+            if (!g_rules_parse_quiet)
+                rf::console::print("  [ERROR] rules preset cycle detected at '{}' in {}\n", resolved_path.generic_string(), context);
             return;
         }
 
@@ -999,7 +1018,8 @@ static AlpineServerConfigRules apply_rules_presets_and_overrides(
             }
         }
         catch (const toml::parse_error& err) {
-            rf::console::print("  [ERROR] failed to parse rules preset '{}' in {}: {}\n", resolved_path.generic_string(), context, err.description());
+            if (!g_rules_parse_quiet)
+                rf::console::print("  [ERROR] failed to parse rules preset '{}' in {}: {}\n", resolved_path.generic_string(), context, err.description());
         }
         preset_stack->pop_back();
     };
@@ -1009,14 +1029,14 @@ static AlpineServerConfigRules apply_rules_presets_and_overrides(
             for (auto& node : *arr) {
                 if (auto preset = node.value<std::string>())
                     apply_preset(*preset);
-                else
+                else if (!g_rules_parse_quiet)
                     rf::console::print("  [WARN] rules_presets entries in {} must be strings.\n", context);
             }
         }
         else if (auto preset = presets.value<std::string>()) {
             apply_preset(*preset);
         }
-        else {
+        else if (!g_rules_parse_quiet) {
             rf::console::print("  [WARN] 'rules_presets' in {} must be a string or array of strings.\n", context);
         }
     }
@@ -1110,10 +1130,13 @@ static void add_level_entry_from_table(
     entry.rule_overrides = apply_rules_presets_and_overrides(
         lvl_tbl, base_dir, cfg.base_rules, context, &cfg.rules_preset_aliases, nullptr, &entry.applied_rules_preset_paths);
     // Mutator-free variant, used as the starting point for level/match votes
-    // that carry mutators (see load_vote_rules_override).
-    entry.rule_overrides_no_mutators = apply_rules_presets_and_overrides(
-        lvl_tbl, base_dir, cfg.base_rules_no_mutators, context + " (no mutators)",
-        &cfg.rules_preset_aliases, nullptr, nullptr, /*apply_mutators*/ false);
+    // that carry mutators.
+    {
+        const RulesParseQuietGuard quiet;
+        entry.rule_overrides_no_mutators = apply_rules_presets_and_overrides(
+            lvl_tbl, base_dir, cfg.base_rules_no_mutators, context,
+            &cfg.rules_preset_aliases, nullptr, nullptr, /*apply_mutators*/ false);
+    }
 
     cfg.levels.push_back(std::move(entry));
 }
@@ -1372,15 +1395,6 @@ static void apply_known_table_in_order(
             cfg.vote_level.allowed_maps = parse_allowed_maps(tbl);
         }
     }
-    else if (key == "vote_gametype") {
-        // Removed in AF 1.4 — game type selection is now part of vote level.
-        static bool warned_vote_gametype_deprecated = false;
-        if (!warned_vote_gametype_deprecated) {
-            warned_vote_gametype_deprecated = true;
-            rf::console::print(
-                "  [WARN] vote_gametype is deprecated and ignored; gametype is now part of vote level\n");
-        }
-    }
     else if (key == "vote_extend")
         cfg.vote_extend = parse_vote_config(tbl);
     else if (key == "vote_restart")
@@ -1399,9 +1413,12 @@ static void apply_known_table_in_order(
         // Also compute the base rules with all mutators stripped, so a mutator applied
         // later via a level/match vote fully replaces (rather than stacks on top of)
         // whatever mutator the base rules declared.
-        cfg.base_rules_no_mutators = apply_rules_presets_and_overrides(
-            tbl, base_dir, cfg.base_rules_no_mutators, "base configuration (no mutators)",
-            &cfg.rules_preset_aliases, nullptr, nullptr, /*apply_mutators*/ false);
+        {
+            const RulesParseQuietGuard quiet;
+            cfg.base_rules_no_mutators = apply_rules_presets_and_overrides(
+                tbl, base_dir, cfg.base_rules_no_mutators, "base configuration",
+                &cfg.rules_preset_aliases, nullptr, nullptr, /*apply_mutators*/ false);
+        }
     }
     else if (key == "levels") {
         if (auto arr = tbl.as_array()) {
@@ -1679,7 +1696,12 @@ void print_rules(std::string& output, const AlpineServerConfigRules& rules, bool
         std::format_to(iter, "  Game type:                             {}\n", multi_game_type_name_short(rules.game_type));
 
     // mutators
-    if (base || rules.mutators.active_labels != b.mutators.active_labels) {
+    const bool mutators_changed =
+        rules.mutators.active_labels != b.mutators.active_labels ||
+        rules.mutators.vampire_enabled != b.mutators.vampire_enabled ||
+        rules.mutators.hide_health_armor_pickups != b.mutators.hide_health_armor_pickups;
+
+    if (base || mutators_changed) {
         std::string joined;
         for (size_t i = 0; i < rules.mutators.active_labels.size(); ++i) {
             if (i)
@@ -1687,6 +1709,10 @@ void print_rules(std::string& output, const AlpineServerConfigRules& rules, bool
             joined += rules.mutators.active_labels[i];
         }
         std::format_to(iter, "  Mutators:                              {}\n", joined.empty() ? "<none>" : joined);
+        if (rules.mutators.vampire_enabled) {
+            std::format_to(iter, "    Hide health/armor pickups:           {}\n",
+                           rules.mutators.hide_health_armor_pickups);
+        }
     }
 
     // time limit

--- a/game_patch/multi/mutators.cpp
+++ b/game_patch/multi/mutators.cpp
@@ -11,6 +11,8 @@
 #include "mutators.h"
 #include "server_internal.h"
 #include "multi.h"
+#include "gametype.h"
+#include "kill.h"
 #include "../rf/weapon.h"
 #include "../rf/item.h"
 #include "../rf/entity.h"
@@ -104,6 +106,8 @@ static void apply_instagib(AlpineServerConfigRules& r, const toml::table& /*opts
 // Rails: spawn with baton, no pickups except weapons/ammo, and every
 // weapon/ammo pickup becomes the featured weapon's pickup (rail by default). The
 // featured weapon otherwise behaves normally (reloads, finite ammo, free switch).
+static constexpr bool RAILS_DEFAULT_EXCLUDE_THROWN = true;
+
 static void apply_rails(AlpineServerConfigRules& r, const toml::table& opts)
 {
     int featured = rf::rail_gun_weapon_type;
@@ -115,7 +119,7 @@ static void apply_rails(AlpineServerConfigRules& r, const toml::table& opts)
             rf::console::print("  [WARN] Rails mutator: unknown featured_weapon '{}', using rail gun\n",
                                clamp_for_console(*v));
     }
-    const bool exclude_thrown = opts["exclude_thrown"].value_or(true);
+    const bool exclude_thrown = opts["exclude_thrown"].value_or(RAILS_DEFAULT_EXCLUDE_THROWN);
 
     // spawn delay
     r.spawn_delay.enabled = true;
@@ -179,6 +183,21 @@ static void apply_arena(AlpineServerConfigRules& r, const toml::table& /*opts*/)
     r.mutators.pickup_policy = PickupPolicy::WeaponsOnly;
 }
 
+// Vampire: landing damage on another player heals the attacker for a fixed
+// share of the damage that was actually applied — 1:2, i.e. 100 damage dealt
+// gives 50 effective health back.
+static constexpr float VAMPIRE_HEAL_RATIO = 0.5f;
+static constexpr bool VAMPIRE_DEFAULT_HIDE_HEALTH_ARMOR = true;
+
+static void apply_vampire(AlpineServerConfigRules& r, const toml::table& opts)
+{
+    r.mutators.vampire_enabled = true;
+
+    // Composed with (not replacing) whatever pickup policy is in force.
+    r.mutators.hide_health_armor_pickups =
+        opts["hide_health_armor_pickups"].value_or(VAMPIRE_DEFAULT_HIDE_HEALTH_ARMOR);
+}
+
 // ============================================================================
 // Registry + application order
 // ============================================================================
@@ -199,6 +218,11 @@ static const MutatorOptionDef RAILS_OPTIONS[] = {
     {1, "exclude_thrown", "Keep thrown explosives", MutatorOptionType::Bool},
 };
 
+// Label kept short enough to clear the option row's checkbox label space at 640x480.
+static const MutatorOptionDef VAMPIRE_OPTIONS[] = {
+    {0, "hide_health_armor_pickups", "No health/armor pickups", MutatorOptionType::Bool},
+};
+
 struct MutatorDef
 {
     MutatorId id;
@@ -213,11 +237,13 @@ static const MutatorDef MUTATORS[] = {
     {MutatorId::Instagib, "instagib", "Instagib", &apply_instagib, nullptr, 0},
     {MutatorId::Rails, "rails", "Rails", &apply_rails, RAILS_OPTIONS, std::size(RAILS_OPTIONS)},
     {MutatorId::Arena, "arena", "Arena", &apply_arena, nullptr, 0},
+    {MutatorId::Vampire, "vampire", "Vampire", &apply_vampire, VAMPIRE_OPTIONS, std::size(VAMPIRE_OPTIONS)},
 };
 
 // Hardcoded order in which simultaneously-active mutators are applied. Later
 // entries win where they overlap.
 static const MutatorId MUTATOR_APPLY_ORDER[] = {
+    MutatorId::Vampire,
     MutatorId::Arena,
     MutatorId::Rails,
     MutatorId::Instagib,
@@ -253,19 +279,15 @@ static bool is_known_mutator_option(const MutatorDef& def, std::string_view key)
     return false;
 }
 
-// Short labels for the featured-weapon selector in the client's vote panel. The
-// stock display names ("Fusion Rocket Launcher") are far wider than the option
-// cycler. Matched case-insensitively against both the weapon's display name and
-// its weapons.tbl class name, so a table without a $Display Name still resolves.
-// Only the label changes; the choice VALUE stays the class name that round-trips
-// through rf::weapon_lookup_type. A weapon matching nothing (TC mods) keeps its
-// original label.
+// Short labels for the featured-weapon selector in the client's vote panel.
 struct WeaponShortLabel
 {
     const char* match; // stock display name or weapons.tbl class name
     const char* label;
 };
 
+// Only display names are needed for Vampire, but map includes class names too
+// so it can be used in the future for other short name translations.
 static const WeaponShortLabel WEAPON_SHORT_LABELS[] = {
     {"Remote Charge", "Charges"},           // class + display
     {"Control Baton", "Baton"},             // display
@@ -305,6 +327,7 @@ static const char* weapon_short_label(std::string_view display_name, std::string
 // Weapons the Rails mutator can feature: anything a level pickup can grant.
 // Rails redirects every weapon/ammo pickup onto the featured weapon's own
 // pickup, so a weapon without one would leave players stuck with the baton.
+// Not relevant in the stock game but could be in TC mods.
 static std::vector<MutatorOptionChoice> build_featured_weapon_choices()
 {
     std::vector<MutatorOptionChoice> choices;
@@ -332,13 +355,13 @@ static std::vector<MutatorOptionChoice> build_featured_weapon_choices()
 }
 
 static std::vector<MutatorInfo> g_mutator_registry;
+// Whether the cached build saw the weapon/item tables.
+static bool g_mutator_registry_built_with_tables = false;
 
 const std::vector<MutatorInfo>& mutators_get_registry()
 {
-    // Built once the weapon/item tables are loaded. An early call (before they
-    // are) leaves the choice lists empty, so don't cache that result.
     const bool tables_ready = rf::num_weapon_types > 0 && rf::num_item_types > 0;
-    if (!g_mutator_registry.empty() && tables_ready)
+    if (!g_mutator_registry.empty() && (g_mutator_registry_built_with_tables || !tables_ready))
         return g_mutator_registry;
 
     std::vector<MutatorInfo> registry;
@@ -370,7 +393,10 @@ const std::vector<MutatorInfo>& mutators_get_registry()
                 }
             }
             else if (def.id == MutatorId::Rails && opt.name == "exclude_thrown") {
-                opt.default_bool = true; // matches apply_rails
+                opt.default_bool = RAILS_DEFAULT_EXCLUDE_THROWN;
+            }
+            else if (def.id == MutatorId::Vampire && opt.name == "hide_health_armor_pickups") {
+                opt.default_bool = VAMPIRE_DEFAULT_HIDE_HEALTH_ARMOR;
             }
 
             info.options.push_back(std::move(opt));
@@ -380,6 +406,7 @@ const std::vector<MutatorInfo>& mutators_get_registry()
     }
 
     g_mutator_registry = std::move(registry);
+    g_mutator_registry_built_with_tables = tables_ready;
     return g_mutator_registry;
 }
 
@@ -613,9 +640,13 @@ std::optional<ManualRulesOverride> load_vote_rules_override(
     // single mutator to a level vote could flip the whole game type.
     AlpineServerConfigRules rules = vote_natural_rules_for_level(level_filename);
 
-    if (gametype) {
-        // apply_defaults_for_game_type() rebuilds the loadout and clears
-        // MutatorConfig, so the mutators must be applied after it.
+    if (gametype && rules.game_type != *gametype) {
+        // Only re-derive the gametype defaults when the type actually CHANGES.
+        // apply_defaults_for_game_type() overwrites operator-configured rules
+        // (spawn loadout, pvp_damage_modifier, spawn_delay, ...), so explicitly
+        // voting the type a level already runs must behave the same as voting
+        // "Server default" rather than silently wiping the config. It also
+        // rebuilds the loadout and clears MutatorConfig, so mutators come after.
         rules.game_type = *gametype;
         apply_defaults_for_game_type(*gametype, rules);
     }
@@ -637,19 +668,47 @@ std::optional<ManualRulesOverride> load_vote_rules_override(
 // Runtime logic
 // ============================================================================
 
+// Touch callbacks the engine binds by class name. Stock bindings:
+//   0x0045A2E0  medical kit      -> "Medical Kit", "First Aid Kit"
+//   0x0045A1F0  suit repair      -> "Suit Repair"
+//   0x0045A050  miner envirosuit -> "Miner Envirosuit"
+static constexpr uintptr_t ITEM_TOUCH_MEDICAL_KIT = 0x0045A2E0;
+static constexpr uintptr_t ITEM_TOUCH_SUIT_REPAIR = 0x0045A1F0;
+static constexpr uintptr_t ITEM_TOUCH_MINER_ENVIROSUIT = 0x0045A050;
+
+static bool is_standard_health_or_armor_item(const rf::ItemInfo& info)
+{
+    const auto callback = reinterpret_cast<uintptr_t>(info.touch_callback);
+    return callback == ITEM_TOUCH_MEDICAL_KIT
+        || callback == ITEM_TOUCH_SUIT_REPAIR
+        || callback == ITEM_TOUCH_MINER_ENVIROSUIT;
+}
+
 void mutators_level_init_post()
 {
     if (!rf::is_server)
         return;
 
     const auto& m = g_alpine_server_config_active_rules.mutators;
-    if (m.pickup_policy == PickupPolicy::Normal)
+    if (m.pickup_policy == PickupPolicy::Normal && !m.hide_health_armor_pickups)
         return;
 
     std::vector<int> allowed;
     if (m.pickup_policy != PickupPolicy::HideAll) {
         for (int i = 0; i < rf::num_item_types; ++i) {
             const rf::ItemInfo& info = rf::item_info[i];
+
+            // Composed on top of the policy, not instead of it: Vampire removes
+            // the standard health/armour pickups from whatever set the policy
+            // would otherwise keep.
+            if (m.hide_health_armor_pickups && is_standard_health_or_armor_item(info))
+                continue;
+
+            if (m.pickup_policy == PickupPolicy::Normal) {
+                allowed.push_back(i);
+                continue;
+            }
+
             const bool is_weapon = info.gives_weapon_id >= 0;
             const bool is_ammo = info.ammo_for_weapon_id >= 0;
             if (is_weapon || (is_ammo && m.pickup_policy == PickupPolicy::WeaponsAndAmmoOnly))
@@ -742,6 +801,37 @@ void mutators_on_player_frag(rf::Player* killer)
     // killer's own client. No reload packet is sent, so there's no reload animation
     // or pause, you just keep firing.
     ep->ai.clip_ammo[wt] = rf::weapon_types[wt].clip_size;
+}
+
+void mutators_on_pvp_damage(rf::Player* attacker, rf::Player* victim, float effective_damage)
+{
+    if (!rf::is_server || !rf::is_multi)
+        return;
+
+    const auto& m = g_alpine_server_config_active_rules.mutators;
+    if (!m.vampire_enabled)
+        return;
+
+    // Prevent Vampire healing from self damage.
+    if (!attacker || !victim || attacker == victim)
+        return;
+
+    // Prevent Vampire healing from team damage.
+    if (multi_game_type_is_team_type(rf::multi_get_game_type()) && attacker->team == victim->team)
+        return;
+
+    if (!(effective_damage > 0.0f))
+        return;
+
+    rf::Entity* ep = rf::entity_from_handle(attacker->entity_handle);
+    if (!ep || !ep->info || rf::entity_is_dying(ep))
+        return;
+
+    const float max_life_limit = std::max(ep->life, ep->info->max_life);
+    const float max_armor_limit = std::max(ep->armor, ep->info->max_armor);
+
+    // Same logic effective health kill reward uses.
+    distribute_effective_health(ep, effective_damage * VAMPIRE_HEAL_RATIO, max_life_limit, max_armor_limit);
 }
 
 // The weapon currently forced to no-clip.

--- a/game_patch/multi/mutators.cpp
+++ b/game_patch/multi/mutators.cpp
@@ -1,6 +1,8 @@
 #include <algorithm>
+#include <format>
 #include <map>
 #include <optional>
+#include <set>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -21,6 +23,16 @@
 // but we suppress the per-shot decrement, so this is purely the (constant) number
 // the HUD shows and it never counts down.
 static constexpr int NO_CLIP_RESERVE = 1;
+
+// Config-supplied strings are clamped before being interpolated into a console
+// line: the engine's console output (0x00509EC0) copies a line into its ring
+// buffer without bounding it to the slot size, so an over-long line corrupts
+// adjacent entries.
+static std::string_view clamp_for_console(std::string_view value)
+{
+    constexpr size_t max_len = 32;
+    return value.substr(0, std::min(value.size(), max_len));
+}
 
 // The weapon table class name for a given weapon type (accepted by
 // weapon_lookup_type and the loadout/default-weapon setters).
@@ -100,7 +112,8 @@ static void apply_rails(AlpineServerConfigRules& r, const toml::table& opts)
         if (idx >= 0)
             featured = idx;
         else
-            rf::console::print("  [WARN] Rails mutator: unknown featured_weapon '{}', using rail gun\n", *v);
+            rf::console::print("  [WARN] Rails mutator: unknown featured_weapon '{}', using rail gun\n",
+                               clamp_for_console(*v));
     }
     const bool exclude_thrown = opts["exclude_thrown"].value_or(true);
 
@@ -170,11 +183,20 @@ static void apply_arena(AlpineServerConfigRules& r, const toml::table& /*opts*/)
 // Registry + application order
 // ============================================================================
 
-enum class MutatorId
+// Static half of the option schema. Option ids are frozen per mutator (they are
+// wire values in the vote-options schema); choice lists and defaults that depend
+// on the loaded weapon table are filled in by mutators_get_registry().
+struct MutatorOptionDef
 {
-    Arena,
-    Rails,
-    Instagib,
+    uint8_t id;
+    const char* name;  // toml key
+    const char* label; // shown in the client UI
+    MutatorOptionType type;
+};
+
+static const MutatorOptionDef RAILS_OPTIONS[] = {
+    {0, "featured_weapon", "Weapon", MutatorOptionType::Choice},
+    {1, "exclude_thrown", "Keep thrown explosives", MutatorOptionType::Bool},
 };
 
 struct MutatorDef
@@ -183,12 +205,14 @@ struct MutatorDef
     const char* name;  // matched against the toml name
     const char* label; // shown in the printed rules
     void (*apply)(AlpineServerConfigRules&, const toml::table&);
+    const MutatorOptionDef* options;
+    size_t num_options;
 };
 
 static const MutatorDef MUTATORS[] = {
-    {MutatorId::Instagib, "instagib", "Instagib", &apply_instagib},
-    {MutatorId::Rails, "rails", "Rails", &apply_rails},
-    {MutatorId::Arena, "arena", "Arena", &apply_arena},
+    {MutatorId::Instagib, "instagib", "Instagib", &apply_instagib, nullptr, 0},
+    {MutatorId::Rails, "rails", "Rails", &apply_rails, RAILS_OPTIONS, std::size(RAILS_OPTIONS)},
+    {MutatorId::Arena, "arena", "Arena", &apply_arena, nullptr, 0},
 };
 
 // Hardcoded order in which simultaneously-active mutators are applied. Later
@@ -218,9 +242,161 @@ static const MutatorDef* find_mutator_by_id(MutatorId id)
 // Keys allowed inside a [[rules.mutators]] entry. Anything else is usually a
 // base-rule key accidentally placed after the mutators array in the TOML (where
 // it silently becomes a key of the mutator instead of the rules section).
-static bool is_known_mutator_option(std::string_view key)
+static bool is_known_mutator_option(const MutatorDef& def, std::string_view key)
 {
-    return key == "name" || key == "featured_weapon" || key == "exclude_thrown";
+    if (key == "name")
+        return true;
+    for (size_t i = 0; i < def.num_options; ++i) {
+        if (key == def.options[i].name)
+            return true;
+    }
+    return false;
+}
+
+// Short labels for the featured-weapon selector in the client's vote panel. The
+// stock display names ("Fusion Rocket Launcher") are far wider than the option
+// cycler. Matched case-insensitively against both the weapon's display name and
+// its weapons.tbl class name, so a table without a $Display Name still resolves.
+// Only the label changes; the choice VALUE stays the class name that round-trips
+// through rf::weapon_lookup_type. A weapon matching nothing (TC mods) keeps its
+// original label.
+struct WeaponShortLabel
+{
+    const char* match; // stock display name or weapons.tbl class name
+    const char* label;
+};
+
+static const WeaponShortLabel WEAPON_SHORT_LABELS[] = {
+    {"Remote Charge", "Charges"},           // class + display
+    {"Control Baton", "Baton"},             // display
+    {"Riot Stick", "Baton"},                // class
+    {"12mm pistol", "Pistol"},              // display
+    {"12mm handgun", "Pistol"},             // class
+    {"Automatic Shotgun", "Shotgun"},       // display
+    {"Shotgun", "Shotgun"},                 // class
+    {"Sniper Rifle", "Sniper"},             // class + display
+    {"Rocket Launcher", "Rocket"},          // class + display
+    {"Assault Rifle", "AR"},                // class + display
+    {"Submachine Gun", "SMG"},              // display
+    {"Machine Pistol", "SMG"},              // class
+    {"Grenade", "Grenades"},                // class + display
+    {"Grenades", "Grenades"},               // a table that already pluralises
+    {"Flamethrower", "Flame"},              // class + display
+    {"Riot Shield", "Shield"},              // class + display
+    {"Rail Driver", "Rail"},                // display
+    {"rail_gun", "Rail"},                   // class
+    {"Heavy Machine Gun", "HMG"},           // display
+    {"heavy_machine_gun", "HMG"},           // class
+    {"Precision Rifle", "PR"},              // display
+    {"scope_assault_rifle", "PR"},          // class
+    {"Fusion Rocket Launcher", "Fusion"},   // display
+    {"shoulder_cannon", "Fusion"},          // class
+};
+
+static const char* weapon_short_label(std::string_view display_name, std::string_view class_name)
+{
+    for (const auto& entry : WEAPON_SHORT_LABELS) {
+        if (string_iequals(display_name, entry.match) || string_iequals(class_name, entry.match))
+            return entry.label;
+    }
+    return nullptr;
+}
+
+// Weapons the Rails mutator can feature: anything a level pickup can grant.
+// Rails redirects every weapon/ammo pickup onto the featured weapon's own
+// pickup, so a weapon without one would leave players stuck with the baton.
+static std::vector<MutatorOptionChoice> build_featured_weapon_choices()
+{
+    std::vector<MutatorOptionChoice> choices;
+    for (int wt = 0; wt < rf::num_weapon_types; ++wt) {
+        if (rf::weapon_is_detonator(wt))
+            continue;
+
+        bool has_pickup = false;
+        for (int i = 0; i < rf::num_item_types && !has_pickup; ++i)
+            has_pickup = rf::item_info[i].gives_weapon_id == wt;
+        if (!has_pickup)
+            continue;
+
+        std::string value = rf::weapon_types[wt].name.c_str();
+        if (value.empty())
+            continue;
+        std::string label = rf::weapon_types[wt].display_name.c_str();
+        if (label.empty())
+            label = value;
+        if (const char* short_label = weapon_short_label(label, value))
+            label = short_label;
+        choices.push_back(MutatorOptionChoice{std::move(label), std::move(value)});
+    }
+    return choices;
+}
+
+static std::vector<MutatorInfo> g_mutator_registry;
+
+const std::vector<MutatorInfo>& mutators_get_registry()
+{
+    // Built once the weapon/item tables are loaded. An early call (before they
+    // are) leaves the choice lists empty, so don't cache that result.
+    const bool tables_ready = rf::num_weapon_types > 0 && rf::num_item_types > 0;
+    if (!g_mutator_registry.empty() && tables_ready)
+        return g_mutator_registry;
+
+    std::vector<MutatorInfo> registry;
+    for (const auto& def : MUTATORS) {
+        MutatorInfo info;
+        info.id = def.id;
+        info.name = def.name;
+        info.label = def.label;
+
+        for (size_t i = 0; i < def.num_options; ++i) {
+            const MutatorOptionDef& opt_def = def.options[i];
+            MutatorOptionInfo opt;
+            opt.id = opt_def.id;
+            opt.name = opt_def.name;
+            opt.label = opt_def.label;
+            opt.type = opt_def.type;
+
+            if (def.id == MutatorId::Rails && opt.name == "featured_weapon") {
+                opt.choices = build_featured_weapon_choices();
+                const std::string rail_name =
+                    (rf::rail_gun_weapon_type >= 0 && rf::rail_gun_weapon_type < rf::num_weapon_types)
+                        ? rf::weapon_types[rf::rail_gun_weapon_type].name.c_str()
+                        : "";
+                for (size_t c = 0; c < opt.choices.size(); ++c) {
+                    if (string_iequals(opt.choices[c].value, rail_name)) {
+                        opt.default_choice = static_cast<uint8_t>(c);
+                        break;
+                    }
+                }
+            }
+            else if (def.id == MutatorId::Rails && opt.name == "exclude_thrown") {
+                opt.default_bool = true; // matches apply_rails
+            }
+
+            info.options.push_back(std::move(opt));
+        }
+
+        registry.push_back(std::move(info));
+    }
+
+    g_mutator_registry = std::move(registry);
+    return g_mutator_registry;
+}
+
+const MutatorInfo* mutators_find_by_id(MutatorId id)
+{
+    for (const auto& info : mutators_get_registry())
+        if (info.id == id)
+            return &info;
+    return nullptr;
+}
+
+const MutatorInfo* mutators_find_by_name(std::string_view name)
+{
+    for (const auto& info : mutators_get_registry())
+        if (string_iequals(name, info.name))
+            return &info;
+    return nullptr;
 }
 
 void apply_mutators_from_toml(const toml::array& mutators_arr, AlpineServerConfigRules& rules)
@@ -238,9 +414,14 @@ void apply_mutators_from_toml(const toml::array& mutators_arr, AlpineServerConfi
             rf::console::print("  [WARN] a mutators entry is missing its 'name'\n");
             continue;
         }
+        // Config-supplied names are clamped before being interpolated: the engine
+        // console ring buffer copies a line without bounding it to its slot, so a
+        // long line corrupts adjacent entries.
+        const std::string_view name_for_msg = clamp_for_console(*name);
+
         const MutatorDef* def = find_mutator_by_name(*name);
         if (!def) {
-            rf::console::print("  [WARN] unknown mutator '{}'\n", *name);
+            rf::console::print("  [WARN] unknown mutator '{}'\n", name_for_msg);
             continue;
         }
 
@@ -249,9 +430,9 @@ void apply_mutators_from_toml(const toml::array& mutators_arr, AlpineServerConfi
         // [[rules.mutators]] header in the TOML.
         for ([[maybe_unused]] const auto& [k, v] : *tbl) {
             const std::string_view key = k.str();
-            if (!is_known_mutator_option(key))
+            if (!is_known_mutator_option(*def, key))
                 rf::console::print("  [WARN] mutator '{}': unexpected key '{}'. In TOML, keys after [[rules.mutators]] belong to the mutator, not [rules] — move base-rule keys above the mutators array.\n",
-                    *name, key);
+                    name_for_msg, clamp_for_console(key));
         }
 
         declared[def->id] = *tbl; // a later declaration of the same mutator wins
@@ -277,10 +458,29 @@ void apply_mutators_from_toml(const toml::array& mutators_arr, AlpineServerConfi
         // same mutator, matching the label dedup above.
         MutatorDeclaration decl;
         decl.name = def->name;
-        if (auto fw = it->second["featured_weapon"].value<std::string>())
-            decl.featured_weapon = *fw;
-        if (auto et = it->second["exclude_thrown"].value<bool>())
-            decl.exclude_thrown = *et;
+        for (size_t i = 0; i < def->num_options; ++i) {
+            const MutatorOptionDef& opt = def->options[i];
+            const auto node = it->second[opt.name];
+            switch (opt.type) {
+                case MutatorOptionType::Bool:
+                    if (auto v = node.value<bool>())
+                        decl.options[opt.name] = *v;
+                    break;
+                case MutatorOptionType::Int:
+                    if (auto v = node.value<int64_t>())
+                        decl.options[opt.name] = static_cast<int32_t>(*v);
+                    break;
+                case MutatorOptionType::Float:
+                    if (auto v = node.value<double>())
+                        decl.options[opt.name] = static_cast<float>(*v);
+                    break;
+                case MutatorOptionType::Choice:
+                case MutatorOptionType::String:
+                    if (auto v = node.value<std::string>())
+                        decl.options[opt.name] = *v;
+                    break;
+            }
+        }
         auto& decls = rules.mutators.declarations;
         decls.erase(std::remove_if(decls.begin(), decls.end(),
             [&](const MutatorDeclaration& d) { return string_iequals(d.name, def->name); }), decls.end());
@@ -288,26 +488,148 @@ void apply_mutators_from_toml(const toml::array& mutators_arr, AlpineServerConfi
     }
 }
 
-std::optional<ManualRulesOverride> load_mutator_rules_override(std::string_view mutator_name)
+toml::array mutator_declarations_to_toml_array(const std::vector<MutatorDeclaration>& declarations)
 {
-    const MutatorDef* def = find_mutator_by_name(mutator_name);
-    if (!def)
+    toml::array arr;
+    for (const auto& decl : declarations) {
+        toml::table tbl;
+        tbl.insert_or_assign("name", decl.name);
+        for (const auto& [key, value] : decl.options) {
+            if (const auto* v = std::get_if<bool>(&value))
+                tbl.insert_or_assign(key, *v);
+            else if (const auto* v = std::get_if<int32_t>(&value))
+                tbl.insert_or_assign(key, static_cast<int64_t>(*v));
+            else if (const auto* v = std::get_if<float>(&value))
+                tbl.insert_or_assign(key, static_cast<double>(*v));
+            else if (const auto* v = std::get_if<std::string>(&value))
+                tbl.insert_or_assign(key, *v);
+        }
+        arr.push_back(std::move(tbl));
+    }
+    return arr;
+}
+
+std::optional<std::string> mutators_build_declarations_from_vote(
+    const std::vector<VoteMutatorInput>& input, std::vector<MutatorDeclaration>& out)
+{
+    out.clear();
+
+    std::set<uint8_t> seen_ids;
+    for (const auto& entry : input) {
+        const MutatorInfo* info = mutators_find_by_id(static_cast<MutatorId>(entry.mutator_id));
+        if (!info) {
+            return std::format("this server does not know mutator id {}", entry.mutator_id);
+        }
+        if (!seen_ids.insert(entry.mutator_id).second) {
+            return std::format("mutator '{}' was selected more than once", info->label);
+        }
+
+        MutatorDeclaration decl;
+        decl.name = info->name;
+
+        for (const auto& opt_in : entry.options) {
+            const MutatorOptionInfo* opt = nullptr;
+            for (const auto& candidate : info->options) {
+                if (candidate.id == opt_in.option_id) {
+                    opt = &candidate;
+                    break;
+                }
+            }
+            if (!opt) {
+                return std::format("mutator '{}' has no option id {}", info->label, opt_in.option_id);
+            }
+            if (opt->type != opt_in.type) {
+                return std::format("option '{}' of mutator '{}' was sent with the wrong value type",
+                                   opt->name, info->label);
+            }
+
+            switch (opt->type) {
+                case MutatorOptionType::Bool:
+                    decl.options[opt->name] = opt_in.bool_value;
+                    break;
+                case MutatorOptionType::Choice:
+                    if (opt_in.choice_index >= opt->choices.size()) {
+                        return std::format("option '{}' of mutator '{}' has an out of range selection",
+                                           opt->name, info->label);
+                    }
+                    decl.options[opt->name] = opt->choices[opt_in.choice_index].value;
+                    break;
+                case MutatorOptionType::Int:
+                    decl.options[opt->name] = opt_in.int_value;
+                    break;
+                case MutatorOptionType::Float:
+                    decl.options[opt->name] = opt_in.float_value;
+                    break;
+                case MutatorOptionType::String:
+                    decl.options[opt->name] = opt_in.string_value;
+                    break;
+            }
+        }
+
+        out.push_back(std::move(decl));
+    }
+
+    return std::nullopt;
+}
+
+std::string mutators_join_labels(const std::vector<MutatorDeclaration>& declarations)
+{
+    std::string joined;
+    for (const auto& decl : declarations) {
+        const MutatorInfo* info = mutators_find_by_name(decl.name);
+        if (!joined.empty())
+            joined += ", ";
+        joined += info ? info->label : decl.name;
+    }
+    return joined;
+}
+
+const AlpineServerConfigRules& vote_natural_rules_for_level(std::string_view level_filename)
+{
+    for (const auto& entry : g_alpine_server_config.levels) {
+        if (string_iequals(entry.level_filename, level_filename))
+            return entry.rule_overrides_no_mutators;
+    }
+    // Not in the rotation: a manually named level runs on the base rules.
+    return g_alpine_server_config.base_rules_no_mutators;
+}
+
+std::optional<ManualRulesOverride> load_vote_rules_override(
+    std::string_view level_filename, const std::vector<MutatorDeclaration>& mutators,
+    std::optional<rf::NetGameType> gametype)
+{
+    if (mutators.empty() && !gametype)
         return std::nullopt;
 
-    // Apply the single mutator on top of the base rules with base mutators
-    // stripped, so the voted mutator fully replaces (rather than stacks on) any
-    // mutator the base rules declared.
-    AlpineServerConfigRules rules = g_alpine_server_config.base_rules_no_mutators;
+    // Inheritance rule for a vote override, in layering order:
+    //   1. the rules the voted level would run with on its own — its rotation
+    //      entry's rules if it is in the rotation, otherwise the base rules —
+    //      with config-declared mutators stripped (voted mutators REPLACE
+    //      configured ones rather than stacking on them),
+    //   2. the voted game type and its gametype defaults, if one was voted,
+    //   3. the voted mutator declarations.
+    // Starting from the base rules instead (as this used to) silently dragged the
+    // base game type onto a level whose rotation entry overrides it, so adding a
+    // single mutator to a level vote could flip the whole game type.
+    AlpineServerConfigRules rules = vote_natural_rules_for_level(level_filename);
 
-    toml::table entry;
-    entry.insert_or_assign("name", std::string{mutator_name});
-    toml::array arr;
-    arr.push_back(std::move(entry));
-    apply_mutators_from_toml(arr, rules);
+    if (gametype) {
+        // apply_defaults_for_game_type() rebuilds the loadout and clears
+        // MutatorConfig, so the mutators must be applied after it.
+        rules.game_type = *gametype;
+        apply_defaults_for_game_type(*gametype, rules);
+    }
+
+    if (!mutators.empty()) {
+        const toml::array arr = mutator_declarations_to_toml_array(mutators);
+        apply_mutators_from_toml(arr, rules);
+    }
 
     ManualRulesOverride result;
     result.rules = std::move(rules);
-    result.preset_alias = std::string{def->label};
+    std::string labels = mutators_join_labels(mutators);
+    if (!labels.empty())
+        result.preset_alias = std::move(labels);
     return result;
 }
 

--- a/game_patch/multi/mutators.cpp
+++ b/game_patch/multi/mutators.cpp
@@ -228,16 +228,21 @@ struct MutatorDef
     MutatorId id;
     const char* name;  // matched against the toml name
     const char* label; // shown in the printed rules
+    // Minimum AF client MINOR version (major implicitly 1) needed to play with
+    // this mutator active, or MUTATOR_NO_CLIENT_REQUIREMENT.
+    int min_client_minor_version;
     void (*apply)(AlpineServerConfigRules&, const toml::table&);
     const MutatorOptionDef* options;
     size_t num_options;
 };
 
+// Per-mutator client requirement — what the mutator actually depends on, not
+// necessarily what release it shipped in.
 static const MutatorDef MUTATORS[] = {
-    {MutatorId::Instagib, "instagib", "Instagib", &apply_instagib, nullptr, 0},
-    {MutatorId::Rails, "rails", "Rails", &apply_rails, RAILS_OPTIONS, std::size(RAILS_OPTIONS)},
-    {MutatorId::Arena, "arena", "Arena", &apply_arena, nullptr, 0},
-    {MutatorId::Vampire, "vampire", "Vampire", &apply_vampire, VAMPIRE_OPTIONS, std::size(VAMPIRE_OPTIONS)},
+    {MutatorId::Instagib, "instagib", "Instagib", 4, &apply_instagib, nullptr, 0},
+    {MutatorId::Rails, "rails", "Rails", 4, &apply_rails, RAILS_OPTIONS, std::size(RAILS_OPTIONS)},
+    {MutatorId::Arena, "arena", "Arena", 4, &apply_arena, nullptr, 0},
+    {MutatorId::Vampire, "vampire", "Vampire", MUTATOR_NO_CLIENT_REQUIREMENT, &apply_vampire, VAMPIRE_OPTIONS, std::size(VAMPIRE_OPTIONS)},
 };
 
 // Hardcoded order in which simultaneously-active mutators are applied. Later
@@ -370,6 +375,7 @@ const std::vector<MutatorInfo>& mutators_get_registry()
         info.id = def.id;
         info.name = def.name;
         info.label = def.label;
+        info.min_client_minor_version = def.min_client_minor_version;
 
         for (size_t i = 0; i < def.num_options; ++i) {
             const MutatorOptionDef& opt_def = def.options[i];
@@ -424,6 +430,19 @@ const MutatorInfo* mutators_find_by_name(std::string_view name)
         if (string_iequals(name, info.name))
             return &info;
     return nullptr;
+}
+
+int mutators_min_client_minor_version(const std::vector<MutatorDeclaration>& declarations)
+{
+    int required = MUTATOR_NO_CLIENT_REQUIREMENT;
+    for (const auto& decl : declarations) {
+        // A name with no registry entry cannot be in force — apply_mutators_from_toml
+        // rejects unknown names before a declaration is ever recorded — so a miss
+        // here means "no requirement", not a defaulted one.
+        if (const MutatorInfo* info = mutators_find_by_name(decl.name))
+            required = std::max(required, info->min_client_minor_version);
+    }
+    return required;
 }
 
 void apply_mutators_from_toml(const toml::array& mutators_arr, AlpineServerConfigRules& rules)

--- a/game_patch/multi/mutators.h
+++ b/game_patch/multi/mutators.h
@@ -1,6 +1,12 @@
 #pragma once
 
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
 #include <toml++/toml.hpp>
+#include "server_internal.h"
 
 struct AlpineServerConfigRules;
 
@@ -17,6 +23,47 @@ namespace rf
 // base rules scope and each per-level scope; when several are active in one scope
 // they run in a fixed, hardcoded order designed to minimize awkward overlap.
 
+// FROZEN wire constants: these values are the `mutator_id` sent in the
+// vote-options schema and in vote-call packets. Never reorder or reuse.
+enum class MutatorId : uint8_t
+{
+    Instagib = 0,
+    Rails = 1,
+    Arena = 2,
+};
+
+struct MutatorOptionChoice
+{
+    std::string label; // shown in the client UI
+    std::string value; // written into the TOML declaration
+};
+
+// One option of one mutator. `id` is frozen per mutator (wire value).
+struct MutatorOptionInfo
+{
+    uint8_t id = 0;
+    std::string name;  // TOML key
+    std::string label; // shown in the client UI
+    MutatorOptionType type = MutatorOptionType::Bool;
+
+    // Only the member matching `type` is meaningful.
+    bool default_bool = false;
+    uint8_t default_choice = 0; // index into `choices`
+    int32_t default_int = 0;
+    float default_float = 0.0f;
+    std::string default_string;
+
+    std::vector<MutatorOptionChoice> choices; // Choice only
+};
+
+struct MutatorInfo
+{
+    MutatorId id = MutatorId::Instagib;
+    std::string name;  // canonical, matches the TOML `name` key
+    std::string label; // shown in the printed rules and the client UI
+    std::vector<MutatorOptionInfo> options;
+};
+
 void mutators_do_patch();
 void apply_mutators_from_toml(const toml::array& mutators_arr, AlpineServerConfigRules& rules);
 void mutators_level_init_post();
@@ -24,3 +71,32 @@ int mutators_redirect_item_index(int item_type_index);
 bool mutators_should_deny_weapon_switch(int from_weapon, int to_weapon);
 void mutators_on_player_frag(rf::Player* killer);
 void mutators_set_no_clip_weapon(int weapon_type);
+
+// Registry view. Built lazily because choice lists (e.g. the Rails featured
+// weapon) are derived from the loaded weapon/item tables.
+const std::vector<MutatorInfo>& mutators_get_registry();
+const MutatorInfo* mutators_find_by_id(MutatorId id);
+const MutatorInfo* mutators_find_by_name(std::string_view name);
+
+// Declarations -> TOML, the shape apply_mutators_from_toml consumes.
+toml::array mutator_declarations_to_toml_array(const std::vector<MutatorDeclaration>& declarations);
+
+// Validate packet-supplied mutator selections against the registry and turn them
+// into declarations. Returns an error string on failure, std::nullopt on success.
+std::optional<std::string> mutators_build_declarations_from_vote(
+    const std::vector<VoteMutatorInput>& input, std::vector<MutatorDeclaration>& out);
+
+// Human-readable labels of the declared mutators, joined with ", ".
+std::string mutators_join_labels(const std::vector<MutatorDeclaration>& declarations);
+
+// The rules `level_filename` would run with if no vote were involved: its
+// rotation entry's rules when it is in the rotation, otherwise the base rules —
+// in both cases with config-declared mutators stripped.
+const AlpineServerConfigRules& vote_natural_rules_for_level(std::string_view level_filename);
+
+// Build the rules a level/match vote should install: the voted level's natural
+// rules (above), optionally re-based on a voted game type plus that type's
+// defaults, then the voted mutators applied in MUTATOR_APPLY_ORDER.
+std::optional<ManualRulesOverride> load_vote_rules_override(
+    std::string_view level_filename, const std::vector<MutatorDeclaration>& mutators,
+    std::optional<rf::NetGameType> gametype);

--- a/game_patch/multi/mutators.h
+++ b/game_patch/multi/mutators.h
@@ -30,6 +30,7 @@ enum class MutatorId : uint8_t
     Instagib = 0,
     Rails = 1,
     Arena = 2,
+    Vampire = 3,
 };
 
 struct MutatorOptionChoice
@@ -71,6 +72,7 @@ int mutators_redirect_item_index(int item_type_index);
 bool mutators_should_deny_weapon_switch(int from_weapon, int to_weapon);
 void mutators_on_player_frag(rf::Player* killer);
 void mutators_set_no_clip_weapon(int weapon_type);
+void mutators_on_pvp_damage(rf::Player* attacker, rf::Player* victim, float effective_damage);
 
 // Registry view. Built lazily because choice lists (e.g. the Rails featured
 // weapon) are derived from the loaded weapon/item tables.

--- a/game_patch/multi/mutators.h
+++ b/game_patch/multi/mutators.h
@@ -57,11 +57,21 @@ struct MutatorOptionInfo
     std::vector<MutatorOptionChoice> choices; // Choice only
 };
 
+// A mutator that needs no client-side support at all: it imposes no version
+// floor and does not even require an Alpine client.
+inline constexpr int MUTATOR_NO_CLIENT_REQUIREMENT = 0;
+
 struct MutatorInfo
 {
     MutatorId id = MutatorId::Instagib;
     std::string name;  // canonical, matches the TOML `name` key
     std::string label; // shown in the printed rules and the client UI
+
+    // Minimum Alpine Faction MINOR version a client needs in order to play on a
+    // server with this mutator active, or MUTATOR_NO_CLIENT_REQUIREMENT for
+    // none.
+    int min_client_minor_version = MUTATOR_NO_CLIENT_REQUIREMENT;
+
     std::vector<MutatorOptionInfo> options;
 };
 
@@ -79,6 +89,11 @@ void mutators_on_pvp_damage(rf::Player* attacker, rf::Player* victim, float effe
 const std::vector<MutatorInfo>& mutators_get_registry();
 const MutatorInfo* mutators_find_by_id(MutatorId id);
 const MutatorInfo* mutators_find_by_name(std::string_view name);
+
+// Highest min_client_minor_version among the mutators these declarations put in
+// force, or MUTATOR_NO_CLIENT_REQUIREMENT when none of them needs client-side
+// support (including the empty list).
+int mutators_min_client_minor_version(const std::vector<MutatorDeclaration>& declarations);
 
 // Declarations -> TOML, the shape apply_mutators_from_toml consumes.
 toml::array mutator_declarations_to_toml_array(const std::vector<MutatorDeclaration>& declarations);

--- a/game_patch/multi/network.cpp
+++ b/game_patch/multi/network.cpp
@@ -32,6 +32,7 @@
 #include "server.h"
 #include "server_internal.h"
 #include "sprays.h"
+#include "vote_client.h"
 #include "bots/bot_chat_manager.h"
 #include "../main/main.h"
 #include "../os/os.h"
@@ -815,10 +816,14 @@ FunHook<MultiIoPacketHandler> process_left_game_packet_hook{
 };
 
 void handle_vote_or_ready_up_msg(const std::string_view msg) {
+    // AF 1.4+ servers drive the vote HUD through af_sreq_vote_state and never
+    // send us this text, so the sniffing below only serves older servers.
+    const bool server_uses_vote_packets = is_server_minimum_af_version(1, 4);
+
     constexpr std::string_view vote_start_prefix =
         "\n=============== VOTE STARTING ===============\n";
 
-    if (string_istarts_with(msg, vote_start_prefix)) {
+    if (!server_uses_vote_packets && string_istarts_with(msg, vote_start_prefix)) {
         // Move past the prefix to start parsing the actual vote title
         const std::string_view title = msg.substr(vote_start_prefix.size());
         // Find the position of " vote started by"
@@ -834,7 +839,9 @@ void handle_vote_or_ready_up_msg(const std::string_view msg) {
     // remove ready up prompt if match is cancelled prematurely
     constexpr std::string_view match_canceled_msg = "\xA6 Vote passed: The match has been canceled";
     if (string_istarts_with(msg, match_canceled_msg) || string_istarts_with(msg, match_canceled_msg.substr(2))) {
-        remove_hud_vote_notification();
+        if (!server_uses_vote_packets) {
+            remove_hud_vote_notification();
+        }
         set_local_pre_match_active(false);
         return;
     }
@@ -848,14 +855,16 @@ void handle_vote_or_ready_up_msg(const std::string_view msg) {
     };
 
     // remove the vote notification if the vote has ended
-    for (const std::string_view& end_msg : vote_end_messages) {
-        if (string_istarts_with(msg, end_msg)
-            || string_istarts_with(msg, end_msg.substr(2))) {
-            remove_hud_vote_notification();
-            return;
+    if (!server_uses_vote_packets) {
+        for (const std::string_view& end_msg : vote_end_messages) {
+            if (string_istarts_with(msg, end_msg)
+                || string_istarts_with(msg, end_msg.substr(2))) {
+                remove_hud_vote_notification();
+                return;
+            }
         }
     }
-    
+
     // TODO: remove after AF 1.4 ships — the two ready-up blocks below drive the
     // ready prompt from server chat text for AF 1.3 clients on 1.4 servers.
 
@@ -2522,6 +2531,7 @@ FunHook<void()> multi_stop_hook{
     [] {
         g_af_server_info.reset(); // Clear server info when leaving
         mutators_set_no_clip_weapon(-1); // restore any server weapon-table overrides
+        vote_client_reset(); // drop the cached vote options and active vote state
         g_local_player_spectators.clear();
         g_remote_server_cfg_popup.reset();
         set_local_pre_match_active(false); // clear pre-match state when leaving

--- a/game_patch/multi/pit.cpp
+++ b/game_patch/multi/pit.cpp
@@ -552,7 +552,7 @@ void pit_do_frame()
     }
 }
 
-bool pit_can_player_spawn(rf::Player* player)
+bool pit_can_player_spawn(rf::Player* player, bool notify)
 {
     if (!gt_is_pit()) return true; // not our problem
     if (!player) return true;
@@ -565,8 +565,10 @@ bool pit_can_player_spawn(rf::Player* player)
     // The client re-requests a spawn every frame while fire is held, so throttle
     // the denial notice. Check the gate BEFORE building any message so a denied
     // spawn costs only a timer read in steady state.
-    const bool throttle_open =
-        !player->waiting_msg_timer.valid() || player->waiting_msg_timer.elapsed();
+    // With notify = false the caller only wants the verdict, so the throttle is
+    // held shut: no message is built and waiting_msg_timer is left untouched.
+    const bool throttle_open = notify
+        && (!player->waiting_msg_timer.valid() || player->waiting_msg_timer.elapsed());
     auto send_throttled = [&](std::string_view msg) {
         af_send_automated_chat_msg(msg, player);
         player->waiting_msg_timer.set(3000);

--- a/game_patch/multi/pit.h
+++ b/game_patch/multi/pit.h
@@ -20,7 +20,7 @@ void pit_level_init();
 void pit_level_init_post();
 void pit_do_frame();
 void pit_on_entity_will_die(rf::Entity* ep);
-bool pit_can_player_spawn(rf::Player* player);
+bool pit_can_player_spawn(rf::Player* player, bool notify = true);
 void pit_on_player_disconnect(rf::Player* player);
 void pit_handle_queue_request(rf::Player* player, uint8_t action);
 void pit_reset_world_items();

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -243,7 +243,7 @@ FunHook<void ()> dedicated_server_load_config_hook{
                 "You should launch your server with `-ads` using a TOML config instead.\n\n"
                 "To build a TOML config for your server, visit https://dedi.alpinefaction.com\n\n"
                 "For more information or to find support, visit https://alpinefaction.com/help\n";
-            rf::console::printf(msg);
+            rf::console::print("{}", msg);
             rf::console::do_critical_error();
         }
     },
@@ -677,9 +677,8 @@ static void notify_for_upcoming_level_version_incompatible(rf::Player* player)
     af_send_automated_chat_msg(client_msg2, player);
     af_send_automated_chat_msg(client_msg3, player);
 
-    auto server_msg = std::format("{} cannot load the upcoming level. The maximum RFL version they can load is {}.",
-                    player->name, player->version_info.max_rfl_ver);    
-    rf::console::printf(server_msg.c_str());
+    auto server_msg = std::format("{} cannot load the upcoming level. The maximum RFL version they can load is {}.", player->name, player->version_info.max_rfl_ver);
+    rf::console::print("{}", server_msg); // remote-supplied name
 }
 
 static void notify_for_client_incompatible_with_switching_game_type(rf::Player* player)
@@ -694,7 +693,7 @@ static void notify_for_client_incompatible_with_switching_game_type(rf::Player* 
     af_send_automated_chat_msg(client_msg4, player);
 
     auto server_msg = std::format("{} doesn't support changing game type. They can rejoin after the level changes.", player->name);
-    rf::console::printf(server_msg.c_str());
+    rf::console::print("{}", server_msg); // remote-supplied name
 }
 
 CodeInjection multi_limbo_leave_pre_patch{
@@ -711,7 +710,7 @@ CodeInjection multi_limbo_leave_pre_patch{
 
                 if (static_cast<int>(p.version_info.max_rfl_ver) < ver && p.version_info.software != ClientSoftware::Browser) {
                     auto server_msg = std::format("{} was kicked because they cannot load the upcoming level.", p.name);
-                    rf::console::printf(server_msg.c_str());
+                    rf::console::print("{}", server_msg); // remote-supplied name
 
                     // queue for kick
                     to_kick.push_back(&p);
@@ -720,7 +719,7 @@ CodeInjection multi_limbo_leave_pre_patch{
                     !(p.version_info.software == ClientSoftware::AlpineFaction && p.version_info.minor >= 2) &&
                     p.version_info.software != ClientSoftware::Browser) {
                     auto server_msg = std::format("{} was kicked because their client does not support changing game type.", p.name);
-                    rf::console::printf(server_msg.c_str());
+                    rf::console::print("{}", server_msg); // remote-supplied name
 
                     // queue for kick
                     to_kick.push_back(&p);
@@ -1115,8 +1114,8 @@ bool handle_server_chat_command(std::string_view server_command, rf::Player* sen
         );
     }
     else if (cmd_name == "vote") {
-        auto [vote_name, vote_arg] = strip_by_space(cmd_arg);
-        handle_vote_command(vote_name, vote_arg, sender);
+        // Only used for old clients participating in a vote.
+        handle_vote_command(strip_by_space(cmd_arg).first, sender);
     }
     else if (cmd_name == "nextmap" || cmd_name == "nextlevel") {
         handle_next_map_command(sender);
@@ -1357,6 +1356,9 @@ FunHook<float(rf::Entity*, float, int, int, int)> entity_damage_hook{
             auto* damaged_player_stats = static_cast<PlayerStatsNew*>(damaged_player->stats);
             damaged_player_stats->add_damage_received(effective_damage);
 
+            // Vampire mutator
+            mutators_on_pvp_damage(killer_player, damaged_player, effective_damage);
+
             if (g_alpine_server_config.damage_notification_config.enabled && damaged_player && killer_player) {
                 if (!(!damaged_ep || rf::entity_is_dying(damaged_ep) || rf::player_is_dead(damaged_player))) {
 
@@ -1587,22 +1589,18 @@ CodeInjection multi_on_new_player_injection{
     },
 };
 
-// A dead client re-sends a spawn request every frame while fire is held, so every
-// "you can't spawn because..." notice in the spawn path shares one per-player
-// throttle (the same timer Pit and Wipeout already use for their own spawn-denied
-// lines, so two reasons can never alternate and double the rate). Only the
-// notification is throttled — the spawn is still declined every time.
-static constexpr int spawn_decline_msg_cooldown_ms = 10000;
+// Cooldown throttle for spawn rejection chat messages to prevent spam.
+static constexpr int spawn_decline_msg_cooldown_ms = 5000;
 
 static void send_spawn_decline_msg(rf::Player* player, std::string_view msg)
 {
     if (!player) {
         return;
     }
-    if (player->waiting_msg_timer.valid() && !player->waiting_msg_timer.elapsed()) {
+    if (player->spawn_decline_msg_timer.valid() && !player->spawn_decline_msg_timer.elapsed()) {
         return;
     }
-    player->waiting_msg_timer.set(spawn_decline_msg_cooldown_ms);
+    player->spawn_decline_msg_timer.set(spawn_decline_msg_cooldown_ms);
     af_send_automated_chat_msg(msg, player);
 }
 
@@ -1740,6 +1738,29 @@ void cancel_match()
     }
 }
 
+// Does this player support packet-based voting?
+static bool player_can_call_votes(rf::Player* player)
+{
+    if (!player) {
+        return false;
+    }
+    return player == rf::local_player || is_player_minimum_af_client_version(player, 1, 4, 0);
+}
+
+static std::string_view cancel_match_vote_hint(rf::Player* player)
+{
+    return player_can_call_votes(player)
+        ? "Ready up, or call a vote to cancel the match."
+        : "Ready up. Canceling the match needs a vote, which requires Alpine Faction 1.4+ (alpinefaction.com).";
+}
+
+static std::string_view start_match_vote_hint(rf::Player* player)
+{
+    return player_can_call_votes(player)
+        ? "Call a match vote to queue one."
+        : "Queueing a match needs a vote, which requires Alpine Faction 1.4+ (alpinefaction.com).";
+}
+
 void start_pre_match()
 {
     if (g_match_info.pre_match_queued) {
@@ -1757,8 +1778,8 @@ void start_pre_match()
 
             std::string msg = std::format(
                 "\n>>>>>>>>>>>>>>>>> {}v{} MATCH QUEUED <<<<<<<<<<<<<<<<<\n"
-                "Waiting for players. Ready up, or call a vote to cancel the match.",
-                g_match_info.team_size, g_match_info.team_size);
+                "Waiting for players. {}",
+                g_match_info.team_size, g_match_info.team_size, cancel_match_vote_hint(player));
 
             af_send_automated_chat_msg(msg, player);
             af_send_ready_prompt(player, 1); // pre-match active — show ready prompt
@@ -1859,7 +1880,8 @@ void remove_ready_player(rf::Player* player)
 void toggle_ready_status(rf::Player* player)
 {
     if (!g_match_info.pre_match_active) {
-        af_send_automated_chat_msg("No match is queued. Call a match vote to queue one.", player);
+        af_send_automated_chat_msg(
+            std::format("No match is queued. {}", start_match_vote_hint(player)), player);
         return;
     }
 
@@ -1893,7 +1915,8 @@ void set_ready_status(rf::Player* player, bool is_ready)
         }
     }
     else {
-        af_send_automated_chat_msg("No match is queued. Call a match vote to queue one.", player);
+        af_send_automated_chat_msg(
+            std::format("No match is queued. {}", start_match_vote_hint(player)), player);
     }
 }
 
@@ -1930,8 +1953,17 @@ void match_do_frame()
         if (current_time >= g_match_info.last_match_reminder_time + 270) {
             g_match_info.last_match_reminder_time = current_time;
 
-            af_broadcast_automated_chat_msg(
-                "No active match. Call a match vote to start one.");
+            // Per-recipient rather than broadcast: the instruction differs by
+            // client. The console keeps the line af_broadcast_automated_chat_msg
+            // used to print.
+            rf::console::print("Server: No active match. Call a match vote to start one.");
+            for (rf::Player* player : get_clients(false, false)) {
+                if (player == rf::local_player) {
+                    continue;
+                }
+                af_send_automated_chat_msg(
+                    std::format("No active match. {}", start_match_vote_hint(player)), player);
+            }
         }
     }
     else if (g_match_info.pre_match_active) {
@@ -1946,10 +1978,10 @@ void match_do_frame()
             for (rf::Player* player : get_clients(false, false)) {
                 if (!is_player_ready(player)) {
                     auto msg = std::format(
-                        "You are NOT ready! {}v{} match queued, waiting for players - RED: {}, BLUE: {}.\n"
-                        "Ready up, or call a vote to cancel the match.",
+                        "You are NOT ready! {}v{} match queued, waiting for players - RED: {}, BLUE: {}.\n{}",
                         g_match_info.team_size, g_match_info.team_size,
-                        g_match_info.team_size - ready_red, g_match_info.team_size - ready_blue);
+                        g_match_info.team_size - ready_red, g_match_info.team_size - ready_blue,
+                        cancel_match_vote_hint(player));
                     af_send_automated_chat_msg(msg, player);
                     af_send_ready_prompt(player, 1); // belt-and-braces resync (show prompt)
                 }
@@ -1972,6 +2004,39 @@ std::pair<bool, std::string> is_level_name_valid(std::string_view level_name_inp
     return {is_valid, level_name};
 }
 
+// Is the game itself currently refusing to spawn this player?
+// Note: does NOT include players who fail client reqs (like AF version)
+bool player_spawn_blocked_by_game(const rf::Player* const player)
+{
+    if (!player || !rf::is_server) {
+        return false;
+    }
+
+    rf::Player* const p = const_cast<rf::Player*>(player);
+
+    // Server-set respawn delay has a live timer.
+    // Note: does NOT prevent players being marked as idle when they are able
+    // to spawn (ie. spawn delay timer elapsed) but just haven't done so.
+    if (p->respawn_timer.valid() && !p->respawn_timer.elapsed()) {
+        return true;
+    }
+
+    // A match is in progress that this player is not part of.
+    if (g_match_info.match_active && !is_player_in_match(p)) {
+        return true;
+    }
+
+    // Gametype spawn gates.
+    if (!pit_can_player_spawn(p, false)) {
+        return true;
+    }
+    if (!wipeout_can_player_spawn(p, false)) {
+        return true;
+    }
+
+    return false;
+}
+
 void update_player_active_status(rf::Player* const player) {
     if (rf::is_dedicated_server && g_alpine_server_config.inactivity_config.enabled) {
         player->idle.kick_timer.invalidate();
@@ -1985,7 +2050,16 @@ void player_idle_check(rf::Player* const player) {
     const InactivityConfig& inactivity_cfg = g_alpine_server_config.inactivity_config;
     if (!inactivity_cfg.enabled) {
         return;
-    } else if (player->idle.kick_timer.valid()) {
+    }
+
+    // Pause the inactivity countdown while the game itself is refusing to spawn
+    // this player.
+    if (player_spawn_blocked_by_game(player)) {
+        update_player_active_status(player);
+        return;
+    }
+
+    if (player->idle.kick_timer.valid()) {
         if (inactivity_cfg.kick_after_warning && player->idle.kick_timer.elapsed()) {
             kick_player_delayed(player);
         }
@@ -2236,11 +2310,10 @@ FunHook<void(rf::Player*)> multi_spawn_player_server_side_hook{
                 static_cast<float>(player->respawn_timer.time_until()) / 1000.f,
                 .001f // at least 1ms
             );
-            std::string msg = std::format(
-                "Respawn delay: {} seconds left until you can respawn.",
-                spawn_delay_left
-            );
-            af_send_automated_chat_msg(msg, player);
+
+            // Throttle spawn rejection notifications to prevent spamming the chat box.
+            send_spawn_decline_msg(player, std::format(
+                "Respawn delay: {} seconds left until you can respawn.", spawn_delay_left));
             return;
         }
 
@@ -2774,6 +2847,15 @@ struct AutoTeamBalanceState {
     rf::TimestampRealtime check_timer;
     int consecutive_unbalanced_checks = 0;
     bool queued = false;
+
+    // Round-based gametypes (Wipeout is the case that matters): a death during an
+    // active round is an ELIMINATION, so swapping at that instant would change
+    // team rosters and alive counts mid-round. The swap decision is recorded here
+    // instead and applied at the round boundary. Stored as a player id rather
+    // than a Player*, so a disconnect between the death and the boundary cannot
+    // leave a dangling pointer behind.
+    bool deferred_pending = false;
+    rf::ubyte deferred_player_id = 0;
 };
 static AutoTeamBalanceState g_auto_balance;
 
@@ -2812,12 +2894,87 @@ static void auto_team_balance_announce_pending()
     af_broadcast_automated_chat_msg("Teams are unbalanced and will be automatically rebalanced.");
 }
 
-// Cancel any queued balance and reset the unbalanced-check streak. Nothing to
-// un-send since the pending notice is a chat message.
+// Cancel any queued balance, drop any swap deferred to a round boundary, and
+// reset the unbalanced-check streak. Nothing to un-send since the pending notice
+// is a chat message.
 static void auto_team_balance_reset()
 {
     g_auto_balance.queued = false;
     g_auto_balance.consecutive_unbalanced_checks = 0;
+    g_auto_balance.deferred_pending = false;
+    g_auto_balance.deferred_player_id = 0;
+}
+
+// Perform the swap and tell everyone about it. Shared by the immediate
+// (non-round) path and the deferred round-boundary path so both announce
+// identically and both end the sequence once the teams are even again.
+static void auto_team_balance_apply_swap(rf::Player* const player, const rf::ubyte target_team)
+{
+    assign_player_to_team(player, target_team);
+
+    // Announce the move to everyone in chat.
+    af_broadcast_automated_chat_msg(std::format(
+        "{} was moved to {} to balance the teams.", player->name.c_str(), team_name(target_team)));
+
+    // Give the moved player a personal HUD notification so it's obvious.
+    af_send_hud_notification(
+        std::format("You have been moved to {} to balance the teams.", team_name(target_team)),
+        6, // seconds
+        static_cast<int>(HudNotificationType::GenericBig),
+        true, // fade out on expiry
+        player);
+
+    // Re-evaluate after the swap; if the teams are now balanced, end the
+    // sequence (further deaths won't trigger swaps until it re-queues).
+    int red = 0, blue = 0;
+    count_active_team_players(red, blue);
+    if (team_count_difference(red, blue) < AUTO_BALANCE_THRESHOLD) {
+        auto_team_balance_reset();
+    }
+}
+
+// Is the player still a valid subject for a swap that was decided earlier?
+// Mirrors the eligibility gate in auto_team_balance_on_player_death.
+static bool auto_team_balance_player_eligible(rf::Player* const player)
+{
+    if (!player) {
+        return false;
+    }
+    if (player->is_browser || player->is_spectator || player_is_idle(player)) {
+        return false;
+    }
+    if (is_player_ready(player) || is_player_in_match(player)) {
+        return false;
+    }
+    return true;
+}
+
+// Apply a swap that was deferred out of an active round.
+// The decision is re-validated from scratch instead of being trusted: between
+// the death and this boundary the player may have disconnected, gone to
+// spectate, become idle, joined a match, or already switched teams themselves.
+// If they are no longer the right person to move, the deferral is simply
+// dropped and the balance stays queued.
+static void auto_team_balance_apply_deferred(const int red, const int blue)
+{
+    const rf::ubyte deferred_id = g_auto_balance.deferred_player_id;
+    g_auto_balance.deferred_pending = false;
+    g_auto_balance.deferred_player_id = 0;
+
+    rf::Player* const player = rf::multi_find_player_by_id(deferred_id);
+    if (!auto_team_balance_player_eligible(player)) {
+        return;
+    }
+
+    const rf::ubyte larger_team = (red > blue) ? rf::TEAM_RED : rf::TEAM_BLUE;
+    if (player->team != larger_team) {
+        // Already moved off the larger team (manual switch, or the larger team
+        // flipped while they were waiting) — moving them now would make it worse.
+        return;
+    }
+
+    const rf::ubyte target_team = (larger_team == rf::TEAM_RED) ? rf::TEAM_BLUE : rf::TEAM_RED;
+    auto_team_balance_apply_swap(player, target_team);
 }
 
 static void auto_team_balance_do_frame()
@@ -2845,7 +3002,15 @@ static void auto_team_balance_do_frame()
         int red = 0, blue = 0;
         count_active_team_players(red, blue);
         if (team_count_difference(red, blue) < AUTO_BALANCE_THRESHOLD) {
+            // Drops any deferred swap along with the queue.
             auto_team_balance_reset();
+            return;
+        }
+
+        // Round boundary: apply a swap that was deferred out of an active round.
+        // Fires on the first frame the round is no longer.
+        if (g_auto_balance.deferred_pending && !rounds_is_active()) {
+            auto_team_balance_apply_deferred(red, blue);
         }
         return;
     }
@@ -2888,11 +3053,13 @@ void auto_team_balance_on_player_death(rf::Player* killed_player)
     if (g_match_info.match_active || g_match_info.pre_match_active) {
         return;
     }
-    // The dead player has to be eligible to be moved.
-    if (killed_player->is_browser || killed_player->is_spectator || player_is_idle(killed_player)) {
+    // A swap already deferred out of an active round owns this balance until the
+    // round boundary resolves it.
+    if (g_auto_balance.deferred_pending) {
         return;
     }
-    if (is_player_ready(killed_player) || is_player_in_match(killed_player)) {
+    // The dead player has to be eligible to be moved.
+    if (!auto_team_balance_player_eligible(killed_player)) {
         return;
     }
 
@@ -2912,27 +3079,18 @@ void auto_team_balance_on_player_death(rf::Player* killed_player)
         return;
     }
 
-    const rf::ubyte target_team = (larger_team == rf::TEAM_RED) ? rf::TEAM_BLUE : rf::TEAM_RED;
-    assign_player_to_team(killed_player, target_team);
-
-    // Announce the move to everyone in chat.
-    af_broadcast_automated_chat_msg(std::format(
-        "{} was moved to {} to balance the teams.", killed_player->name.c_str(), team_name(target_team)));
-
-    // Give the moved player a personal HUD notification so it's obvious.
-    af_send_hud_notification(
-        std::format("You have been moved to {} to balance the teams.", team_name(target_team)),
-        6, // seconds
-        static_cast<int>(HudNotificationType::GenericBig),
-        true, // fade out on expiry
-        killed_player);
-
-    // Re-evaluate after the swap; if the teams are now balanced, end the
-    // sequence (further deaths won't trigger swaps until it re-queues).
-    count_active_team_players(red, blue);
-    if (team_count_difference(red, blue) < AUTO_BALANCE_THRESHOLD) {
-        auto_team_balance_reset();
+    // Round-based gametypes: this death is an elimination, so don't swap now —
+    // record the intent and let the round boundary apply it.
+    if (rounds_is_active()) {
+        if (killed_player->net_data) {
+            g_auto_balance.deferred_pending = true;
+            g_auto_balance.deferred_player_id = killed_player->net_data->player_id;
+        }
+        return;
     }
+
+    const rf::ubyte target_team = (larger_team == rf::TEAM_RED) ? rf::TEAM_BLUE : rf::TEAM_RED;
+    auto_team_balance_apply_swap(killed_player, target_team);
 }
 
 // Returns true if a manual team-change request should be blocked because auto

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -1587,16 +1587,34 @@ CodeInjection multi_on_new_player_injection{
     },
 };
 
+// A dead client re-sends a spawn request every frame while fire is held, so every
+// "you can't spawn because..." notice in the spawn path shares one per-player
+// throttle (the same timer Pit and Wipeout already use for their own spawn-denied
+// lines, so two reasons can never alternate and double the rate). Only the
+// notification is throttled — the spawn is still declined every time.
+static constexpr int spawn_decline_msg_cooldown_ms = 10000;
+
+static void send_spawn_decline_msg(rf::Player* player, std::string_view msg)
+{
+    if (!player) {
+        return;
+    }
+    if (player->waiting_msg_timer.valid() && !player->waiting_msg_timer.elapsed()) {
+        return;
+    }
+    player->waiting_msg_timer.set(spawn_decline_msg_cooldown_ms);
+    af_send_automated_chat_msg(msg, player);
+}
+
 static bool check_player_ac_status([[maybe_unused]] rf::Player* player)
 {
 #ifdef HAS_PF
     if (g_additional_server_config.anticheat_level > 0) {
         bool verified = pf_is_player_verified(player);
         if (!verified) {
-            af_send_automated_chat_msg(
+            send_spawn_decline_msg(player,
                 "Sorry! Your spawn request was rejected because verification of your client software failed. "
-                "Please use the latest officially released version of Alpine Faction.",
-                player);
+                "Please use the latest officially released version of Alpine Faction.");
             return false;
         }
 
@@ -1607,7 +1625,7 @@ static bool check_player_ac_status([[maybe_unused]] rf::Player* player)
                 "Please make sure you do not have any mods installed and that your client software is up to date.",
                 ac_level, g_additional_server_config.anticheat_level
             );
-            af_send_automated_chat_msg(msg, player);
+            send_spawn_decline_msg(player, msg);
             return false;
         }
     }
@@ -1739,7 +1757,7 @@ void start_pre_match()
 
             std::string msg = std::format(
                 "\n>>>>>>>>>>>>>>>>> {}v{} MATCH QUEUED <<<<<<<<<<<<<<<<<\n"
-                "Waiting for players. Ready up or use \"/vote nomatch\" to call a vote to cancel the match.",
+                "Waiting for players. Ready up, or call a vote to cancel the match.",
                 g_match_info.team_size, g_match_info.team_size);
 
             af_send_automated_chat_msg(msg, player);
@@ -1841,7 +1859,7 @@ void remove_ready_player(rf::Player* player)
 void toggle_ready_status(rf::Player* player)
 {
     if (!g_match_info.pre_match_active) {
-        af_send_automated_chat_msg("No match is queued. Use \"/vote match\" to queue a match.", player);
+        af_send_automated_chat_msg("No match is queued. Call a match vote to queue one.", player);
         return;
     }
 
@@ -1875,7 +1893,7 @@ void set_ready_status(rf::Player* player, bool is_ready)
         }
     }
     else {
-        af_send_automated_chat_msg("No match is queued. Use \"/vote match\" to queue a match.", player);
+        af_send_automated_chat_msg("No match is queued. Call a match vote to queue one.", player);
     }
 }
 
@@ -1913,7 +1931,7 @@ void match_do_frame()
             g_match_info.last_match_reminder_time = current_time;
 
             af_broadcast_automated_chat_msg(
-                "No active match. Use \"/vote match <type> <map filename> [preset]\" to call a match vote.");
+                "No active match. Call a match vote to start one.");
         }
     }
     else if (g_match_info.pre_match_active) {
@@ -1929,7 +1947,7 @@ void match_do_frame()
                 if (!is_player_ready(player)) {
                     auto msg = std::format(
                         "You are NOT ready! {}v{} match queued, waiting for players - RED: {}, BLUE: {}.\n"
-                        "Ready up or use \"/vote nomatch\" to call a vote to cancel the match.",
+                        "Ready up, or call a vote to cancel the match.",
                         g_match_info.team_size, g_match_info.team_size,
                         g_match_info.team_size - ready_red, g_match_info.team_size - ready_blue);
                     af_send_automated_chat_msg(msg, player);
@@ -2151,16 +2169,16 @@ bool check_can_player_spawn(rf::Player* player)
     case AlpineRestrictVerdict::ok:
         return true;
     case AlpineRestrictVerdict::need_alpine:
-        af_send_automated_chat_msg("You must upgrade to Alpine Faction to play here. Learn more at alpinefaction.com", player);
+        send_spawn_decline_msg(player, "You must upgrade to Alpine Faction to play here. Learn more at alpinefaction.com");
         return false;
     case AlpineRestrictVerdict::need_release:
-        af_send_automated_chat_msg("This server requires an official Alpine Faction build. Get it at alpinefaction.com", player);
+        send_spawn_decline_msg(player, "This server requires an official Alpine Faction build. Get it at alpinefaction.com");
         return false;
     case AlpineRestrictVerdict::need_update:
-        af_send_automated_chat_msg("This server requires a newer version of Alpine Faction. Download the update at alpinefaction.com", player);
+        send_spawn_decline_msg(player, "This server requires a newer version of Alpine Faction. Download the update at alpinefaction.com");
         return false;
     case AlpineRestrictVerdict::need_d3d11:
-        af_send_automated_chat_msg("This server requires the Direct3D 11 renderer. Enable it in the Alpine Faction launcher settings panel.", player);
+        send_spawn_decline_msg(player, "This server requires the Direct3D 11 renderer. Enable it in the Alpine Faction launcher settings panel.");
         return false;
     }
     return false;
@@ -2192,15 +2210,12 @@ FunHook<void(rf::Player*)> multi_spawn_player_server_side_hook{
             return;
         }
         if (g_match_info.match_active && !is_player_in_match(player)) {
-            af_send_automated_chat_msg(
-                "You cannot spawn because a match is in progress. Please feel free to spectate.",
-                player
-            );
+            send_spawn_decline_msg(player,
+                "You cannot spawn because a match is in progress. Please feel free to spectate.");
             return;
         }
         if (player->is_bot && player->is_spawn_disabled) {
-            std::string msg = std::format("You're a bot and you can't spawn right now.");
-            af_send_automated_chat_msg(msg, player);
+            send_spawn_decline_msg(player, "You're a bot and you can't spawn right now.");
             return;
         }
 
@@ -2534,8 +2549,11 @@ void server_reliable_socket_ready(rf::Player* player)
         }
     }
 
+    // bring a player who joined during a vote up to date (AF 1.4+ only)
+    server_vote_send_state_to_new_player(player);
+
     // alert alpine clients to the queued match on join
-    if (g_match_info.pre_match_active && player->version_info.software == ClientSoftware::AlpineFaction) {    
+    if (g_match_info.pre_match_active && player->version_info.software == ClientSoftware::AlpineFaction) {
         auto msg = std::format("Match is queued and waiting for players: {}v{}! Use \"/ready\" to ready up.",
             g_match_info.team_size, g_match_info.team_size);
 
@@ -2570,6 +2588,7 @@ CodeInjection multi_level_init_injection{
                 shuffle_level_array();
                 g_alpine_server_config.printed_cfg.clear();
                 g_alpine_server_config.signal_cfg_changed = true;
+                server_vote_invalidate_options_blob(); // rotation order feeds the votable level list
             }
             initialize_game_info_server_flags();
             af_send_server_info_packet_to_all();

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -1114,8 +1114,9 @@ bool handle_server_chat_command(std::string_view server_command, rf::Player* sen
         );
     }
     else if (cmd_name == "vote") {
-        // Only used for old clients participating in a vote.
-        handle_vote_command(strip_by_space(cmd_arg).first, sender);
+        // Only used by old clients casting a vote. Anything else under `vote` moved
+        // to packets in 1.4, so it falls through as unrecognized like any other.
+        return handle_vote_command(strip_by_space(cmd_arg).first, sender);
     }
     else if (cmd_name == "nextmap" || cmd_name == "nextlevel") {
         handle_next_map_command(sender);
@@ -4478,6 +4479,14 @@ std::tuple<bool, int, bool, bool> server_features_require_alpine_client()
         requires_alpine = true;
         hard_reject = true;
         min_minor_version = std::max(min_minor_version, 4);
+    }
+
+    // Mutators declare their own client requirement in the registry.
+    const int mutator_minor_version =
+        mutators_min_client_minor_version(g_alpine_server_config_active_rules.mutators.declarations);
+    if (mutator_minor_version > MUTATOR_NO_CLIENT_REQUIREMENT) {
+        requires_alpine = true;
+        min_minor_version = std::max(min_minor_version, mutator_minor_version);
     }
 
     return {requires_alpine, min_minor_version, hard_reject, require_release_version};

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -78,7 +78,7 @@ struct InactivityConfig
     bool enabled = true;
     bool kick_after_warning = false;
     uint32_t new_player_grace_ms = 120000;
-    uint32_t allowed_inactive_ms = 30000;
+    uint32_t allowed_inactive_ms = 60000;
     uint32_t warning_duration_ms = 10000;
     std::string kick_message = "You have been marked as idle due to inactivity! You will be kicked from the game unless you respawn in the next 10 seconds.";
 
@@ -111,7 +111,7 @@ struct VoteConfig
     
     void set_time_limit_seconds(float in_time)
     {
-        time_limit_seconds = static_cast<int>(std::max(in_time, 1.0f));
+        time_limit_seconds = static_cast<int>(std::clamp(in_time, 1.0f, 65535.0f));
     }
 };
 
@@ -605,6 +605,10 @@ struct MutatorConfig
     // Arena: instantly refill the killer's current weapon clip after each frag.
     bool reload_weapon_on_kill = false;
 
+    // Vampire: gain effective health when dealing PvP damage.
+    bool vampire_enabled = false;
+    bool hide_health_armor_pickups = false;
+
     // Display only: human-readable names of the mutators applied to these rules.
     std::vector<std::string> active_labels;
 
@@ -936,14 +940,19 @@ bool set_upcoming_game_type(rf::NetGameType gt, UpcomingGameTypeSelection select
 void apply_defaults_for_game_type(rf::NetGameType game_type, AlpineServerConfigRules& rules);
 int get_active_rules_generation();
 void cleanup_win32_server_console();
-void handle_vote_command(std::string_view vote_name, std::string_view vote_arg, rf::Player* sender);
+// Still accept chat command votes for compatibility with older clients.
+void handle_vote_command(std::string_view vote_name, rf::Player* sender);
 // Packet-driven vote entry points (see alpine_packets.h for the wire formats).
 void handle_vote_call_packet(rf::Player* sender, AfVoteCallParams&& params);
 void handle_vote_cast_packet(rf::Player* sender, bool is_yes_vote);
 void handle_vote_cancel_packet(rf::Player* sender);
-// Serialized vote-options blob (server side). `generation` is bumped whenever
-// the blob is rebuilt so clients can discard partial/stale chunk sets.
-const std::vector<uint8_t>& server_vote_get_options_blob(uint8_t& generation);
+// af_req_vote_options: streams the blob unless this player already has the
+// current generation. `known_generation` is only meaningful with has_cache.
+void server_vote_handle_options_request(rf::Player* sender, bool has_cache, uint32_t known_generation);
+// Serialized vote-options blob (server side). `generation` is bumped whenever the
+// blob is rebuilt, so a client can tell a refresh from a redundant re-send and
+// discard a stream that was superseded mid-flight.
+const std::vector<uint8_t>& server_vote_get_options_blob(uint32_t& generation);
 void server_vote_invalidate_options_blob();
 // Push the current vote state to a player who joined while a vote is running.
 void server_vote_send_state_to_new_player(rf::Player* player);
@@ -955,6 +964,9 @@ void set_manual_rules_override(ManualRulesOverride override_rules);
 void clear_manual_rules_override();
 bool is_player_in_match(rf::Player* player);
 bool is_player_ready(rf::Player* player);
+// True when the game itself is currently refusing to spawn this player (respawn
+// delay, gametype spawn gate, match in progress they are not part of).
+bool player_spawn_blocked_by_game(const rf::Player* player);
 void update_pre_match_powerups(rf::Player* player);
 void start_match();
 void cancel_match();

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -5,6 +5,7 @@
 #include <set>
 #include <map>
 #include <optional>
+#include <variant>
 #include <vector>
 #include <filesystem>
 #include <unordered_map>
@@ -22,6 +23,8 @@ namespace rf
 {
     struct Player;
 }
+
+struct AfVoteCallParams; // alpine_packets.h
 
 // used for game_info packets
 struct AFGameInfoFlags
@@ -538,12 +541,45 @@ enum class PickupPolicy : uint8_t
     HideAll               // hide every pickup
 };
 
-// Runtime behaviors enabled by mutators.
+// Type tag for a mutator option value.
+// FROZEN wire constants: these values are sent in the vote-options schema and
+// echoed back in vote-call packets. Never reorder or reuse.
+enum class MutatorOptionType : uint8_t
+{
+    Bool = 0,
+    Choice = 1,
+    Int = 2,
+    Float = 3,
+    String = 4,
+};
+
+using MutatorOptionValue = std::variant<bool, int32_t, float, std::string>;
+
+// One declared mutator plus its option values, keyed by TOML key. Kept generic
+// so new mutator options need no struct changes here or in the TOML round-trip.
 struct MutatorDeclaration
 {
-    std::string name; // canonical mutator name (matches find_mutator_by_name)
-    std::optional<std::string> featured_weapon;
-    std::optional<bool> exclude_thrown;
+    std::string name; // canonical mutator name (matches mutators_find_by_name)
+    std::map<std::string, MutatorOptionValue> options;
+};
+
+// A single mutator option as received from a vote-call packet, before it is
+// validated against the server's schema.
+struct VoteMutatorOptionInput
+{
+    uint8_t option_id = 0;
+    MutatorOptionType type = MutatorOptionType::Bool;
+    bool bool_value = false;
+    uint8_t choice_index = 0;
+    int32_t int_value = 0;
+    float float_value = 0.0f;
+    std::string string_value;
+};
+
+struct VoteMutatorInput
+{
+    uint8_t mutator_id = 0;
+    std::vector<VoteMutatorOptionInput> options;
 };
 
 struct MutatorConfig
@@ -717,6 +753,11 @@ struct AlpineServerConfigLevelEntry
 {
     std::string level_filename;
     AlpineServerConfigRules rule_overrides;
+    // The same rules re-resolved with every config-declared mutator stripped.
+    // Starting point for a level/match vote that carries mutators, so the voted
+    // mutators replace (rather than stack on) whatever the config declared while
+    // the rest of this level's rules — notably its game type — are preserved.
+    AlpineServerConfigRules rule_overrides_no_mutators;
     std::vector<std::pair<std::filesystem::path, std::optional<std::string>>> applied_rules_preset_paths;
 };
 
@@ -786,7 +827,6 @@ struct AlpineServerConfig
     VoteConfig vote_match;
     VoteConfig vote_kick;
     VoteConfig vote_level;
-    VoteConfig vote_gametype;
     VoteConfig vote_extend;
     VoteConfig vote_restart;
     VoteConfig vote_next;
@@ -897,11 +937,20 @@ void apply_defaults_for_game_type(rf::NetGameType game_type, AlpineServerConfigR
 int get_active_rules_generation();
 void cleanup_win32_server_console();
 void handle_vote_command(std::string_view vote_name, std::string_view vote_arg, rf::Player* sender);
+// Packet-driven vote entry points (see alpine_packets.h for the wire formats).
+void handle_vote_call_packet(rf::Player* sender, AfVoteCallParams&& params);
+void handle_vote_cast_packet(rf::Player* sender, bool is_yes_vote);
+void handle_vote_cancel_packet(rf::Player* sender);
+// Serialized vote-options blob (server side). `generation` is bumped whenever
+// the blob is rebuilt so clients can discard partial/stale chunk sets.
+const std::vector<uint8_t>& server_vote_get_options_blob(uint8_t& generation);
+void server_vote_invalidate_options_blob();
+// Push the current vote state to a player who joined while a vote is running.
+void server_vote_send_state_to_new_player(rf::Player* player);
 void handle_player_set_handicap(rf::Player* player, uint8_t amount);
 std::vector<rf::Player*> get_clients(bool include_browsers, bool include_bots);
 std::pair<bool, std::string> is_level_name_valid(std::string_view level_name_input);
 std::optional<ManualRulesOverride> load_rules_preset_alias(std::string_view preset_name);
-std::optional<ManualRulesOverride> load_mutator_rules_override(std::string_view mutator_name);
 void set_manual_rules_override(ManualRulesOverride override_rules);
 void clear_manual_rules_override();
 bool is_player_in_match(rf::Player* player);

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -940,8 +940,10 @@ bool set_upcoming_game_type(rf::NetGameType gt, UpcomingGameTypeSelection select
 void apply_defaults_for_game_type(rf::NetGameType game_type, AlpineServerConfigRules& rules);
 int get_active_rules_generation();
 void cleanup_win32_server_console();
-// Still accept chat command votes for compatibility with older clients.
-void handle_vote_command(std::string_view vote_name, rf::Player* sender);
+// Legacy chat vote CASTING, kept for clients older than 1.4 (which have no
+// af_req_vote_cast). Only yes/no (and the y/n aliases) are handled; returns false
+// for anything else so the chat dispatcher reports it as an unrecognized command.
+bool handle_vote_command(std::string_view vote_name, rf::Player* sender);
 // Packet-driven vote entry points (see alpine_packets.h for the wire formats).
 void handle_vote_call_packet(rf::Player* sender, AfVoteCallParams&& params);
 void handle_vote_cast_packet(rf::Player* sender, bool is_yes_vote);

--- a/game_patch/multi/vote_client.cpp
+++ b/game_patch/multi/vote_client.cpp
@@ -20,8 +20,7 @@ namespace
 //
 // `loaded` data stays usable while `stale` is set: a stale cache means "the server
 // told us its config changed", and the refresh request it triggers is answered
-// with silence when the server's generation is in fact unchanged. Blanking the
-// cache on stale would therefore strand the UI on "Loading..." forever.
+// with silence when the server's generation is in fact unchanged.
 struct VoteOptionsCache
 {
     VoteOptionsData data;
@@ -606,8 +605,8 @@ void vote_state_on_start(uint8_t type_raw, uint16_t time_remaining_sec, uint8_t 
 
     draw_hud_vote_notification(g_active_vote->title);
 
-    // Mirrors the legacy "<title> vote started by <name>." line. The name is
-    // absent when the server couldn't resolve the owner (late joiner sync).
+    // "<title> vote started by <name>." The name is absent when the
+    // server couldn't resolve the owner (late joiner sync).
     std::string by_clause;
     if (g_active_vote->is_owner) {
         by_clause = " by you";

--- a/game_patch/multi/vote_client.cpp
+++ b/game_patch/multi/vote_client.cpp
@@ -16,19 +16,25 @@
 namespace
 {
 
-// Reassembly buffer for the chunked vote-options blob. Chunks of a different
-// generation than the one in progress restart the assembly.
+// Accumulator for the streamed vote-options blob plus the parsed result.
+//
+// `loaded` data stays usable while `stale` is set: a stale cache means "the server
+// told us its config changed", and the refresh request it triggers is answered
+// with silence when the server's generation is in fact unchanged. Blanking the
+// cache on stale would therefore strand the UI on "Loading..." forever.
 struct VoteOptionsCache
 {
     VoteOptionsData data;
     bool loaded = false;
     bool stale = true;
-    int loaded_generation = -1;
+    // Generation of `data`. Sent back with every request so the server can skip
+    // re-sending an identical blob.
+    uint32_t loaded_generation = 0;
 
-    int pending_generation = -1;
-    uint8_t pending_total = 0;
-    std::vector<std::vector<uint8_t>> pending_chunks;
-    std::vector<bool> pending_received;
+    // Stream in progress (Begin seen, End not yet).
+    bool streaming = false;
+    uint32_t stream_generation = 0;
+    std::vector<uint8_t> stream_bytes;
 
     int64_t last_request_ms = 0;
 };
@@ -36,8 +42,21 @@ struct VoteOptionsCache
 VoteOptionsCache g_vote_options;
 std::optional<ActiveVoteState> g_active_vote;
 
-// Don't re-ask more than this often; the server also guards per generation.
+// Retry interval while we have no blob at all. Once one is loaded a stale marker
+// costs exactly one request, so this only paces the initial fetch.
 constexpr int64_t vote_options_request_cooldown_ms = 3000;
+
+void vote_options_stream_discard(std::string_view reason)
+{
+    if (!g_vote_options.streaming) {
+        return;
+    }
+    xlog::warn("vote options: discarding partial stream (generation {}, {} bytes): {}",
+               g_vote_options.stream_generation, g_vote_options.stream_bytes.size(), reason);
+    g_vote_options.streaming = false;
+    g_vote_options.stream_bytes.clear();
+    g_vote_options.stream_bytes.shrink_to_fit();
+}
 
 // Bounds-checked little-endian reader over the reassembled blob.
 class BlobReader
@@ -49,7 +68,7 @@ public:
 
     uint8_t u8()
     {
-        if (!m_ok || m_pos + 1 > m_len) {
+        if (!m_ok || 1 > m_len - m_pos) {
             m_ok = false;
             return 0;
         }
@@ -58,7 +77,7 @@ public:
 
     uint16_t u16()
     {
-        if (!m_ok || m_pos + 2 > m_len) {
+        if (!m_ok || 2 > m_len - m_pos) {
             m_ok = false;
             return 0;
         }
@@ -70,7 +89,7 @@ public:
 
     uint32_t u32()
     {
-        if (!m_ok || m_pos + 4 > m_len) {
+        if (!m_ok || 4 > m_len - m_pos) {
             m_ok = false;
             return 0;
         }
@@ -82,7 +101,7 @@ public:
 
     int32_t i32()
     {
-        if (!m_ok || m_pos + 4 > m_len) {
+        if (!m_ok || 4 > m_len - m_pos) {
             m_ok = false;
             return 0;
         }
@@ -94,7 +113,7 @@ public:
 
     float f32()
     {
-        if (!m_ok || m_pos + 4 > m_len) {
+        if (!m_ok || 4 > m_len - m_pos) {
             m_ok = false;
             return 0.0f;
         }
@@ -107,13 +126,27 @@ public:
     std::string str()
     {
         const uint8_t len = u8();
-        if (!m_ok || m_pos + len > m_len) {
+        if (!m_ok || len > m_len - m_pos) {
             m_ok = false;
             return {};
         }
         std::string value(reinterpret_cast<const char*>(m_data + m_pos), len);
         m_pos += len;
         return value;
+    }
+
+    [[nodiscard]] size_t remaining() const { return m_ok ? m_len - m_pos : 0; }
+    [[nodiscard]] const uint8_t* cur() const { return m_data + m_pos; }
+
+    // Step over a length-prefixed descriptor body (or its unparsed tail). The
+    // caller has already checked `n <= remaining()`.
+    void skip(size_t n)
+    {
+        if (!m_ok || n > m_len - m_pos) {
+            m_ok = false;
+            return;
+        }
+        m_pos += n;
     }
 
 private:
@@ -123,97 +156,196 @@ private:
     bool m_ok = true;
 };
 
+// One option_descriptor body. Returns false when the option cannot be
+// represented — an unknown option TYPE, or a malformed body. The caller then
+// omits the option and the server's own default applies to any vote that doesn't
+// mention it, so the mutator stays fully usable.
+bool parse_option_descriptor(BlobReader& r, VoteMutatorOptionSchema& out)
+{
+    out.id = r.u8();
+    out.name = r.str();
+    out.label = r.str();
+    const uint8_t type_raw = r.u8();
+    if (!r.ok()) {
+        return false;
+    }
+    out.type = static_cast<MutatorOptionType>(type_raw);
+
+    switch (out.type) {
+        case MutatorOptionType::Bool:
+            out.default_bool = r.u8() != 0;
+            break;
+        case MutatorOptionType::Choice:
+            out.default_choice = r.u8();
+            break;
+        case MutatorOptionType::Int:
+            out.default_int = r.i32();
+            break;
+        case MutatorOptionType::Float:
+            out.default_float = r.f32();
+            break;
+        case MutatorOptionType::String:
+            out.default_string = r.str();
+            break;
+        default:
+            // A newer server added an option type this build has no encoding for.
+            // Nothing after the type byte can be interpreted, which is exactly why
+            // the descriptor is length-prefixed.
+            xlog::info("vote options: option '{}' has unknown type {}; omitting it", out.name, type_raw);
+            return false;
+    }
+
+    if (out.type == MutatorOptionType::Choice) {
+        const uint8_t choice_count = r.u8();
+        if (!r.ok()) {
+            return false;
+        }
+        out.choices.reserve(choice_count);
+        for (uint8_t c = 0; c < choice_count && r.ok(); ++c) {
+            out.choices.push_back(r.str());
+        }
+    }
+
+    // Trailing bytes inside the body are fields a newer server added; ignored.
+    return r.ok();
+}
+
+// One mutator_descriptor body. Returns false when the descriptor itself is
+// malformed, in which case the whole mutator is dropped (the rest of the blob is
+// still intact because the descriptor is length-prefixed).
+bool parse_mutator_descriptor(BlobReader& r, VoteMutatorSchema& out)
+{
+    out.id = r.u8();
+    out.name = r.str();
+    out.label = r.str();
+    const uint8_t option_count = r.u8();
+    if (!r.ok()) {
+        return false;
+    }
+
+    out.options.reserve(option_count);
+    for (uint8_t o = 0; o < option_count; ++o) {
+        const uint8_t body_len = r.u8();
+        if (!r.ok() || body_len > r.remaining()) {
+            return false; // the declared option count doesn't fit the body
+        }
+        BlobReader body{r.cur(), body_len};
+        VoteMutatorOptionSchema opt;
+        if (parse_option_descriptor(body, opt)) {
+            out.options.push_back(std::move(opt));
+        }
+        r.skip(body_len); // unconditional: parsed or not, the next option starts here
+    }
+
+    return true;
+}
+
 bool parse_vote_options_blob(const uint8_t* data, size_t len, VoteOptionsData& out)
 {
     BlobReader r{data, len};
 
     const uint8_t version = r.u8();
-    if (!r.ok() || version != af_vote_options_blob_version) {
-        xlog::warn("vote options: unsupported blob version {}", version);
+    if (!r.ok()) {
+        xlog::warn("vote options: empty blob");
+        return false;
+    }
+    // MAJOR version: anything at or below what this build knows is parseable,
+    // because every additive change is skippable (see af_vote_options_blob_version).
+    if (version > af_vote_options_blob_version) {
+        xlog::warn("vote options: blob version {} is newer than this client understands ({})", version,
+                   af_vote_options_blob_version);
         return false;
     }
 
     VoteOptionsData parsed;
-    parsed.enabled_vote_mask = r.u16();
+    parsed.enabled_vote_mask = r.u32();
     parsed.gametype_prefix_restricted = (r.u8() & AF_VOTE_SERVER_FLAG_GAMETYPE_PREFIX) != 0;
 
+    // Game type entries are length-prefixed, so fields a newer server appends
+    // inside one are skipped instead of desyncing everything behind it.
     const uint8_t gametype_count = r.u8();
-    parsed.gametypes.reserve(gametype_count);
-    for (uint8_t i = 0; i < gametype_count && r.ok(); ++i) {
-        VoteGametypeInfo gt;
-        gt.id = r.u8();
-        gt.is_team_type = (r.u8() & AF_VOTE_GAMETYPE_FLAG_TEAM) != 0;
-        gt.name = r.str();
-        parsed.gametypes.push_back(std::move(gt));
-    }
-
-    const uint8_t mutator_count = r.u8();
-    parsed.mutators.reserve(mutator_count);
-    for (uint8_t i = 0; i < mutator_count && r.ok(); ++i) {
-        VoteMutatorSchema mutator;
-        mutator.id = r.u8();
-        mutator.name = r.str();
-        mutator.label = r.str();
-
-        const uint8_t option_count = r.u8();
-        mutator.options.reserve(option_count);
-        for (uint8_t o = 0; o < option_count && r.ok(); ++o) {
-            VoteMutatorOptionSchema opt;
-            opt.id = r.u8();
-            opt.name = r.str();
-            opt.label = r.str();
-            opt.type = static_cast<MutatorOptionType>(r.u8());
-
-            switch (opt.type) {
-                case MutatorOptionType::Bool:
-                    opt.default_bool = r.u8() != 0;
-                    break;
-                case MutatorOptionType::Choice:
-                    opt.default_choice = r.u8();
-                    break;
-                case MutatorOptionType::Int:
-                    opt.default_int = r.i32();
-                    break;
-                case MutatorOptionType::Float:
-                    opt.default_float = r.f32();
-                    break;
-                case MutatorOptionType::String:
-                    opt.default_string = r.str();
-                    break;
-                default:
-                    xlog::warn("vote options: unknown option type {}", static_cast<int>(opt.type));
-                    return false;
-            }
-
-            if (opt.type == MutatorOptionType::Choice) {
-                const uint8_t choice_count = r.u8();
-                opt.choices.reserve(choice_count);
-                for (uint8_t c = 0; c < choice_count && r.ok(); ++c) {
-                    opt.choices.push_back(r.str());
-                }
-            }
-
-            mutator.options.push_back(std::move(opt));
-        }
-
-        parsed.mutators.push_back(std::move(mutator));
-    }
-
-    const uint16_t level_count = r.u16();
-    parsed.levels.reserve(level_count);
-    for (uint16_t i = 0; i < level_count && r.ok(); ++i) {
-        VoteLevelInfo level;
-        level.filename = r.str();
-        level.natural_gametype = r.u8();
-        level.valid_gametype_mask = r.u32();
-        parsed.levels.push_back(std::move(level));
-    }
-
     if (!r.ok()) {
-        xlog::warn("vote options: truncated blob ({} bytes)", len);
+        xlog::warn("vote options: truncated blob before the game type section ({} bytes)", len);
         return false;
     }
+    parsed.gametypes.reserve(gametype_count);
+    for (uint8_t i = 0; i < gametype_count; ++i) {
+        const uint16_t body_len = r.u16();
+        if (!r.ok() || body_len > r.remaining()) {
+            xlog::warn("vote options: truncated blob in the game type section ({} bytes)", len);
+            return false;
+        }
+        // Bounded to the body, so a bad inner length can't reach the next entry.
+        BlobReader body{r.cur(), body_len};
+        VoteGametypeInfo gt;
+        gt.id = body.u8();
+        gt.is_team_type = (body.u8() & AF_VOTE_GAMETYPE_FLAG_TEAM) != 0;
+        gt.name = body.str();
+        if (body.ok()) {
+            parsed.gametypes.push_back(std::move(gt));
+        }
+        else {
+            xlog::warn("vote options: unparseable game type entry ({} bytes); skipping it", body_len);
+        }
+        r.skip(body_len); // unconditional: the next entry starts here either way
+    }
 
+    // Mutator and option descriptors are length-prefixed, so a mutator this build
+    // can't make sense of is skipped instead of desyncing everything after it.
+    const uint8_t mutator_count = r.u8();
+    if (!r.ok()) {
+        xlog::warn("vote options: truncated blob before the mutator section ({} bytes)", len);
+        return false;
+    }
+    parsed.mutators.reserve(mutator_count);
+    for (uint8_t i = 0; i < mutator_count; ++i) {
+        const uint16_t body_len = r.u16();
+        if (!r.ok() || body_len > r.remaining()) {
+            xlog::warn("vote options: truncated blob in the mutator section ({} bytes)", len);
+            return false;
+        }
+        BlobReader body{r.cur(), body_len};
+        VoteMutatorSchema mutator;
+        if (parse_mutator_descriptor(body, mutator)) {
+            parsed.mutators.push_back(std::move(mutator));
+        }
+        else {
+            xlog::warn("vote options: unparseable mutator descriptor ({} bytes); skipping it", body_len);
+        }
+        r.skip(body_len); // unconditional: the next descriptor starts here either way
+    }
+
+    // Level entries are length-prefixed too, same contract as the entries above.
+    const uint16_t level_count = r.u16();
+    if (!r.ok()) {
+        xlog::warn("vote options: truncated blob before the level section ({} bytes)", len);
+        return false;
+    }
+    // Smallest possible entry: u16 body len + str len byte + natural gametype + mask + flags.
+    constexpr size_t min_level_entry = 2 + 1 + 1 + 4 + 1;
+    parsed.levels.reserve(std::min<size_t>(level_count, r.remaining() / min_level_entry));
+    for (uint16_t i = 0; i < level_count; ++i) {
+        const uint16_t body_len = r.u16();
+        if (!r.ok() || body_len > r.remaining()) {
+            xlog::warn("vote options: truncated blob in the level section ({} bytes)", len);
+            return false;
+        }
+        BlobReader body{r.cur(), body_len};
+        VoteLevelInfo level;
+        level.filename = body.str();
+        level.natural_gametype = body.u8();
+        level.valid_gametype_mask = body.u32();
+        level.allowed_for_vote = (body.u8() & AF_VOTE_LEVEL_FLAG_ALLOWED) != 0;
+        if (body.ok()) {
+            parsed.levels.push_back(std::move(level));
+        }
+        else {
+            xlog::warn("vote options: unparseable level entry ({} bytes); skipping it", body_len);
+        }
+        r.skip(body_len); // unconditional: the next entry starts here either way
+    }
+
+    // Anything left over is a section a newer server appended; ignored on purpose.
     out = std::move(parsed);
     return true;
 }
@@ -228,17 +360,18 @@ void print_vote_chat_line(std::string_view msg)
     }
 }
 
-const char* vote_result_text(AfVoteResult result)
+// Fallback wording when the server sent no outcome detail. Normally the detail
+// string carries the exact line legacy clients receive.
+const char* vote_result_text(AfVoteResult result, bool passed)
 {
     switch (result) {
         case AfVoteResult::Passed:
-            return "Vote passed!";
+        case AfVoteResult::TimedOut:
+            return passed ? "Vote passed!" : "Vote failed!";
         case AfVoteResult::Failed:
             return "Vote failed!";
         case AfVoteResult::Canceled:
             return "Vote canceled!";
-        case AfVoteResult::TimedOut:
-            return "Vote timed out!";
     }
     return "Vote ended.";
 }
@@ -247,7 +380,9 @@ const char* vote_result_text(AfVoteResult result)
 
 bool vote_options_are_loaded()
 {
-    return g_vote_options.loaded && !g_vote_options.stale;
+    // Stale-but-loaded still counts: see VoteOptionsCache. The refresh happens in
+    // the background and replaces the data in place when it arrives.
+    return g_vote_options.loaded;
 }
 
 const VoteOptionsData* vote_options_get()
@@ -270,11 +405,15 @@ bool vote_level_allows_default_gametype(const VoteLevelInfo& level)
 
 bool vote_options_is_type_enabled(AfVoteType type)
 {
+    // Deliberately keyed on `loaded` alone, matching vote_options_are_loaded():
+    // a stale mask is the best answer available and the server validates anyway.
     if (!g_vote_options.loaded) {
         return false;
     }
+    // The mask is a u32; shifting by 32 or more is undefined, and a bit that far
+    // out cannot be a type this build knows anyway.
     const auto bit = static_cast<unsigned>(type);
-    if (bit >= 16) {
+    if (bit >= 32) {
         return false;
     }
     return (g_vote_options.data.enabled_vote_mask & (1u << bit)) != 0;
@@ -282,10 +421,12 @@ bool vote_options_is_type_enabled(AfVoteType type)
 
 void vote_options_request_if_needed()
 {
-    if (!rf::is_multi) {
+    // The listen-server host has no vote UI at all (it can neither call nor cast),
+    // so it never needs the schema and there is no local build path.
+    if (!rf::is_multi || rf::is_server) {
         return;
     }
-    if (vote_options_are_loaded()) {
+    if (g_vote_options.loaded && !g_vote_options.stale) {
         return;
     }
 
@@ -296,74 +437,131 @@ void vote_options_request_if_needed()
     }
     g_vote_options.last_request_ms = now;
 
-    if (rf::is_server) {
-        af_send_vote_options_data(rf::local_player); // listen host builds it locally
+    // Asking clears `stale` even though nothing has arrived yet: the request tells
+    // the server the generation we hold, and the server answers with silence when
+    // that is already current. Retrying would then loop forever. A cache we don't
+    // have yet keeps retrying on the cooldown above.
+    if (g_vote_options.loaded) {
+        g_vote_options.stale = false;
     }
-    else {
-        af_send_vote_options_request();
-    }
+
+    af_send_vote_options_request(g_vote_options.loaded, g_vote_options.loaded_generation);
 }
 
 void vote_options_mark_stale()
 {
-    g_vote_options.stale = true;
-    g_vote_options.last_request_ms = 0;
-}
-
-void vote_options_handle_chunk(uint8_t generation, uint8_t seq, uint8_t total,
-                               const uint8_t* data, size_t len)
-{
-    if (total == 0 || seq >= total) {
-        xlog::warn("vote options: bad chunk framing (seq={}, total={})", seq, total);
+    if (!g_vote_options.loaded) {
+        // Nothing cached yet, so there is nothing to refresh; the UI asks on demand
+        // (`stale` is already true in this state).
         return;
     }
 
-    // A different generation invalidates whatever is being assembled.
-    if (g_vote_options.pending_generation != static_cast<int>(generation) ||
-        g_vote_options.pending_total != total) {
-        g_vote_options.pending_generation = static_cast<int>(generation);
-        g_vote_options.pending_total = total;
-        g_vote_options.pending_chunks.assign(total, {});
-        g_vote_options.pending_received.assign(total, false);
+    g_vote_options.stale = true;
+    g_vote_options.last_request_ms = 0;
+
+    // Refresh right away rather than waiting for the UI to be opened. A UI only
+    // asks while it has nothing to show, and stale data now counts as loaded, so
+    // otherwise nothing would ever ask. The request costs 5 bytes and the server
+    // answers with silence when its generation hasn't actually changed.
+    vote_options_request_if_needed();
+}
+
+void vote_options_stream_begin(uint32_t generation, uint32_t total_bytes)
+{
+    vote_options_stream_discard("superseded by a new stream");
+
+    if (total_bytes > af_vote_options_max_blob_size) {
+        xlog::error("vote options: server announced a {} byte blob, above the {} byte cap; ignoring it",
+                    total_bytes, af_vote_options_max_blob_size);
+        return;
     }
 
-    g_vote_options.pending_chunks[seq].assign(data, data + len);
-    g_vote_options.pending_received[seq] = true;
+    g_vote_options.streaming = true;
+    g_vote_options.stream_generation = generation;
+    g_vote_options.stream_bytes.clear();
+    g_vote_options.stream_bytes.reserve(total_bytes);
+}
 
-    for (uint8_t i = 0; i < total; ++i) {
-        if (!g_vote_options.pending_received[i]) {
-            return; // still waiting for more chunks
-        }
+void vote_options_stream_data(uint32_t generation, const uint8_t* data, size_t len)
+{
+    if (!g_vote_options.streaming) {
+        xlog::warn("vote options: data frame with no stream in progress (generation {})", generation);
+        return;
+    }
+    if (generation != g_vote_options.stream_generation) {
+        // The server rebuilt the blob mid-stream. Everything accumulated belongs to
+        // the old generation and the new one will arrive with its own Begin.
+        vote_options_stream_discard("generation changed mid-stream");
+        return;
+    }
+    if (g_vote_options.stream_bytes.size() + len > af_vote_options_max_blob_size) {
+        vote_options_stream_discard("accumulation exceeded the blob size cap");
+        return;
+    }
+    g_vote_options.stream_bytes.insert(g_vote_options.stream_bytes.end(), data, data + len);
+}
+
+void vote_options_stream_end(uint32_t generation)
+{
+    if (!g_vote_options.streaming) {
+        xlog::warn("vote options: end frame with no stream in progress (generation {})", generation);
+        return;
+    }
+    if (generation != g_vote_options.stream_generation) {
+        vote_options_stream_discard("generation changed before the end frame");
+        return;
     }
 
-    std::vector<uint8_t> blob;
-    for (const auto& chunk : g_vote_options.pending_chunks) {
-        blob.insert(blob.end(), chunk.begin(), chunk.end());
-    }
-
-    g_vote_options.pending_generation = -1;
-    g_vote_options.pending_total = 0;
-    g_vote_options.pending_chunks.clear();
-    g_vote_options.pending_received.clear();
+    std::vector<uint8_t> blob = std::move(g_vote_options.stream_bytes);
+    g_vote_options.streaming = false;
+    g_vote_options.stream_bytes.clear();
+    g_vote_options.stream_bytes.shrink_to_fit();
 
     VoteOptionsData parsed;
     if (!parse_vote_options_blob(blob.data(), blob.size(), parsed)) {
-        return;
+        return; // keep whatever was already loaded rather than blanking the UI
     }
 
     g_vote_options.data = std::move(parsed);
     g_vote_options.loaded = true;
     g_vote_options.stale = false;
-    g_vote_options.loaded_generation = static_cast<int>(generation);
+    g_vote_options.loaded_generation = generation;
+    xlog::debug("vote options: loaded {} bytes (generation {}): {} levels, {} mutators", blob.size(),
+                generation, g_vote_options.data.levels.size(), g_vote_options.data.mutators.size());
+}
+
+// Client-side safety net only. If the server's End event never arrives (dropped,
+// or a server path that fails to emit one), a stuck g_active_vote would pin the
+// HUD at "0s left" and make CALL VOTE unreachable for the rest of the session.
+// The server stays authoritative: this fires only well past the deadline, and a
+// late End is still handled because vote_state_on_end guards on g_active_vote.
+// It cannot fire early for a late-joiner sync — end_timestamp_ms is derived from
+// the actual remaining seconds the server sent.
+static constexpr int64_t vote_state_expiry_grace_ms = 5000;
+
+static void vote_state_expire_if_overdue()
+{
+    if (!g_active_vote) {
+        return;
+    }
+    if (timer::get_i64(1000) <= g_active_vote->end_timestamp_ms + vote_state_expiry_grace_ms) {
+        return;
+    }
+    xlog::warn("vote state: no end event within {} ms of the deadline; clearing locally",
+               vote_state_expiry_grace_ms);
+    g_active_vote.reset();
+    remove_hud_vote_notification();
 }
 
 const std::optional<ActiveVoteState>& vote_state_get()
 {
+    vote_state_expire_if_overdue();
     return g_active_vote;
 }
 
 int vote_state_seconds_remaining()
 {
+    vote_state_expire_if_overdue();
     if (!g_active_vote) {
         return 0;
     }
@@ -381,12 +579,20 @@ void vote_state_mark_local_voted()
     }
 }
 
-void vote_state_on_start(AfVoteType type, uint16_t time_remaining_sec, uint8_t yes, uint8_t no,
-                         uint8_t remaining, bool is_owner, std::string initiator_name,
+void vote_state_on_start(uint8_t type_raw, uint16_t time_remaining_sec, uint8_t yes, uint8_t no,
+                         uint8_t remaining, bool is_owner, bool is_sync, std::string initiator_name,
                          std::string title)
 {
     ActiveVoteState state;
-    state.type = type;
+    state.type_raw = type_raw;
+    if (!state.known_type()) {
+        // A newer server added a vote type this build predates. The vote still
+        // runs normally here: the server counts this client as an eligible voter
+        // either way, so refusing the event would only make it a silent
+        // non-voter that drags the tally out to the deadline.
+        xlog::info("vote state: server started vote type {}, which this build does not know; "
+                   "showing it as '{}'", type_raw, title.empty() ? "Vote in progress" : title);
+    }
     state.title = std::move(title);
     state.initiator_name = std::move(initiator_name);
     state.yes = yes;
@@ -410,6 +616,14 @@ void vote_state_on_start(AfVoteType type, uint16_t time_remaining_sec, uint8_t y
         by_clause = std::format(" by {}", g_active_vote->initiator_name);
     }
 
+    if (is_sync) {
+        // Joined while the vote was already running: the "VOTE STARTING" banner
+        // would be a lie, so report the state instead.
+        print_vote_chat_line(std::format("Vote in progress: {}{} - Yes: {} No: {} Waiting: {} ({}s left)",
+            g_active_vote->title, by_clause, yes, no, remaining, time_remaining_sec));
+        return;
+    }
+
     print_vote_chat_line(std::format("\n=============== VOTE STARTING ===============\n{} vote started{}.",
         g_active_vote->title, by_clause));
 }
@@ -426,10 +640,17 @@ void vote_state_on_update(uint8_t yes, uint8_t no, uint8_t remaining)
     print_vote_chat_line(std::format("Vote status: Yes: {} No: {} Waiting: {}", yes, no, remaining));
 }
 
-void vote_state_on_end(AfVoteResult result)
+void vote_state_on_end(AfVoteResult result, bool passed, std::string detail)
 {
     if (g_active_vote) {
-        print_vote_chat_line(vote_result_text(result));
+        // Legacy clients get "Vote timed out!" and then the outcome line, so print
+        // both. Without the second line a timed-out vote that PASSED would leave
+        // chat saying "timed out" while the server changes the level.
+        if (result == AfVoteResult::TimedOut) {
+            print_vote_chat_line("Vote timed out!");
+        }
+        print_vote_chat_line(detail.empty() ? std::string_view{vote_result_text(result, passed)}
+                                            : std::string_view{detail});
     }
     g_active_vote.reset();
     remove_hud_vote_notification();
@@ -438,5 +659,10 @@ void vote_state_on_end(AfVoteResult result)
 void vote_client_reset()
 {
     g_active_vote.reset();
+    // Drops any partial stream along with the parsed cache: the accumulated bytes
+    // belong to the server we just left.
     g_vote_options = VoteOptionsCache{};
+    // Also drop the HUD prompt: without this a vote left running on the server we
+    // just left would keep its notification up across a reconnect elsewhere.
+    remove_hud_vote_notification();
 }

--- a/game_patch/multi/vote_client.cpp
+++ b/game_patch/multi/vote_client.cpp
@@ -1,0 +1,442 @@
+#include <cstring>
+#include <format>
+#include <string_view>
+#include <utility>
+#include <xlog/xlog.h>
+#include "vote_client.h"
+#include "alpine_packets.h"
+#include "../hud/hud.h"
+#include "../misc/alpine_settings.h"
+#include "../os/os.h"
+#include "../rf/multi.h"
+#include "../rf/player/player.h"
+#include "../rf/sound/sound.h"
+#include "../sound/sound.h"
+
+namespace
+{
+
+// Reassembly buffer for the chunked vote-options blob. Chunks of a different
+// generation than the one in progress restart the assembly.
+struct VoteOptionsCache
+{
+    VoteOptionsData data;
+    bool loaded = false;
+    bool stale = true;
+    int loaded_generation = -1;
+
+    int pending_generation = -1;
+    uint8_t pending_total = 0;
+    std::vector<std::vector<uint8_t>> pending_chunks;
+    std::vector<bool> pending_received;
+
+    int64_t last_request_ms = 0;
+};
+
+VoteOptionsCache g_vote_options;
+std::optional<ActiveVoteState> g_active_vote;
+
+// Don't re-ask more than this often; the server also guards per generation.
+constexpr int64_t vote_options_request_cooldown_ms = 3000;
+
+// Bounds-checked little-endian reader over the reassembled blob.
+class BlobReader
+{
+public:
+    BlobReader(const uint8_t* data, size_t len) : m_data(data), m_len(len) {}
+
+    [[nodiscard]] bool ok() const { return m_ok; }
+
+    uint8_t u8()
+    {
+        if (!m_ok || m_pos + 1 > m_len) {
+            m_ok = false;
+            return 0;
+        }
+        return m_data[m_pos++];
+    }
+
+    uint16_t u16()
+    {
+        if (!m_ok || m_pos + 2 > m_len) {
+            m_ok = false;
+            return 0;
+        }
+        uint16_t value = 0;
+        std::memcpy(&value, m_data + m_pos, sizeof(value));
+        m_pos += sizeof(value);
+        return value;
+    }
+
+    uint32_t u32()
+    {
+        if (!m_ok || m_pos + 4 > m_len) {
+            m_ok = false;
+            return 0;
+        }
+        uint32_t value = 0;
+        std::memcpy(&value, m_data + m_pos, sizeof(value));
+        m_pos += sizeof(value);
+        return value;
+    }
+
+    int32_t i32()
+    {
+        if (!m_ok || m_pos + 4 > m_len) {
+            m_ok = false;
+            return 0;
+        }
+        int32_t value = 0;
+        std::memcpy(&value, m_data + m_pos, sizeof(value));
+        m_pos += sizeof(value);
+        return value;
+    }
+
+    float f32()
+    {
+        if (!m_ok || m_pos + 4 > m_len) {
+            m_ok = false;
+            return 0.0f;
+        }
+        float value = 0.0f;
+        std::memcpy(&value, m_data + m_pos, sizeof(value));
+        m_pos += sizeof(value);
+        return value;
+    }
+
+    std::string str()
+    {
+        const uint8_t len = u8();
+        if (!m_ok || m_pos + len > m_len) {
+            m_ok = false;
+            return {};
+        }
+        std::string value(reinterpret_cast<const char*>(m_data + m_pos), len);
+        m_pos += len;
+        return value;
+    }
+
+private:
+    const uint8_t* m_data;
+    size_t m_len;
+    size_t m_pos = 0;
+    bool m_ok = true;
+};
+
+bool parse_vote_options_blob(const uint8_t* data, size_t len, VoteOptionsData& out)
+{
+    BlobReader r{data, len};
+
+    const uint8_t version = r.u8();
+    if (!r.ok() || version != af_vote_options_blob_version) {
+        xlog::warn("vote options: unsupported blob version {}", version);
+        return false;
+    }
+
+    VoteOptionsData parsed;
+    parsed.enabled_vote_mask = r.u16();
+    parsed.gametype_prefix_restricted = (r.u8() & AF_VOTE_SERVER_FLAG_GAMETYPE_PREFIX) != 0;
+
+    const uint8_t gametype_count = r.u8();
+    parsed.gametypes.reserve(gametype_count);
+    for (uint8_t i = 0; i < gametype_count && r.ok(); ++i) {
+        VoteGametypeInfo gt;
+        gt.id = r.u8();
+        gt.is_team_type = (r.u8() & AF_VOTE_GAMETYPE_FLAG_TEAM) != 0;
+        gt.name = r.str();
+        parsed.gametypes.push_back(std::move(gt));
+    }
+
+    const uint8_t mutator_count = r.u8();
+    parsed.mutators.reserve(mutator_count);
+    for (uint8_t i = 0; i < mutator_count && r.ok(); ++i) {
+        VoteMutatorSchema mutator;
+        mutator.id = r.u8();
+        mutator.name = r.str();
+        mutator.label = r.str();
+
+        const uint8_t option_count = r.u8();
+        mutator.options.reserve(option_count);
+        for (uint8_t o = 0; o < option_count && r.ok(); ++o) {
+            VoteMutatorOptionSchema opt;
+            opt.id = r.u8();
+            opt.name = r.str();
+            opt.label = r.str();
+            opt.type = static_cast<MutatorOptionType>(r.u8());
+
+            switch (opt.type) {
+                case MutatorOptionType::Bool:
+                    opt.default_bool = r.u8() != 0;
+                    break;
+                case MutatorOptionType::Choice:
+                    opt.default_choice = r.u8();
+                    break;
+                case MutatorOptionType::Int:
+                    opt.default_int = r.i32();
+                    break;
+                case MutatorOptionType::Float:
+                    opt.default_float = r.f32();
+                    break;
+                case MutatorOptionType::String:
+                    opt.default_string = r.str();
+                    break;
+                default:
+                    xlog::warn("vote options: unknown option type {}", static_cast<int>(opt.type));
+                    return false;
+            }
+
+            if (opt.type == MutatorOptionType::Choice) {
+                const uint8_t choice_count = r.u8();
+                opt.choices.reserve(choice_count);
+                for (uint8_t c = 0; c < choice_count && r.ok(); ++c) {
+                    opt.choices.push_back(r.str());
+                }
+            }
+
+            mutator.options.push_back(std::move(opt));
+        }
+
+        parsed.mutators.push_back(std::move(mutator));
+    }
+
+    const uint16_t level_count = r.u16();
+    parsed.levels.reserve(level_count);
+    for (uint16_t i = 0; i < level_count && r.ok(); ++i) {
+        VoteLevelInfo level;
+        level.filename = r.str();
+        level.natural_gametype = r.u8();
+        level.valid_gametype_mask = r.u32();
+        parsed.levels.push_back(std::move(level));
+    }
+
+    if (!r.ok()) {
+        xlog::warn("vote options: truncated blob ({} bytes)", len);
+        return false;
+    }
+
+    out = std::move(parsed);
+    return true;
+}
+
+// Structured servers send no vote chat text, so mirror the legacy wording
+// locally to keep chat history the same as what pre-1.4 clients see.
+void print_vote_chat_line(std::string_view msg)
+{
+    rf::multi_chat_print(rf::String{msg}, rf::ChatMsgColor::gold_white, rf::String{"Server: "});
+    if (!g_alpine_game_config.simple_server_chat_msgs) {
+        rf::snd_play(stock_sound_id::end_voice, 0, 0.0f, 1.0f);
+    }
+}
+
+const char* vote_result_text(AfVoteResult result)
+{
+    switch (result) {
+        case AfVoteResult::Passed:
+            return "Vote passed!";
+        case AfVoteResult::Failed:
+            return "Vote failed!";
+        case AfVoteResult::Canceled:
+            return "Vote canceled!";
+        case AfVoteResult::TimedOut:
+            return "Vote timed out!";
+    }
+    return "Vote ended.";
+}
+
+} // namespace
+
+bool vote_options_are_loaded()
+{
+    return g_vote_options.loaded && !g_vote_options.stale;
+}
+
+const VoteOptionsData* vote_options_get()
+{
+    return g_vote_options.loaded ? &g_vote_options.data : nullptr;
+}
+
+bool vote_level_allows_gametype(const VoteLevelInfo& level, uint8_t game_type)
+{
+    if (game_type >= 32) {
+        return false;
+    }
+    return (level.valid_gametype_mask & (1u << game_type)) != 0;
+}
+
+bool vote_level_allows_default_gametype(const VoteLevelInfo& level)
+{
+    return vote_level_allows_gametype(level, level.natural_gametype);
+}
+
+bool vote_options_is_type_enabled(AfVoteType type)
+{
+    if (!g_vote_options.loaded) {
+        return false;
+    }
+    const auto bit = static_cast<unsigned>(type);
+    if (bit >= 16) {
+        return false;
+    }
+    return (g_vote_options.data.enabled_vote_mask & (1u << bit)) != 0;
+}
+
+void vote_options_request_if_needed()
+{
+    if (!rf::is_multi) {
+        return;
+    }
+    if (vote_options_are_loaded()) {
+        return;
+    }
+
+    const int64_t now = timer::get_i64(1000);
+    if (g_vote_options.last_request_ms != 0 &&
+        now - g_vote_options.last_request_ms < vote_options_request_cooldown_ms) {
+        return;
+    }
+    g_vote_options.last_request_ms = now;
+
+    if (rf::is_server) {
+        af_send_vote_options_data(rf::local_player); // listen host builds it locally
+    }
+    else {
+        af_send_vote_options_request();
+    }
+}
+
+void vote_options_mark_stale()
+{
+    g_vote_options.stale = true;
+    g_vote_options.last_request_ms = 0;
+}
+
+void vote_options_handle_chunk(uint8_t generation, uint8_t seq, uint8_t total,
+                               const uint8_t* data, size_t len)
+{
+    if (total == 0 || seq >= total) {
+        xlog::warn("vote options: bad chunk framing (seq={}, total={})", seq, total);
+        return;
+    }
+
+    // A different generation invalidates whatever is being assembled.
+    if (g_vote_options.pending_generation != static_cast<int>(generation) ||
+        g_vote_options.pending_total != total) {
+        g_vote_options.pending_generation = static_cast<int>(generation);
+        g_vote_options.pending_total = total;
+        g_vote_options.pending_chunks.assign(total, {});
+        g_vote_options.pending_received.assign(total, false);
+    }
+
+    g_vote_options.pending_chunks[seq].assign(data, data + len);
+    g_vote_options.pending_received[seq] = true;
+
+    for (uint8_t i = 0; i < total; ++i) {
+        if (!g_vote_options.pending_received[i]) {
+            return; // still waiting for more chunks
+        }
+    }
+
+    std::vector<uint8_t> blob;
+    for (const auto& chunk : g_vote_options.pending_chunks) {
+        blob.insert(blob.end(), chunk.begin(), chunk.end());
+    }
+
+    g_vote_options.pending_generation = -1;
+    g_vote_options.pending_total = 0;
+    g_vote_options.pending_chunks.clear();
+    g_vote_options.pending_received.clear();
+
+    VoteOptionsData parsed;
+    if (!parse_vote_options_blob(blob.data(), blob.size(), parsed)) {
+        return;
+    }
+
+    g_vote_options.data = std::move(parsed);
+    g_vote_options.loaded = true;
+    g_vote_options.stale = false;
+    g_vote_options.loaded_generation = static_cast<int>(generation);
+}
+
+const std::optional<ActiveVoteState>& vote_state_get()
+{
+    return g_active_vote;
+}
+
+int vote_state_seconds_remaining()
+{
+    if (!g_active_vote) {
+        return 0;
+    }
+    const int64_t left_ms = g_active_vote->end_timestamp_ms - timer::get_i64(1000);
+    if (left_ms <= 0) {
+        return 0;
+    }
+    return static_cast<int>((left_ms + 999) / 1000);
+}
+
+void vote_state_mark_local_voted()
+{
+    if (g_active_vote) {
+        g_active_vote->has_voted = true;
+    }
+}
+
+void vote_state_on_start(AfVoteType type, uint16_t time_remaining_sec, uint8_t yes, uint8_t no,
+                         uint8_t remaining, bool is_owner, std::string initiator_name,
+                         std::string title)
+{
+    ActiveVoteState state;
+    state.type = type;
+    state.title = std::move(title);
+    state.initiator_name = std::move(initiator_name);
+    state.yes = yes;
+    state.no = no;
+    state.remaining = remaining;
+    // 64-bit monotonic ms; rf::timer::get truncates to 32 bits and wraps.
+    state.end_timestamp_ms = timer::get_i64(1000) + static_cast<int64_t>(time_remaining_sec) * 1000;
+    state.is_owner = is_owner;
+    state.has_voted = is_owner; // the caller's own vote is counted server-side
+    g_active_vote = std::move(state);
+
+    draw_hud_vote_notification(g_active_vote->title);
+
+    // Mirrors the legacy "<title> vote started by <name>." line. The name is
+    // absent when the server couldn't resolve the owner (late joiner sync).
+    std::string by_clause;
+    if (g_active_vote->is_owner) {
+        by_clause = " by you";
+    }
+    else if (!g_active_vote->initiator_name.empty()) {
+        by_clause = std::format(" by {}", g_active_vote->initiator_name);
+    }
+
+    print_vote_chat_line(std::format("\n=============== VOTE STARTING ===============\n{} vote started{}.",
+        g_active_vote->title, by_clause));
+}
+
+void vote_state_on_update(uint8_t yes, uint8_t no, uint8_t remaining)
+{
+    if (!g_active_vote) {
+        return;
+    }
+    g_active_vote->yes = yes;
+    g_active_vote->no = no;
+    g_active_vote->remaining = remaining;
+
+    print_vote_chat_line(std::format("Vote status: Yes: {} No: {} Waiting: {}", yes, no, remaining));
+}
+
+void vote_state_on_end(AfVoteResult result)
+{
+    if (g_active_vote) {
+        print_vote_chat_line(vote_result_text(result));
+    }
+    g_active_vote.reset();
+    remove_hud_vote_notification();
+}
+
+void vote_client_reset()
+{
+    g_active_vote.reset();
+    g_vote_options = VoteOptionsCache{};
+}

--- a/game_patch/multi/vote_client.h
+++ b/game_patch/multi/vote_client.h
@@ -52,11 +52,21 @@ struct VoteLevelInfo
     // knowledge). Always populated, even when the server does not enforce them —
     // see VoteOptionsData::gametype_prefix_restricted for whether it does.
     uint32_t valid_gametype_mask = 0;
+    // The server's vote_level allow-list accepts this level. Derived server-side
+    // from the same predicate that validates an incoming vote, so false means a
+    // vote naming this level is rejected outright whatever game type is picked.
+    // The blob still lists the level because it is in the rotation (rotation
+    // levels are NOT votable unless vote_level.add_rotation_to_allowed_levels is
+    // set or allowed_maps is empty), so a UI must filter on this.
+    bool allowed_for_vote = true;
 };
 
 struct VoteOptionsData
 {
-    uint16_t enabled_vote_mask = 0; // bit N = AfVoteType N is enabled
+    // bit N = AfVoteType N is enabled. u32 so the wire enum has room to grow past
+    // the 9 types of 1.4 (same reasoning as VoteLevelInfo::valid_gametype_mask).
+    // Bits for types this build does not know are simply never queried.
+    uint32_t enabled_vote_mask = 0;
     // vote_level.only_allow_gametype_prefix is on: the server will REJECT a vote
     // whose level fails valid_gametype_mask, so the filter must be applied. When
     // false the mask is still populated and a client may offer it as an opt-in
@@ -75,7 +85,13 @@ bool vote_level_allows_default_gametype(const VoteLevelInfo& level);
 
 struct ActiveVoteState
 {
-    AfVoteType type = AfVoteType::Kick;
+    // The RAW wire byte, deliberately NOT an AfVoteType: a newer server may run a
+    // vote type added after this build, and an old client must still show the
+    // vote, let the player cast, and be counted — being dropped from the tally is
+    // far worse than not knowing what the vote is called. The type is display
+    // metadata for the running vote; the authoritative text is `title`, which the
+    // server composes and always sends.
+    uint8_t type_raw = static_cast<uint8_t>(AfVoteType::Kick);
     std::string title;          // server-composed, display only
     std::string initiator_name; // empty if the server couldn't name the owner
     uint8_t yes = 0;
@@ -84,27 +100,51 @@ struct ActiveVoteState
     int64_t end_timestamp_ms = 0; // timer::get_i64(1000) based
     bool is_owner = false;
     bool has_voted = false; // set locally when this client casts
+
+    // The vote type when this build recognises it. `nullopt` means the server is
+    // running a type added after this build: everything else about the vote still
+    // works, so any type-keyed presentation must degrade to a neutral fallback
+    // (normally just `title`) rather than refusing to display the vote. Going
+    // through this accessor is what keeps a `switch` on the type honest.
+    [[nodiscard]] std::optional<AfVoteType> known_type() const
+    {
+        if (type_raw >= af_vote_type_count) {
+            return std::nullopt;
+        }
+        return static_cast<AfVoteType>(type_raw);
+    }
 };
 
 // --- vote options cache ---
+// True once a blob has been parsed. A cache marked stale still answers true: the
+// data stays usable while a refresh is in flight, because the server answers a
+// refresh request with nothing at all when its generation hasn't changed.
 bool vote_options_are_loaded();
 const VoteOptionsData* vote_options_get();
 bool vote_options_is_type_enabled(AfVoteType type);
 // Ask the server for the blob if it isn't loaded (or went stale). Rate limited.
 void vote_options_request_if_needed();
 void vote_options_mark_stale();
-void vote_options_handle_chunk(uint8_t generation, uint8_t seq, uint8_t total,
-                               const uint8_t* data, size_t len);
+
+// Blob stream (af_sreq_vote_options_data). Ordered reliable delivery, so Begin ->
+// Data* -> End arrive in that order; anything out of order is a protocol error and
+// discards the stream.
+void vote_options_stream_begin(uint32_t generation, uint32_t total_bytes);
+void vote_options_stream_data(uint32_t generation, const uint8_t* data, size_t len);
+void vote_options_stream_end(uint32_t generation);
 
 // --- active vote state ---
 const std::optional<ActiveVoteState>& vote_state_get();
 int vote_state_seconds_remaining();
 void vote_state_mark_local_voted();
-void vote_state_on_start(AfVoteType type, uint16_t time_remaining_sec, uint8_t yes, uint8_t no,
-                         uint8_t remaining, bool is_owner, std::string initiator_name,
+// `type_raw` is the unvalidated wire byte on purpose; see ActiveVoteState.
+void vote_state_on_start(uint8_t type_raw, uint16_t time_remaining_sec, uint8_t yes, uint8_t no,
+                         uint8_t remaining, bool is_owner, bool is_sync, std::string initiator_name,
                          std::string title);
 void vote_state_on_update(uint8_t yes, uint8_t no, uint8_t remaining);
-void vote_state_on_end(AfVoteResult result);
+// `passed` is independent of `result`: a timed-out vote can still pass. `detail`
+// is the server-composed outcome line (empty falls back to generic wording).
+void vote_state_on_end(AfVoteResult result, bool passed, std::string detail);
 
 // Drop every cached vote thing (leaving a server).
 void vote_client_reset();

--- a/game_patch/multi/vote_client.h
+++ b/game_patch/multi/vote_client.h
@@ -48,23 +48,15 @@ struct VoteLevelInfo
     // Game type this level runs with when the vote picks "Server default".
     uint8_t natural_gametype = 0; // rf::NetGameType
     // bit N (matching NetGameType N) = this level matches that game type's level
-    // prefix rules (computed server-side; prefix rules are server-only
-    // knowledge). Always populated, even when the server does not enforce them —
-    // see VoteOptionsData::gametype_prefix_restricted for whether it does.
+    // prefix rules.
     uint32_t valid_gametype_mask = 0;
-    // The server's vote_level allow-list accepts this level. Derived server-side
-    // from the same predicate that validates an incoming vote, so false means a
-    // vote naming this level is rejected outright whatever game type is picked.
-    // The blob still lists the level because it is in the rotation (rotation
-    // levels are NOT votable unless vote_level.add_rotation_to_allowed_levels is
-    // set or allowed_maps is empty), so a UI must filter on this.
+    // The server's vote_level allow-list accepts this level.
     bool allowed_for_vote = true;
 };
 
 struct VoteOptionsData
 {
-    // bit N = AfVoteType N is enabled. u32 so the wire enum has room to grow past
-    // the 9 types of 1.4 (same reasoning as VoteLevelInfo::valid_gametype_mask).
+    // bit N = AfVoteType N is enabled.
     // Bits for types this build does not know are simply never queried.
     uint32_t enabled_vote_mask = 0;
     // vote_level.only_allow_gametype_prefix is on: the server will REJECT a vote
@@ -86,11 +78,7 @@ bool vote_level_allows_default_gametype(const VoteLevelInfo& level);
 struct ActiveVoteState
 {
     // The RAW wire byte, deliberately NOT an AfVoteType: a newer server may run a
-    // vote type added after this build, and an old client must still show the
-    // vote, let the player cast, and be counted — being dropped from the tally is
-    // far worse than not knowing what the vote is called. The type is display
-    // metadata for the running vote; the authoritative text is `title`, which the
-    // server composes and always sends.
+    // vote type added after this build, and an old client must still show it.
     uint8_t type_raw = static_cast<uint8_t>(AfVoteType::Kick);
     std::string title;          // server-composed, display only
     std::string initiator_name; // empty if the server couldn't name the owner

--- a/game_patch/multi/vote_client.h
+++ b/game_patch/multi/vote_client.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <vector>
+#include "alpine_packets.h"
+
+// Client-side mirror of the server's vote system: the vote-options schema blob
+// (what can be voted for) and the state of the vote currently running.
+
+struct VoteGametypeInfo
+{
+    uint8_t id = 0; // rf::NetGameType
+    bool is_team_type = false;
+    std::string name;
+};
+
+struct VoteMutatorOptionSchema
+{
+    uint8_t id = 0;
+    std::string name;  // toml key
+    std::string label; // UI text
+    MutatorOptionType type = MutatorOptionType::Bool;
+
+    // Only the member matching `type` is meaningful.
+    bool default_bool = false;
+    uint8_t default_choice = 0;
+    int32_t default_int = 0;
+    float default_float = 0.0f;
+    std::string default_string;
+
+    std::vector<std::string> choices; // Choice only
+};
+
+struct VoteMutatorSchema
+{
+    uint8_t id = 0;
+    std::string name;  // canonical, keys the client-local description table
+    std::string label; // UI text
+    std::vector<VoteMutatorOptionSchema> options;
+};
+
+struct VoteLevelInfo
+{
+    std::string filename;
+    // Game type this level runs with when the vote picks "Server default".
+    uint8_t natural_gametype = 0; // rf::NetGameType
+    // bit N (matching NetGameType N) = this level matches that game type's level
+    // prefix rules (computed server-side; prefix rules are server-only
+    // knowledge). Always populated, even when the server does not enforce them —
+    // see VoteOptionsData::gametype_prefix_restricted for whether it does.
+    uint32_t valid_gametype_mask = 0;
+};
+
+struct VoteOptionsData
+{
+    uint16_t enabled_vote_mask = 0; // bit N = AfVoteType N is enabled
+    // vote_level.only_allow_gametype_prefix is on: the server will REJECT a vote
+    // whose level fails valid_gametype_mask, so the filter must be applied. When
+    // false the mask is still populated and a client may offer it as an opt-in
+    // filter, but off-prefix votes are accepted.
+    bool gametype_prefix_restricted = false;
+    std::vector<VoteGametypeInfo> gametypes;
+    std::vector<VoteMutatorSchema> mutators;
+    std::vector<VoteLevelInfo> levels; // rotation order, then vote-allowed extras
+};
+
+// Does this level match the given game type's level prefix rules? Whether that
+// is a hard restriction depends on VoteOptionsData::gametype_prefix_restricted.
+bool vote_level_allows_gametype(const VoteLevelInfo& level, uint8_t game_type);
+// Same, for the "Server default" (no gametype override) selection.
+bool vote_level_allows_default_gametype(const VoteLevelInfo& level);
+
+struct ActiveVoteState
+{
+    AfVoteType type = AfVoteType::Kick;
+    std::string title;          // server-composed, display only
+    std::string initiator_name; // empty if the server couldn't name the owner
+    uint8_t yes = 0;
+    uint8_t no = 0;
+    uint8_t remaining = 0;
+    int64_t end_timestamp_ms = 0; // timer::get_i64(1000) based
+    bool is_owner = false;
+    bool has_voted = false; // set locally when this client casts
+};
+
+// --- vote options cache ---
+bool vote_options_are_loaded();
+const VoteOptionsData* vote_options_get();
+bool vote_options_is_type_enabled(AfVoteType type);
+// Ask the server for the blob if it isn't loaded (or went stale). Rate limited.
+void vote_options_request_if_needed();
+void vote_options_mark_stale();
+void vote_options_handle_chunk(uint8_t generation, uint8_t seq, uint8_t total,
+                               const uint8_t* data, size_t len);
+
+// --- active vote state ---
+const std::optional<ActiveVoteState>& vote_state_get();
+int vote_state_seconds_remaining();
+void vote_state_mark_local_voted();
+void vote_state_on_start(AfVoteType type, uint16_t time_remaining_sec, uint8_t yes, uint8_t no,
+                         uint8_t remaining, bool is_owner, std::string initiator_name,
+                         std::string title);
+void vote_state_on_update(uint8_t yes, uint8_t no, uint8_t remaining);
+void vote_state_on_end(AfVoteResult result);
+
+// Drop every cached vote thing (leaving a server).
+void vote_client_reset();

--- a/game_patch/multi/votes.cpp
+++ b/game_patch/multi/votes.cpp
@@ -71,17 +71,44 @@ static AfVoteType vote_type_to_wire(VoteType type)
     }
 }
 
-// Clients that consume af_sreq_vote_state instead of the legacy chat text. The
-// listen-server host always does (its packets are applied locally).
+// The listen-server host is excluded from the vote system entirely: it can
+// neither call a vote (the panel and the F4 bind are gated on !rf::is_server) nor
+// cast one (F1/F2, same gate). Counting it as an eligible voter would dilute every
+// tally and make the "everyone has voted" early finish unreachable forever.
+static bool is_listen_server_host(const rf::Player* player)
+{
+    return rf::is_server && player == rf::local_player;
+}
+
+// Clients that consume af_sreq_vote_state instead of the legacy chat text.
 static bool player_uses_vote_packets(rf::Player* player)
 {
-    if (!player) {
+    if (!player || is_listen_server_host(player)) {
         return false;
     }
-    if (player == rf::local_player) {
-        return true;
-    }
     return is_player_minimum_af_client_version(player, 1, 4, 0);
+}
+
+// Every "you can't do that" reply to a vote action. Each one costs a reliable
+// packet to the sender, and the eligibility ones also pass tell_server=true, which
+// writes a server console line and a log entry — so a client that spams
+// af_req_vote_call / _cast / _cancel floods the server's own output, not just its
+// own chat. Throttled per player, pattern of vote_options_req_timer.
+//
+// Only the REPLY is throttled. The action still runs (and is still rejected) every
+// time, so nothing about the vote's behaviour depends on this.
+static constexpr int vote_reject_msg_cooldown_ms = 1000;
+
+static void send_vote_reject_msg(std::string_view msg, rf::Player* player, bool tell_server = false)
+{
+    if (!player) {
+        return;
+    }
+    if (player->vote_reject_msg_timer.valid() && !player->vote_reject_msg_timer.elapsed()) {
+        return;
+    }
+    player->vote_reject_msg_timer.set(vote_reject_msg_cooldown_ms);
+    af_send_automated_chat_msg(msg, player, tell_server);
 }
 
 static bool player_is_connected(const rf::Player* target)
@@ -142,13 +169,16 @@ public:
     {
         owner = source;
         owner_name = source ? source->name.c_str() : "";
+        start_time = std::time(nullptr);
+
+        // The owner's own yes vote is recorded BEFORE the announcement so the
+        // announced tally is the same compute_tally() every later event uses.
+        players_who_voted.insert({source, true});
+
         announced = true;
         send_vote_starting_msg(source);
 
-        start_time = std::time(nullptr);
         early_finish_check_timer.set(1000);
-
-        players_who_voted.insert({source, true});
 
         return check_for_early_vote_finish();
     }
@@ -157,23 +187,17 @@ public:
     {
         if (player == owner) {
             early_finish_check_timer.invalidate();
-            broadcast_vote_legacy_msg("Vote canceled: owner left the game!");
-            broadcast_vote_end(AfVoteResult::Canceled);
+            emit_vote_end(AfVoteResult::Canceled, false, "Vote canceled: owner left the game!");
             return false;
         }
         players_who_voted.erase(player);
         return check_for_early_vote_finish();
     }
 
-    [[nodiscard]] virtual bool is_allowed_in_limbo_state() const
-    {
-        return true;
-    }
-
     bool add_player_vote(bool is_yes_vote, rf::Player* source)
     {
         if (players_who_voted.count(source) == 1) {
-            af_send_automated_chat_msg("You already voted!", source);
+            send_vote_reject_msg("You already voted!", source);
         }
         else {
             players_who_voted[source] = is_yes_vote;
@@ -230,21 +254,19 @@ public:
     bool try_cancel_vote(rf::Player* source)
     {
         if (owner != source) {
-            af_send_automated_chat_msg("You cannot cancel a vote you didn't start!", source);
+            send_vote_reject_msg("You cannot cancel a vote you didn't start!", source);
             return false;
         }
 
         early_finish_check_timer.invalidate();
-        broadcast_vote_legacy_msg("Vote canceled!");
-        broadcast_vote_end(AfVoteResult::Canceled);
+        emit_vote_end(AfVoteResult::Canceled, false, "Vote canceled!");
         return true;
     }
 
     void cancel_for_limbo()
     {
         early_finish_check_timer.invalidate();
-        broadcast_vote_legacy_msg("Vote canceled!");
-        broadcast_vote_end(AfVoteResult::Canceled);
+        emit_vote_end(AfVoteResult::Canceled, false, "Vote canceled!");
     }
 
     // Bring a player who joined mid-vote up to date.
@@ -266,7 +288,7 @@ public:
         af_send_vote_state_start(player, vote_type_to_wire(get_type()),
                                  static_cast<uint16_t>(seconds_left), clamp_to_u8(tally.yes),
                                  clamp_to_u8(tally.no), clamp_to_u8(tally.remaining),
-                                 player == owner, initiator, get_title());
+                                 player == owner, /*is_sync*/ true, initiator, get_title());
     }
 
     // Run whatever finish_vote() decided. Only VoteMgr calls this, and only on a
@@ -285,7 +307,11 @@ public:
     // Tell every structured client the vote is over. Idempotent: a vote that
     // disappears for any other reason (kick target left, limbo, ...) still gets
     // exactly one end event.
-    void broadcast_vote_end(AfVoteResult result)
+    //
+    // `passed` is carried separately from `result` because they are independent: a
+    // vote that TIMES OUT can still pass. `detail` is the same line legacy clients
+    // are sent as chat, so a 1.4 client can print text equivalent to theirs.
+    void broadcast_vote_end(AfVoteResult result, bool passed, std::string_view detail)
     {
         if (end_event_sent || !announced) {
             return; // a vote rejected during validation was never announced
@@ -293,8 +319,10 @@ public:
         end_event_sent = true;
 
         for (rf::Player& player : SinglyLinkedList{rf::player_list}) {
-            if (player_uses_vote_packets(&player)) {
-                af_send_vote_state_end(&player, result);
+            // Same filter as the start event: a client that never got a start
+            // event must not get updates or an end event either.
+            if (player_uses_vote_packets(&player) && player_meets_alpine_restrict(&player)) {
+                af_send_vote_state_end(&player, result, passed, detail);
             }
         }
     }
@@ -309,15 +337,18 @@ protected:
     [[nodiscard]] virtual std::string get_title() const = 0;
     [[nodiscard]] virtual const VoteConfig& get_config() const = 0;
 
-    virtual void on_accepted()
+    // The one line that describes the outcome. Broadcast as chat to legacy clients
+    // and carried in the structured end event, so both see identical wording.
+    // Called just before the outcome handler runs, so it may read the same state.
+    [[nodiscard]] virtual std::string get_outcome_text(bool accepted) const
     {
-        broadcast_vote_legacy_msg("Vote passed!");
+        return accepted ? "Vote passed!" : "Vote failed!";
     }
 
-    virtual void on_rejected()
-    {
-        broadcast_vote_legacy_msg("Vote failed!");
-    }
+    // Performs the outcome. Deliberately silent: finish_vote() has already
+    // broadcast get_outcome_text().
+    virtual void on_accepted() {}
+    virtual void on_rejected() {}
 
     static uint8_t clamp_to_u8(int value)
     {
@@ -325,28 +356,27 @@ protected:
     }
 
     // Vote chat text goes only to clients that can't receive the structured
-    // events; their sniffing contract depends on these exact strings. The
-    // console line matches af_broadcast_automated_chat_msg so dedicated server
-    // output is unchanged.
+    // events; their sniffing contract depends on these exact strings. The console
+    // line matches af_broadcast_automated_chat_msg so dedicated server output is
+    // unchanged, and the packet is built once for the whole broadcast.
     static void broadcast_vote_legacy_msg(std::string_view msg)
     {
-        rf::console::print("Server: {}", msg);
+        af_broadcast_vote_legacy_chat_msg(msg);
+    }
 
-        for (rf::Player& player : SinglyLinkedList{rf::player_list}) {
-            if (&player == rf::local_player) {
-                continue;
-            }
-            if (player_uses_vote_packets(&player)) {
-                continue;
-            }
-            af_send_automated_chat_msg(msg, &player);
-        }
+    // Ends the vote for everyone: the legacy chat line (which is also the server
+    // console line) and the structured end event carrying that same text, so both
+    // client generations are told the same thing.
+    void emit_vote_end(AfVoteResult result, bool passed, std::string_view detail)
+    {
+        broadcast_vote_legacy_msg(detail);
+        broadcast_vote_end(result, passed, detail);
     }
 
     void broadcast_vote_update(const VoteTally& tally)
     {
         for (rf::Player& player : SinglyLinkedList{rf::player_list}) {
-            if (player_uses_vote_packets(&player)) {
+            if (player_uses_vote_packets(&player) && player_meets_alpine_restrict(&player)) {
                 af_send_vote_state_update(&player, clamp_to_u8(tally.yes), clamp_to_u8(tally.no),
                                           clamp_to_u8(tally.remaining));
             }
@@ -362,8 +392,10 @@ protected:
         auto title = get_title();
         std::string base_msg = std::format("{} vote started by {}.\n", title, source->name);
 
-        // print to server console
-        rf::console::printf(base_msg.c_str());
+        // print to server console. NEVER pass this through console::printf: it is
+        // a varargs vsnprintf, and base_msg embeds the player name and the voted
+        // level name, so a remote client could supply the format string.
+        rf::console::print("{}", base_msg);
 
         // Prepare messages for legacy players
         std::string msg_non_alpine = "\n=============== VOTE STARTING ===============\n" + base_msg +
@@ -373,8 +405,14 @@ protected:
 
         const int time_limit = std::max(0, get_config().time_limit_seconds);
 
+        // start() already recorded the owner's yes vote, so this is the exact same
+        // tally the update/timeout paths compute — not an open-coded
+        // "eligible voters - 1", which disagreed whenever the owner was not
+        // themselves an eligible voter.
+        const VoteTally tally = compute_tally();
+
         for (rf::Player* player : get_clients(false, false)) {
-            if (!player) {
+            if (!player || is_listen_server_host(player)) {
                 continue;
             }
 
@@ -383,11 +421,10 @@ protected:
             }
 
             if (player_uses_vote_packets(player)) {
-                // The vote owner's own yes vote is already counted.
                 af_send_vote_state_start(player, vote_type_to_wire(get_type()),
-                                         static_cast<uint16_t>(time_limit), 1, 0,
-                                         clamp_to_u8(count_eligible_voters() - 1), player == source,
-                                         owner_name, title);
+                                         static_cast<uint16_t>(time_limit), clamp_to_u8(tally.yes),
+                                         clamp_to_u8(tally.no), clamp_to_u8(tally.remaining),
+                                         player == source, /*is_sync*/ false, owner_name, title);
                 continue;
             }
 
@@ -411,7 +448,11 @@ protected:
     {
         early_finish_check_timer.invalidate();
 
-        broadcast_vote_end(result.value_or(is_accepted ? AfVoteResult::Passed : AfVoteResult::Failed));
+        // The outcome TEXT is produced here rather than inside on_accepted() so the
+        // end event can carry it. It only reads state the outcome handler has not
+        // touched yet (both run in the same frame, back to back via conclude()).
+        emit_vote_end(result.value_or(is_accepted ? AfVoteResult::Passed : AfVoteResult::Failed),
+                      is_accepted, get_outcome_text(is_accepted));
 
         pending_outcome = is_accepted ? Outcome::Accepted : Outcome::Rejected;
     }
@@ -419,6 +460,9 @@ protected:
     static bool is_eligible_voter(rf::Player* const p) {
         if (!p) {
             return false;
+        }
+        if (is_listen_server_host(p)) {
+            return false; // has no way to vote at all; see is_listen_server_host
         }
         if (p->version_info.software == ClientSoftware::Browser
             || p->is_bot
@@ -429,17 +473,10 @@ protected:
         return true;
     }
 
-    static int count_eligible_voters()
-    {
-        int count = 0;
-        for (auto* p : get_clients(false, false)) {
-            if (is_eligible_voter(p)) {
-                ++count;
-            }
-        }
-        return count;
-    }
-
+    // Every count that is shown or acted on comes from here, so the announcement,
+    // the live updates, the early-finish check and the timeout can never disagree.
+    // (There used to be a separate count_eligible_voters() used only by the
+    // announcement, which produced a different "waiting" number.)
     [[nodiscard]] VoteTally compute_tally() const
     {
         VoteTally tally;
@@ -602,42 +639,56 @@ static uint32_t build_level_valid_gametype_mask(const std::string& level_name)
     return mask;
 }
 
-static bool is_level_allowed_for_vote(const std::string& level_name, rf::Player* source,
-                                      rf::NetGameType effective_game_type)
+// The allow-list arm of vote validation, as a pure predicate: is this level one
+// the server permits votes for at all, independent of game type? Note that a level
+// merely being in the ROTATION is not enough — with a non-empty allowed_maps and
+// add_rotation_to_allowed_levels off (the default) rotation levels are refused.
+// The blob advertises the answer per level so a client can filter its map list
+// instead of offering votes the server will reject.
+static bool is_level_in_vote_allow_list(const std::string& level_name)
 {
     const auto& vote_level_cfg = g_alpine_server_config.vote_level;
-
-    // Checked against the game type the level will run with once the vote
-    // applies, not the one currently running.
-    if (!is_level_valid_for_vote_gametype(level_name, effective_game_type)) {
-        auto msg = std::format("Cannot start vote: level {} does not match the {} gametype!", level_name,
-                               multi_game_type_name_short(effective_game_type));
-        af_send_automated_chat_msg(msg, source);
-        return false; // level does not match gametype prefix
-    }
 
     if (vote_level_cfg.allowed_maps.empty() && !vote_level_cfg.add_rotation_to_allowed_levels) {
         return true; // no allowed_levels configured and not adding rotation, so all levels are allowed
     }
 
-    std::vector<std::string> allowed_maps = vote_level_cfg.allowed_maps;
+    const auto matches = [&](const std::string& allowed_name) {
+        return string_iequals(allowed_name, level_name);
+    };
+
+    if (std::any_of(vote_level_cfg.allowed_maps.begin(), vote_level_cfg.allowed_maps.end(), matches)) {
+        return true;
+    }
+
     if (vote_level_cfg.add_rotation_to_allowed_levels) {
         for (const auto& level_entry : g_alpine_server_config.levels) {
-            allowed_maps.push_back(level_entry.level_filename);
+            if (matches(level_entry.level_filename)) {
+                return true;
+            }
         }
     }
 
-    if (allowed_maps.empty()) {
-        return true; // still empty after all, so all levels are allowed
+    // allowed_maps empty but add_rotation_to_allowed_levels on and the rotation is
+    // empty too: nothing was configured, so everything is allowed.
+    return vote_level_cfg.allowed_maps.empty() && g_alpine_server_config.levels.empty();
+}
+
+static bool is_level_allowed_for_vote(const std::string& level_name, rf::Player* source,
+                                      rf::NetGameType effective_game_type)
+{
+    // Checked against the game type the level will run with once the vote
+    // applies, not the one currently running.
+    if (!is_level_valid_for_vote_gametype(level_name, effective_game_type)) {
+        auto msg = std::format("Cannot start vote: level {} does not match the {} gametype!", level_name,
+                               multi_game_type_name_short(effective_game_type));
+        send_vote_reject_msg(msg, source);
+        return false; // level does not match gametype prefix
     }
 
-    const bool is_allowed = std::any_of(
-        allowed_maps.begin(), allowed_maps.end(),
-        [&](const std::string& allowed_name) { return string_iequals(allowed_name, level_name); });
-
-    if (!is_allowed) {
+    if (!is_level_in_vote_allow_list(level_name)) {
         auto msg = std::format("Cannot start vote: the server does not allow voting for level {}!", level_name);
-        af_send_automated_chat_msg(msg, source);
+        send_vote_reject_msg(msg, source);
         return false; // level not in allowed_levels
     }
 
@@ -681,7 +732,7 @@ struct VoteMatch : public Vote
     bool validate(rf::Player* source) override
     {
         if (m_team_size < 1 || m_team_size > 8) {
-            af_send_automated_chat_msg("Invalid match size! Supported sizes are 1v1 up to 8v8.", source);
+            send_vote_reject_msg("Invalid match size! Supported sizes are 1v1 up to 8v8.", source);
             return false;
         }
 
@@ -691,7 +742,7 @@ struct VoteMatch : public Vote
         else {
             auto [is_valid, normalized_name] = is_level_name_valid(m_level_name);
             if (!is_valid) {
-                af_send_automated_chat_msg(
+                send_vote_reject_msg(
                     "Invalid level specified! Try again, or omit level filename to use the current level.", source);
                 return false;
             }
@@ -700,9 +751,11 @@ struct VoteMatch : public Vote
 
         // A match on the current level with no rules override keeps the level
         // (and therefore its active rules) exactly as they are; anything else
-        // re-resolves from the level's natural rules.
+        // re-resolves from the level's natural rules. Level names are compared
+        // case-insensitively: they come from a client packet, a config file and the
+        // engine, none of which agree on case.
         const bool builds_override = !m_mutators.empty() || m_gametype.has_value();
-        const bool using_current_level = m_level_name == rf::level.filename.c_str();
+        const bool using_current_level = string_iequals(m_level_name, rf::level.filename.c_str());
         const rf::NetGameType effective_game_type = resolve_effective_vote_game_type(
             m_level_name, m_gametype, builds_override, using_current_level);
 
@@ -711,23 +764,24 @@ struct VoteMatch : public Vote
         }
 
         if (!multi_game_type_is_team_type(g_alpine_server_config.base_rules.game_type)) {
-            af_send_automated_chat_msg("Cannot start vote: server base game type is not a team game type.", source);
+            send_vote_reject_msg("Cannot start vote: server base game type is not a team game type.", source);
             return false;
         }
 
         // The match must end up on a team game type — evaluated against what will
         // actually apply, not the base rules.
         if (!multi_game_type_is_team_type(effective_game_type)) {
-            af_send_automated_chat_msg("Cannot start vote: matches must be played on a team game type.", source);
+            send_vote_reject_msg("Cannot start vote: matches must be played on a team game type.", source);
             return false;
         }
 
         m_manual_rules_override = load_vote_rules_override(m_level_name, m_mutators, m_gametype);
         m_mutator_labels = mutators_join_labels(m_mutators);
 
-        // Only touch the shared match state once every check has passed.
-        g_match_info.team_size = m_team_size;
-        g_match_info.match_level_name = m_level_name;
+        // Deliberately does NOT touch g_match_info: validation passing only means
+        // the vote may be PUT, not that it wins. Writing team_size /
+        // match_level_name here left them pointing at a match nobody agreed to for
+        // every vote that was voted down. on_accepted() publishes them instead.
         return true;
     }
 
@@ -737,34 +791,60 @@ struct VoteMatch : public Vote
                            build_rules_title_suffix(m_gametype, m_mutator_labels));
     }
 
-    void on_accepted() override
+    // How the accepted match will actually start. Computed by both the outcome text
+    // and the outcome action; the two run back to back on unchanged state.
+    struct MatchStartPlan
     {
-        const bool match_level_is_current = (g_match_info.match_level_name == rf::level.filename.c_str());
+        bool level_is_current = false;
+        bool using_current_level = false;
+    };
 
-        bool match_game_type_matches_current = true;
-        if (match_level_is_current) {
-            rf::NetGameType desired_game_type = rf::netgame.type;
-            if (m_manual_rules_override)
-                desired_game_type = m_manual_rules_override->rules.game_type;
-            else
-                desired_game_type = g_alpine_server_config_active_rules.game_type;
+    [[nodiscard]] MatchStartPlan plan_match_start() const
+    {
+        MatchStartPlan plan;
+        // m_level_name, not g_match_info.match_level_name: this runs before
+        // on_accepted() publishes the match state, and it is the vote's own level
+        // that matters anyway.
+        plan.level_is_current = string_iequals(m_level_name, rf::level.filename.c_str());
 
-            match_game_type_matches_current = (desired_game_type == rf::netgame.type);
+        bool game_type_matches_current = true;
+        if (plan.level_is_current) {
+            const rf::NetGameType desired_game_type =
+                m_manual_rules_override ? m_manual_rules_override->rules.game_type
+                                        : g_alpine_server_config_active_rules.game_type;
+            game_type_matches_current = (desired_game_type == rf::netgame.type);
         }
 
-        const bool using_current_level = match_level_is_current && match_game_type_matches_current;
-        const char* detail = using_current_level ? "Entering pre-match ready up phase"
-                             : match_level_is_current
-                                 ? "Restarting level to apply match game type, then entering pre-match ready up phase"
-                                 : "Changing to match level, then entering pre-match ready up phase";
+        plan.using_current_level = plan.level_is_current && game_type_matches_current;
+        return plan;
+    }
 
-        std::string msg;
-        if (!m_mutator_labels.empty())
-            msg = std::format("Vote passed. {} (mutators: {}).", detail, m_mutator_labels);
-        else
-            msg = std::format("Vote passed. {}.", detail);
-        broadcast_vote_legacy_msg(msg);
+    [[nodiscard]] std::string get_outcome_text(bool accepted) const override
+    {
+        if (!accepted) {
+            return Vote::get_outcome_text(false);
+        }
 
+        const MatchStartPlan plan = plan_match_start();
+        const char* detail = plan.using_current_level
+                                 ? "Entering pre-match ready up phase"
+                                 : plan.level_is_current
+                                       ? "Restarting level to apply match game type, then entering pre-match ready up phase"
+                                       : "Changing to match level, then entering pre-match ready up phase";
+
+        if (!m_mutator_labels.empty()) {
+            return std::format("Vote passed. {} (mutators: {}).", detail, m_mutator_labels);
+        }
+        return std::format("Vote passed. {}.", detail);
+    }
+
+    void on_accepted() override
+    {
+        const bool using_current_level = plan_match_start().using_current_level;
+
+        // Publish the match state only now that the vote has actually passed.
+        g_match_info.team_size = m_team_size;
+        g_match_info.match_level_name = m_level_name;
         g_match_info.pre_match_queued = true;
 
         if (using_current_level) {
@@ -775,12 +855,12 @@ struct VoteMatch : public Vote
             }
             start_pre_match();
         }
-        else if (!g_match_info.match_level_name.empty()) {
+        else if (!m_level_name.empty()) {
             if (!m_manual_rules_override)
                 clear_manual_rules_override();
             if (m_gametype)
                 set_upcoming_game_type(*m_gametype, UpcomingGameTypeSelection::ExplicitRequest);
-            multi_change_level_alpine(g_match_info.match_level_name.c_str());
+            multi_change_level_alpine(m_level_name.c_str());
             if (m_manual_rules_override) {
                 set_manual_rules_override(std::move(*m_manual_rules_override));
                 m_manual_rules_override.reset();
@@ -809,17 +889,20 @@ struct VoteCancelMatch : public Vote
     bool validate(rf::Player* source) override
     {
         if (!g_match_info.match_active && !g_match_info.pre_match_active) {
-            af_send_automated_chat_msg("No active or queued match to cancel.", source);
+            send_vote_reject_msg("No active or queued match to cancel.", source);
             return false;
         }
 
         return true;
     }
 
+    [[nodiscard]] std::string get_outcome_text(bool accepted) const override
+    {
+        return accepted ? "Vote passed: The match has been canceled." : Vote::get_outcome_text(false);
+    }
+
     void on_accepted() override
     {
-        broadcast_vote_legacy_msg("Vote passed: The match has been canceled.");
-
         cancel_match();
     }
 
@@ -833,8 +916,15 @@ struct VoteCancelMatch : public Vote
 struct VoteKick : public Vote
 {
     rf::Player* m_target_player;
+    // Captured once, at construction, and used instead of m_target_player for the
+    // kick itself: the outcome runs a frame later, by which time the pointer could
+    // name a destroyed player. -1 means "never resolvable".
+    int m_target_player_id = -1;
 
-    explicit VoteKick(rf::Player* target) : m_target_player(target) {}
+    explicit VoteKick(rf::Player* target)
+        : m_target_player(target),
+          m_target_player_id(target && target->net_data ? static_cast<int>(target->net_data->player_id) : -1)
+    {}
 
     VoteType get_type() const override
     {
@@ -843,8 +933,26 @@ struct VoteKick : public Vote
 
     bool validate(rf::Player* source) override
     {
-        if (!m_target_player) {
-            af_send_automated_chat_msg("Cannot start vote: that player is no longer on the server.", source);
+        if (!m_target_player || m_target_player_id < 0) {
+            send_vote_reject_msg("Cannot start vote: that player is no longer on the server.", source);
+            return false;
+        }
+        // A kick target arrives as a raw player id, so it can name things the chat
+        // path could never reach by name.
+        if (is_listen_server_host(m_target_player)) {
+            send_vote_reject_msg("Cannot start vote: the server host cannot be kicked.", source);
+            return false;
+        }
+        if (m_target_player->is_browser) {
+            send_vote_reject_msg("Cannot start vote: that connection is a server browser, not a player.",
+                                       source);
+            return false;
+        }
+        // Self-kick is disallowed: it is a no-op the caller can already do by
+        // disconnecting, it passes instantly (the caller's own yes vote decides it),
+        // and it matches the `kick` console command's "You cannot kick yourself!".
+        if (m_target_player == source) {
+            send_vote_reject_msg("Cannot start vote: you cannot vote to kick yourself.", source);
             return false;
         }
         return true;
@@ -855,16 +963,41 @@ struct VoteKick : public Vote
         return std::format("KICK PLAYER '{}'", m_target_player->name);
     }
 
+    [[nodiscard]] std::string get_outcome_text(bool accepted) const override
+    {
+        return accepted ? "Vote passed: kicking player" : Vote::get_outcome_text(false);
+    }
+
     void on_accepted() override
     {
-        broadcast_vote_legacy_msg("Vote passed: kicking player");
-        rf::multi_kick_player(m_target_player);
+        // NEVER destroy a player from a vote outcome. on_accepted() normally runs
+        // inside the engine's packet receive loop (0x004791F0) — the deciding vote
+        // arrives as a packet — and that loop caches player_list->next BEFORE
+        // dispatching each packet. rf::multi_kick_player unlinks the target, frees its
+        // net_data and deletes the rf::Player, so if the target happened to be the
+        // cached successor the loop then reads net_data off freed memory on its next
+        // iteration: access violation at 0x00479299. (The engine re-checks only the
+        // player it is currently servicing, via 0x004A4E10.)
+        //
+        // Queue by player id — not a pointer — and let process_delayed_kicks() in
+        // server_do_frame() do it once packet dispatch has unwound.
+        if (m_target_player_id < 0) {
+            return;
+        }
+        if (rf::Player* target = rf::multi_find_player_by_id(static_cast<uint8_t>(m_target_player_id))) {
+            kick_player_delayed(target);
+        }
     }
 
     bool on_player_leave(rf::Player* player) override
     {
         if (m_target_player == player) {
-            return false; // the end event goes out when the vote is destroyed
+            // The player being voted on left, so the vote is moot. Announce it like
+            // any other cancellation rather than letting the vote vanish with no
+            // explanation (legacy clients used to be told nothing at all here).
+            // m_target_player is not dereferenced: it may already be destroyed.
+            emit_vote_end(AfVoteResult::Canceled, false, "Vote canceled: the player left the game!");
+            return false;
         }
         return Vote::on_player_leave(player);
     }
@@ -887,15 +1020,14 @@ struct VoteExtend : public Vote
         return "EXTEND ROUND BY 5 MINUTES";
     }
 
-    void on_accepted() override
+    [[nodiscard]] std::string get_outcome_text(bool accepted) const override
     {
-        broadcast_vote_legacy_msg("Vote passed: extending round");
-        extend_round_time(5);
+        return accepted ? "Vote passed: extending round" : Vote::get_outcome_text(false);
     }
 
-    [[nodiscard]] bool is_allowed_in_limbo_state() const override
+    void on_accepted() override
     {
-        return false;
+        extend_round_time(5);
     }
 
     [[nodiscard]] const VoteConfig& get_config() const override
@@ -928,7 +1060,7 @@ struct VoteLevel : public Vote
 
         if (!is_valid) {
             auto msg = std::format("Cannot start vote: level {} is not available on the server!", level_name);
-            af_send_automated_chat_msg(msg, source);
+            send_vote_reject_msg(msg, source);
             return false;
         }
 
@@ -955,13 +1087,18 @@ struct VoteLevel : public Vote
                            build_rules_title_suffix(m_gametype, m_mutator_labels));
     }
 
+    [[nodiscard]] std::string get_outcome_text(bool accepted) const override
+    {
+        if (!accepted) {
+            return Vote::get_outcome_text(false);
+        }
+        return std::format("Vote passed: changing level to {}{}", m_level_name,
+                           build_rules_title_suffix(m_gametype, m_mutator_labels));
+    }
+
     void on_accepted() override
     {
         clear_manual_rules_override();
-
-        std::string msg = std::format("Vote passed: changing level to {}{}", m_level_name,
-                                      build_rules_title_suffix(m_gametype, m_mutator_labels));
-        broadcast_vote_legacy_msg(msg);
 
         if (m_gametype) {
             set_upcoming_game_type(*m_gametype, UpcomingGameTypeSelection::ExplicitRequest);
@@ -973,11 +1110,6 @@ struct VoteLevel : public Vote
             set_manual_rules_override(std::move(*m_manual_rules_override));
             m_manual_rules_override.reset();
         }
-    }
-
-    [[nodiscard]] bool is_allowed_in_limbo_state() const override
-    {
-        return false;
     }
 
     [[nodiscard]] const VoteConfig& get_config() const override
@@ -999,15 +1131,14 @@ struct VoteRestart : public Vote
         return "RESTART LEVEL";
     }
 
-    void on_accepted() override
+    [[nodiscard]] std::string get_outcome_text(bool accepted) const override
     {
-        broadcast_vote_legacy_msg("Vote passed: restarting level");
-        restart_current_level();
+        return accepted ? "Vote passed: restarting level" : Vote::get_outcome_text(false);
     }
 
-    [[nodiscard]] bool is_allowed_in_limbo_state() const override
+    void on_accepted() override
     {
-        return false;
+        restart_current_level();
     }
 
     [[nodiscard]] const VoteConfig& get_config() const override
@@ -1028,15 +1159,14 @@ struct VoteNext : public Vote
         return "LOAD NEXT LEVEL";
     }
 
-    void on_accepted() override
+    [[nodiscard]] std::string get_outcome_text(bool accepted) const override
     {
-        broadcast_vote_legacy_msg("Vote passed: loading next level");
-        load_next_level();
+        return accepted ? "Vote passed: loading next level" : Vote::get_outcome_text(false);
     }
 
-    [[nodiscard]] bool is_allowed_in_limbo_state() const override
+    void on_accepted() override
     {
-        return false;
+        load_next_level();
     }
 
     [[nodiscard]] const VoteConfig& get_config() const override
@@ -1057,17 +1187,16 @@ struct VoteRandom : public Vote
         return "LOAD RANDOM LEVEL";
     }
 
-    void on_accepted() override
+    [[nodiscard]] std::string get_outcome_text(bool accepted) const override
     {
-        broadcast_vote_legacy_msg("Vote passed: loading random level from rotation");
-
-        // if dynamic rotation is on, just load the next level
-        g_alpine_server_config.dynamic_rotation ? load_next_level() : load_rand_level();
+        return accepted ? "Vote passed: loading random level from rotation"
+                        : Vote::get_outcome_text(false);
     }
 
-    [[nodiscard]] bool is_allowed_in_limbo_state() const override
+    void on_accepted() override
     {
-        return false;
+        // if dynamic rotation is on, just load the next level
+        g_alpine_server_config.dynamic_rotation ? load_next_level() : load_rand_level();
     }
 
     [[nodiscard]] const VoteConfig& get_config() const override
@@ -1088,15 +1217,14 @@ struct VotePrevious : public Vote
         return "LOAD PREV LEVEL";
     }
 
-    void on_accepted() override
+    [[nodiscard]] std::string get_outcome_text(bool accepted) const override
     {
-        broadcast_vote_legacy_msg("Vote passed: loading previous level");
-        load_prev_level();
+        return accepted ? "Vote passed: loading previous level" : Vote::get_outcome_text(false);
     }
 
-    [[nodiscard]] bool is_allowed_in_limbo_state() const override
+    void on_accepted() override
     {
-        return false;
+        load_prev_level();
     }
 
     [[nodiscard]] const VoteConfig& get_config() const override
@@ -1122,8 +1250,9 @@ private:
             return;
         }
         // Guarantees exactly one end event on every path that drops a vote,
-        // including the ones with no outcome (kick target left, limbo).
-        vote->broadcast_vote_end(AfVoteResult::Canceled);
+        // including the ones with no outcome (kick target left, limbo). Idempotent,
+        // so a path that already emitted its own end event is unaffected.
+        vote->broadcast_vote_end(AfVoteResult::Canceled, false, "Vote canceled!");
         vote->run_pending_outcome();
     }
 
@@ -1132,24 +1261,28 @@ public:
     bool StartVote(rf::Player* source, Args&&... args)
     {
         if (active_vote) {
-            af_send_automated_chat_msg("Another vote is currently in progress!", source);
+            send_vote_reject_msg("Another vote is currently in progress!", source);
             return false;
         }
 
         auto vote = std::make_unique<T>(std::forward<Args>(args)...);
 
         if (!vote->get_config().enabled) {
-            af_send_automated_chat_msg("This vote type is disabled!", source);
+            send_vote_reject_msg("This vote type is disabled!", source);
             return false;
         }
 
-        if (!vote->is_allowed_in_limbo_state() && rf::gameseq_get_state() != rf::GS_GAMEPLAY) {
-            af_send_automated_chat_msg("Vote cannot be started now!", source);
+        // No vote of any type may be called between levels / at end of match: the
+        // level it would act on is already gone, and OnLimboStateEnter would
+        // cancel it immediately anyway.
+        if (rf::gameseq_get_state() != rf::GS_GAMEPLAY) {
+            send_vote_reject_msg("Votes cannot be called between levels. Try again once the next level starts.",
+                                       source);
             return false;
         }
 
         if (vote->get_type() == VoteType::Match && (g_match_info.pre_match_active || g_match_info.match_active)) {
-            af_send_automated_chat_msg(
+            send_vote_reject_msg(
                 "A match is already queued or in progress. Finish it before starting a new one.", source);
             return false;
         }
@@ -1179,16 +1312,21 @@ public:
 
     void OnLimboStateEnter()
     {
-        if (active_vote && !active_vote->is_allowed_in_limbo_state()) {
+        // Any active vote dies with the level it was called on, whatever its type
+        // — a vote's premise (this level, these players) no longer holds after a
+        // map change. Routed through conclude() so the exactly-once end event is
+        // structural rather than something each drop site has to remember.
+        if (active_vote) {
             std::unique_ptr<Vote> vote = std::move(active_vote);
             vote->cancel_for_limbo();
+            conclude(std::move(vote));
         }
     }
 
     void add_player_vote(bool is_yes_vote, rf::Player* source)
     {
         if (!active_vote) {
-            af_send_automated_chat_msg("No vote in progress!", source);
+            send_vote_reject_msg("No vote in progress!", source);
             return;
         }
 
@@ -1200,7 +1338,7 @@ public:
     void try_cancel_vote(rf::Player* source)
     {
         if (!active_vote) {
-            af_send_automated_chat_msg("No vote in progress!", source);
+            send_vote_reject_msg("No vote in progress!", source);
             return;
         }
 
@@ -1234,7 +1372,10 @@ VoteMgr g_vote_mgr;
 // ============================================================================
 
 static std::vector<uint8_t> g_vote_options_blob;
-static uint8_t g_vote_options_generation = 0;
+// Wide enough that it can never wrap. A u8 wrapped every 256 rebuilds (a rotation
+// shuffle bumps it once per cycle), and a client holding a stale blob at a
+// recurring generation would then never refresh.
+static uint32_t g_vote_options_generation = 0;
 static bool g_vote_options_blob_valid = false;
 
 static void blob_u8(std::vector<uint8_t>& blob, uint8_t value)
@@ -1276,12 +1417,60 @@ static void blob_str(std::vector<uint8_t>& blob, std::string_view value)
     blob.insert(blob.end(), value.begin(), value.begin() + len);
 }
 
-static uint16_t build_enabled_vote_mask()
+// Writes a record whose body is preceded by its own length, so a client that
+// cannot make sense of the body (unknown option type, extra trailing fields a
+// newer server added) can step over it and keep the rest of the blob intact.
+// `write_body` appends the body; the length is patched in afterwards by INDEX,
+// never through a pointer, because the body write reallocates the vector.
+// EVERY repeated record in the blob goes through one of these two helpers.
+template<typename WriteBody>
+static void blob_sized_u8(std::vector<uint8_t>& blob, WriteBody&& write_body)
+{
+    const size_t len_pos = blob.size();
+    blob.push_back(0);
+    write_body();
+    const size_t body_len = blob.size() - len_pos - 1;
+    // A descriptor body that doesn't fit its length prefix would desync every
+    // client, so truncate the body rather than lie about its length.
+    if (body_len > 255) {
+        xlog::error("vote options: descriptor body of {} bytes exceeds the u8 length prefix; truncating",
+                    body_len);
+        blob.resize(len_pos + 1 + 255);
+        blob[len_pos] = 255;
+        return;
+    }
+    blob[len_pos] = static_cast<uint8_t>(body_len);
+}
+
+template<typename WriteBody>
+static void blob_sized_u16(std::vector<uint8_t>& blob, WriteBody&& write_body)
+{
+    const size_t len_pos = blob.size();
+    blob.push_back(0);
+    blob.push_back(0);
+    write_body();
+    const size_t body_len = blob.size() - len_pos - 2;
+    if (body_len > 65535) {
+        xlog::error("vote options: descriptor body of {} bytes exceeds the u16 length prefix; truncating",
+                    body_len);
+        blob.resize(len_pos + 2 + 65535);
+        blob[len_pos] = 0xFF;
+        blob[len_pos + 1] = 0xFF;
+        return;
+    }
+    blob[len_pos] = static_cast<uint8_t>(body_len & 0xFF);
+    blob[len_pos + 1] = static_cast<uint8_t>((body_len >> 8) & 0xFF);
+}
+
+// u32 rather than u16: 16 bits left only seven spare vote types, and widening it
+// after release would be a breaking blob change. Same reasoning as
+// build_level_valid_gametype_mask.
+static uint32_t build_enabled_vote_mask()
 {
     const auto& cfg = g_alpine_server_config;
-    const auto bit = [](AfVoteType type) { return static_cast<uint16_t>(1u << static_cast<unsigned>(type)); };
+    const auto bit = [](AfVoteType type) { return static_cast<uint32_t>(1u << static_cast<unsigned>(type)); };
 
-    uint16_t mask = 0;
+    uint32_t mask = 0;
     if (cfg.vote_kick.enabled) mask |= bit(AfVoteType::Kick);
     if (cfg.vote_level.enabled) mask |= bit(AfVoteType::Level);
     if (cfg.vote_match.enabled) mask |= bit(AfVoteType::Match) | bit(AfVoteType::CancelMatch);
@@ -1297,7 +1486,7 @@ static void build_vote_options_blob(std::vector<uint8_t>& blob)
 {
     blob.clear();
     blob_u8(blob, af_vote_options_blob_version);
-    blob_u16(blob, build_enabled_vote_mask());
+    blob_u32(blob, build_enabled_vote_mask());
 
     // server-wide vote flags
     uint8_t server_flags = 0;
@@ -1306,63 +1495,93 @@ static void build_vote_options_blob(std::vector<uint8_t>& blob)
     }
     blob_u8(blob, server_flags);
 
-    // game types
+    // Game types. Length-prefixed per entry (u16, not u8: display_name alone can be
+    // 255 bytes plus the fixed fields), so per-gametype data can be appended inside
+    // the entry later without desyncing an older client.
     const int gametype_count = static_cast<int>(rf::NG_TYPE_GG) + 1;
     blob_u8(blob, static_cast<uint8_t>(gametype_count));
     for (int i = 0; i < gametype_count; ++i) {
         const auto game_type = static_cast<rf::NetGameType>(i);
-        blob_u8(blob, static_cast<uint8_t>(i));
-        blob_u8(blob, multi_game_type_is_team_type(game_type) ? AF_VOTE_GAMETYPE_FLAG_TEAM : 0);
-        blob_str(blob, multi_game_type_name(game_type));
+        blob_sized_u16(blob, [&] {
+            blob_u8(blob, static_cast<uint8_t>(i));
+            blob_u8(blob, multi_game_type_is_team_type(game_type) ? AF_VOTE_GAMETYPE_FLAG_TEAM : 0);
+            blob_str(blob, multi_game_type_name(game_type));
+        });
     }
 
-    // mutators
+    // Mutators. Every loop below iterates the CLAMPED count, not the container, so
+    // the declared count always matches the number of entries written.
+    //
+    // Both descriptor levels are length-prefixed, which is what makes the schema
+    // additive: a future mutator with an option type this client has never heard of
+    // still parses, minus that option, and a mutator whose descriptor makes no
+    // sense at all is skipped without desyncing the levels section behind it.
     const auto& registry = mutators_get_registry();
-    blob_u8(blob, static_cast<uint8_t>(std::min<size_t>(registry.size(), 255)));
-    for (const auto& mutator : registry) {
-        blob_u8(blob, static_cast<uint8_t>(mutator.id));
-        blob_str(blob, mutator.name);
-        blob_str(blob, mutator.label);
-        blob_u8(blob, static_cast<uint8_t>(std::min<size_t>(mutator.options.size(), 255)));
-        for (const auto& option : mutator.options) {
-            blob_u8(blob, option.id);
-            blob_str(blob, option.name);
-            blob_str(blob, option.label);
-            blob_u8(blob, static_cast<uint8_t>(option.type));
-            switch (option.type) {
-                case MutatorOptionType::Bool:
-                    blob_u8(blob, option.default_bool ? 1 : 0);
-                    break;
-                case MutatorOptionType::Choice:
-                    blob_u8(blob, option.default_choice);
-                    break;
-                case MutatorOptionType::Int:
-                    blob_i32(blob, option.default_int);
-                    break;
-                case MutatorOptionType::Float:
-                    blob_f32(blob, option.default_float);
-                    break;
-                case MutatorOptionType::String:
-                    blob_str(blob, option.default_string);
-                    break;
+    const size_t mutator_count = std::min<size_t>(registry.size(), 255);
+    blob_u8(blob, static_cast<uint8_t>(mutator_count));
+    for (size_t m = 0; m < mutator_count; ++m) {
+        const MutatorInfo& mutator = registry[m];
+        blob_sized_u16(blob, [&] {
+            blob_u8(blob, static_cast<uint8_t>(mutator.id));
+            blob_str(blob, mutator.name);
+            blob_str(blob, mutator.label);
+            const size_t option_count = std::min<size_t>(mutator.options.size(), 255);
+            blob_u8(blob, static_cast<uint8_t>(option_count));
+            for (size_t o = 0; o < option_count; ++o) {
+                const MutatorOptionInfo& option = mutator.options[o];
+                blob_sized_u8(blob, [&] {
+                    blob_u8(blob, option.id);
+                    blob_str(blob, option.name);
+                    blob_str(blob, option.label);
+                    blob_u8(blob, static_cast<uint8_t>(option.type));
+                    switch (option.type) {
+                        case MutatorOptionType::Bool:
+                            blob_u8(blob, option.default_bool ? 1 : 0);
+                            break;
+                        case MutatorOptionType::Choice:
+                            blob_u8(blob, option.default_choice);
+                            break;
+                        case MutatorOptionType::Int:
+                            blob_i32(blob, option.default_int);
+                            break;
+                        case MutatorOptionType::Float:
+                            blob_f32(blob, option.default_float);
+                            break;
+                        case MutatorOptionType::String:
+                            blob_str(blob, option.default_string);
+                            break;
+                    }
+                    if (option.type == MutatorOptionType::Choice) {
+                        const size_t choice_count = std::min<size_t>(option.choices.size(), 255);
+                        blob_u8(blob, static_cast<uint8_t>(choice_count));
+                        for (size_t c = 0; c < choice_count; ++c) {
+                            blob_str(blob, option.choices[c].label);
+                        }
+                    }
+                });
             }
-            if (option.type == MutatorOptionType::Choice) {
-                blob_u8(blob, static_cast<uint8_t>(std::min<size_t>(option.choices.size(), 255)));
-                for (const auto& choice : option.choices) {
-                    blob_str(blob, choice.label);
-                }
-            }
-        }
+        });
     }
 
-    // votable levels, each with the game type it would run with by default and
-    // the set of game types whose prefix rules it matches
+    // Votable levels: the game type each would run with by default, the set of
+    // game types whose prefix rules it matches, and whether the server's
+    // vote_level allow-list accepts it at all. Length-prefixed per entry (u16, not
+    // u8: filename alone can be 255 bytes plus six fixed bytes), so per-level data
+    // can be appended inside the entry later. Two bytes an entry buys in-place
+    // extensibility on the one section that has no size ceiling.
     const std::vector<std::string> levels = build_votable_level_list();
-    blob_u16(blob, static_cast<uint16_t>(std::min<size_t>(levels.size(), 65535)));
-    for (const auto& level : levels) {
-        blob_str(blob, level);
-        blob_u8(blob, static_cast<uint8_t>(vote_natural_rules_for_level(level).game_type));
-        blob_u32(blob, build_level_valid_gametype_mask(level));
+    const size_t level_count = std::min<size_t>(levels.size(), 65535);
+    blob_u16(blob, static_cast<uint16_t>(level_count));
+    for (size_t i = 0; i < level_count; ++i) {
+        const std::string& level = levels[i];
+        blob_sized_u16(blob, [&] {
+            blob_str(blob, level);
+            blob_u8(blob, static_cast<uint8_t>(vote_natural_rules_for_level(level).game_type));
+            blob_u32(blob, build_level_valid_gametype_mask(level));
+            // Derived from the SAME predicate the call-time gate uses, so the blob can
+            // never advertise a level the server would refuse.
+            blob_u8(blob, is_level_in_vote_allow_list(level) ? AF_VOTE_LEVEL_FLAG_ALLOWED : 0);
+        });
     }
 }
 
@@ -1371,17 +1590,68 @@ void server_vote_invalidate_options_blob()
     g_vote_options_blob_valid = false;
 }
 
-const std::vector<uint8_t>& server_vote_get_options_blob(uint8_t& generation)
+const std::vector<uint8_t>& server_vote_get_options_blob(uint32_t& generation)
 {
     if (!g_vote_options_blob_valid) {
         build_vote_options_blob(g_vote_options_blob);
-        ++g_vote_options_generation;
+        ++g_vote_options_generation; // starts at 1, so 0 means "nothing sent yet"
         g_vote_options_blob_valid = true;
         xlog::debug("vote options: rebuilt blob ({} bytes, generation {})",
                     g_vote_options_blob.size(), g_vote_options_generation);
     }
     generation = g_vote_options_generation;
     return g_vote_options_blob;
+}
+
+// Floor rate limit on af_req_vote_options. Applies to every request, accepted or
+// not, so the packet itself costs a bounded amount of work.
+static constexpr int vote_options_req_floor_ms = 1000;
+// Longer window for a re-send of a generation this player already received. The
+// only legitimate reason to ask again is a stream that never completed (the
+// deferred reliable queue is cleared wholesale by af_send_server_cfg), so
+// recovery stays possible without letting a client pull the blob on a 1s loop.
+static constexpr int vote_options_req_repeat_ms = 10000;
+
+void server_vote_handle_options_request(rf::Player* sender, bool has_cache, uint32_t known_generation)
+{
+    if (!rf::is_server || !sender) {
+        return;
+    }
+
+    if (sender->vote_options_req_timer.valid() && !sender->vote_options_req_timer.elapsed()) {
+        return; // still inside the floor window
+    }
+
+    // Do NOT build the blob for a client that cannot receive it: a rebuild bumps
+    // the generation, which would invalidate every other client's cache.
+    if (!is_player_minimum_af_client_version(sender, 1, 4, 0)) {
+        sender->vote_options_req_timer.set(vote_options_req_floor_ms);
+        return;
+    }
+
+    uint32_t generation = 0;
+    server_vote_get_options_blob(generation);
+
+    // The client told us what it already has. This is the case a plain
+    // once-per-generation guard cannot distinguish: a cfg change that does not
+    // affect the vote schema (sv_netfps, maxfps) sets signal_cfg_changed, which
+    // marks every client's cache stale, but leaves the generation alone. Answering
+    // with silence is what stops a needless identical re-download.
+    if (has_cache && known_generation == generation) {
+        sender->vote_options_sent_generation = generation;
+        sender->vote_options_req_timer.set(vote_options_req_floor_ms);
+        return;
+    }
+
+    const bool repeat = sender->vote_options_sent_generation == generation;
+    sender->vote_options_req_timer.set(repeat ? vote_options_req_repeat_ms : vote_options_req_floor_ms);
+    if (repeat) {
+        xlog::debug("vote options: re-streaming generation {} to {} (their copy did not arrive)",
+                    generation, sender->name);
+    }
+
+    af_send_vote_options_data(sender);
+    sender->vote_options_sent_generation = generation;
 }
 
 // ============================================================================
@@ -1391,25 +1661,28 @@ const std::vector<uint8_t>& server_vote_get_options_blob(uint8_t& generation)
 // Shared gate for chat and packet vote actions.
 static bool check_voter_eligibility(rf::Player* sender)
 {
+    if (is_listen_server_host(sender)) {
+        return false; // silently: the host has no vote UI to reply to
+    }
     if (sender->version_info.software == ClientSoftware::Browser || sender->is_bot) {
-        af_send_automated_chat_msg("Browsers and bots are not allowed to vote!", sender, true);
+        send_vote_reject_msg("Browsers and bots are not allowed to vote!", sender, true);
         return false;
     }
     if (!Vote::player_meets_alpine_restrict(sender)) {
-        af_send_automated_chat_msg(
+        send_vote_reject_msg(
             "You can't vote, because your client does not meet the server's requirements. Visit alpinefaction.com to upgrade.",
             sender, true
         );
         return false;
     }
     if (player_is_idle(sender)) {
-        af_send_automated_chat_msg("Idle players are not allowed to vote!", sender, true);
+        send_vote_reject_msg("Idle players are not allowed to vote!", sender, true);
         return false;
     }
     return true;
 }
 
-void handle_vote_command(std::string_view vote_name, [[maybe_unused]] std::string_view vote_arg, rf::Player* sender)
+void handle_vote_command(std::string_view vote_name, rf::Player* sender)
 {
     if (!check_voter_eligibility(sender)) {
         return;
@@ -1422,10 +1695,34 @@ void handle_vote_command(std::string_view vote_name, [[maybe_unused]] std::strin
     else if (vote_name == "cancel")
         g_vote_mgr.try_cancel_vote(sender);
     else
-        af_send_automated_chat_msg(
+        send_vote_reject_msg(
             "Calling votes via chat is no longer supported. Vote calling requires Alpine Faction 1.4+ - "
             "upgrade at alpinefaction.com. You can still vote with /vote yes or /vote no.",
             sender, true);
+}
+
+// A packet-supplied level name reaches both c_str() paths (is_level_name_valid,
+// the engine level load) and std::string comparisons (rotation lookup, the
+// allow-list). An embedded NUL makes those two disagree — "dm02.rfl\0x" passes
+// the checksum check on the truncated name but misses the rotation lookup — so
+// reject anything that isn't a plain filename before it goes any further.
+static bool is_vote_level_string_sane(std::string_view level)
+{
+    if (level.size() > 128) {
+        return false;
+    }
+    if (level.find("..") != std::string_view::npos) {
+        return false;
+    }
+    for (const unsigned char c : level) {
+        if (c < 0x20 || c == 0x7F) {
+            return false; // NUL and control bytes
+        }
+        if (c == '/' || c == '\\' || c == ':') {
+            return false; // path traversal / drive-relative
+        }
+    }
+    return true;
 }
 
 // 0xFF means "server default rules"; anything else must name a real game type.
@@ -1436,7 +1733,7 @@ static bool resolve_vote_gametype(uint8_t wire_value, rf::Player* sender, std::o
         return true;
     }
     if (wire_value > static_cast<uint8_t>(rf::NG_TYPE_GG)) {
-        af_send_automated_chat_msg("Cannot start vote: this server does not support that game type.", sender);
+        send_vote_reject_msg("Cannot start vote: this server does not support that game type.", sender);
         return false;
     }
     out = static_cast<rf::NetGameType>(wire_value);
@@ -1447,7 +1744,7 @@ static bool resolve_vote_mutators(const std::vector<VoteMutatorInput>& input, rf
                                   std::vector<MutatorDeclaration>& out)
 {
     if (auto error = mutators_build_declarations_from_vote(input, out)) {
-        af_send_automated_chat_msg(std::format("Cannot start vote: {}", *error), sender);
+        send_vote_reject_msg(std::format("Cannot start vote: {}", *error), sender);
         return false;
     }
     return true;
@@ -1460,6 +1757,13 @@ void handle_vote_call_packet(rf::Player* sender, AfVoteCallParams&& params)
     }
 
     if (!check_voter_eligibility(sender)) {
+        return;
+    }
+
+    // Sanitize the level string once, before any type-specific handling.
+    if ((params.type == AfVoteType::Level || params.type == AfVoteType::Match)
+        && !is_vote_level_string_sane(params.level)) {
+        send_vote_reject_msg("Cannot start vote: that level name is not valid.", sender);
         return;
     }
 
@@ -1481,7 +1785,7 @@ void handle_vote_call_packet(rf::Player* sender, AfVoteCallParams&& params)
                 return;
             }
             if (params.level.empty()) {
-                af_send_automated_chat_msg("Cannot start vote: no level was specified.", sender);
+                send_vote_reject_msg("Cannot start vote: no level was specified.", sender);
                 return;
             }
             g_vote_mgr.StartVote<VoteLevel>(sender, std::move(params.level), gametype, std::move(mutators));
@@ -1538,6 +1842,12 @@ void handle_vote_cast_packet(rf::Player* sender, bool is_yes_vote)
 void handle_vote_cancel_packet(rf::Player* sender)
 {
     if (!rf::is_server || !sender) {
+        return;
+    }
+    // Same gate as the chat `/vote cancel` path. try_cancel_vote already rejects
+    // anyone who isn't the owner, so this only matters for an owner who has since
+    // become ineligible, but the two paths must not diverge.
+    if (!check_voter_eligibility(sender)) {
         return;
     }
     g_vote_mgr.try_cancel_vote(sender);

--- a/game_patch/multi/votes.cpp
+++ b/game_patch/multi/votes.cpp
@@ -1007,6 +1007,11 @@ struct VoteKick : public Vote
 
 struct VoteExtend : public Vote
 {
+    // Minutes to add.
+    int m_minutes;
+
+    explicit VoteExtend(int minutes) : m_minutes(minutes) {}
+
     VoteType get_type() const override
     {
         return VoteType::Extend;
@@ -1014,17 +1019,22 @@ struct VoteExtend : public Vote
 
     [[nodiscard]] std::string get_title() const override
     {
-        return "EXTEND ROUND BY 5 MINUTES";
+        return std::format("EXTEND ROUND BY {} {}", m_minutes, m_minutes == 1 ? "MINUTE" : "MINUTES");
     }
 
     [[nodiscard]] std::string get_outcome_text(bool accepted) const override
     {
-        return accepted ? "Vote passed: extending round" : Vote::get_outcome_text(false);
+        if (!accepted) {
+            return Vote::get_outcome_text(false);
+        }
+        return std::format("Vote passed: extending round by {} {}", m_minutes,
+                           m_minutes == 1 ? "minute" : "minutes");
     }
 
     void on_accepted() override
     {
-        extend_round_time(5);
+        // extend_round_time takes MINUTES.
+        extend_round_time(m_minutes);
     }
 
     [[nodiscard]] const VoteConfig& get_config() const override
@@ -1799,7 +1809,16 @@ void handle_vote_call_packet(rf::Player* sender, AfVoteCallParams&& params)
             break;
         }
         case AfVoteType::Extend:
-            g_vote_mgr.StartVote<VoteExtend>(sender);
+            if (params.extend_minutes < af_vote_extend_min_minutes
+                || params.extend_minutes > af_vote_extend_max_minutes) {
+                send_vote_reject_msg(
+                    std::format("Cannot start vote: the round can only be extended by {} to {} minutes.",
+                                static_cast<int>(af_vote_extend_min_minutes),
+                                static_cast<int>(af_vote_extend_max_minutes)),
+                    sender);
+                return;
+            }
+            g_vote_mgr.StartVote<VoteExtend>(sender, static_cast<int>(params.extend_minutes));
             break;
         case AfVoteType::Restart:
             g_vote_mgr.StartVote<VoteRestart>(sender);

--- a/game_patch/multi/votes.cpp
+++ b/game_patch/multi/votes.cpp
@@ -304,10 +304,7 @@ public:
         }
     }
 
-    // Tell every structured client the vote is over. Idempotent: a vote that
-    // disappears for any other reason (kick target left, limbo, ...) still gets
-    // exactly one end event.
-    //
+    // Tell every structured client the vote is over.
     // `passed` is carried separately from `result` because they are independent: a
     // vote that TIMES OUT can still pass. `detail` is the same line legacy clients
     // are sent as chat, so a 1.4 client can print text equivalent to theirs.
@@ -695,7 +692,7 @@ static bool is_level_allowed_for_vote(const std::string& level_name, rf::Player*
     return true;
 }
 
-// "(CTF)" / "[Instagib, Rails]" suffixes appended to level and match vote titles.
+// "(GAMETYPE)" / "[MUTATOR]" suffixes appended to level and match vote titles.
 static std::string build_rules_title_suffix(std::optional<rf::NetGameType> gametype,
                                             const std::string& mutator_labels)
 {
@@ -1682,23 +1679,20 @@ static bool check_voter_eligibility(rf::Player* sender)
     return true;
 }
 
-void handle_vote_command(std::string_view vote_name, rf::Player* sender)
+// Chat is a legacy path: 1.4+ clients call, cast and cancel with packets. All that
+// survives here is casting, for clients too old to have af_req_vote_cast.
+bool handle_vote_command(std::string_view vote_name, rf::Player* sender)
 {
-    if (!check_voter_eligibility(sender)) {
-        return;
+    const bool is_yes = vote_name == "yes" || vote_name == "y";
+    if (!is_yes && vote_name != "no" && vote_name != "n") {
+        return false;
     }
 
-    if (vote_name == "yes" || vote_name == "y")
-        g_vote_mgr.add_player_vote(true, sender);
-    else if (vote_name == "no" || vote_name == "n")
-        g_vote_mgr.add_player_vote(false, sender);
-    else if (vote_name == "cancel")
-        g_vote_mgr.try_cancel_vote(sender);
-    else
-        send_vote_reject_msg(
-            "Calling votes via chat is no longer supported. Vote calling requires Alpine Faction 1.4+ - "
-            "upgrade at alpinefaction.com. You can still vote with /vote yes or /vote no.",
-            sender, true);
+    // Recognized either way: an ineligible voter has already been told why.
+    if (check_voter_eligibility(sender)) {
+        g_vote_mgr.add_player_vote(is_yes, sender);
+    }
+    return true;
 }
 
 // A packet-supplied level name reaches both c_str() paths (is_level_name_valid,
@@ -1844,9 +1838,9 @@ void handle_vote_cancel_packet(rf::Player* sender)
     if (!rf::is_server || !sender) {
         return;
     }
-    // Same gate as the chat `/vote cancel` path. try_cancel_vote already rejects
-    // anyone who isn't the owner, so this only matters for an owner who has since
-    // become ineligible, but the two paths must not diverge.
+    // Same eligibility gate as the call and cast packets. try_cancel_vote already
+    // rejects anyone who isn't the owner, so this only matters for an owner who has
+    // since become ineligible, but the entry points must not diverge.
     if (!check_voter_eligibility(sender)) {
         return;
     }

--- a/game_patch/multi/votes.cpp
+++ b/game_patch/multi/votes.cpp
@@ -1,12 +1,15 @@
 #include <string_view>
 #include <algorithm>
+#include <cstring>
 #include <map>
+#include <memory>
 #include <set>
 #include <ctime>
 #include <format>
 #include <optional>
 #include <cctype>
 #include <utility>
+#include <vector>
 #include "../rf/player/player.h"
 #include "../rf/level.h"
 #include "../rf/multi.h"
@@ -23,6 +26,7 @@
 #include "server_internal.h"
 #include "multi.h"
 #include "gametype.h"
+#include "mutators.h"
 #include "server.h"
 #include "alpine_packets.h"
 
@@ -41,7 +45,6 @@ enum class VoteType
 {
     Kick,
     Level,
-    Gametype,
     Restart,
     Extend,
     Next,
@@ -52,26 +55,94 @@ enum class VoteType
     Unknown
 };
 
+static AfVoteType vote_type_to_wire(VoteType type)
+{
+    switch (type) {
+        case VoteType::Kick: return AfVoteType::Kick;
+        case VoteType::Level: return AfVoteType::Level;
+        case VoteType::Match: return AfVoteType::Match;
+        case VoteType::Extend: return AfVoteType::Extend;
+        case VoteType::Restart: return AfVoteType::Restart;
+        case VoteType::Next: return AfVoteType::Next;
+        case VoteType::Random: return AfVoteType::Random;
+        case VoteType::Previous: return AfVoteType::Previous;
+        case VoteType::CancelMatch: return AfVoteType::CancelMatch;
+        default: return AfVoteType::Kick;
+    }
+}
+
+// Clients that consume af_sreq_vote_state instead of the legacy chat text. The
+// listen-server host always does (its packets are applied locally).
+static bool player_uses_vote_packets(rf::Player* player)
+{
+    if (!player) {
+        return false;
+    }
+    if (player == rf::local_player) {
+        return true;
+    }
+    return is_player_minimum_af_client_version(player, 1, 4, 0);
+}
+
+static bool player_is_connected(const rf::Player* target)
+{
+    if (!target) {
+        return false;
+    }
+    for (const rf::Player& player : SinglyLinkedList{rf::player_list}) {
+        if (&player == target) {
+            return true;
+        }
+    }
+    return false;
+}
+
+struct VoteTally
+{
+    int yes = 0;
+    int no = 0;
+    int remaining = 0;
+};
+
 struct Vote
 {
 private:
     std::time_t start_time = 0;
     bool reminder_sent = false;
+    bool announced = false;
+    bool end_event_sent = false;
     rf::Timestamp early_finish_check_timer;
     std::map<rf::Player*, bool> players_who_voted;
-    rf::Player* owner;
+    rf::Player* owner = nullptr;
+    // Copied at start time so the wire name never depends on the owner's
+    // rf::Player still being alive.
+    std::string owner_name;
+
+    enum class Outcome
+    {
+        None,
+        Accepted,
+        Rejected,
+    };
+    Outcome pending_outcome = Outcome::None;
 
 public:
     virtual ~Vote() = default;
 
     virtual VoteType get_type() const = 0;
 
-    bool start(std::string_view arg, rf::Player* source)
+    // Type-specific validation, run before the vote is announced. Rejection
+    // messages are sent to `source` here.
+    virtual bool validate([[maybe_unused]] rf::Player* source)
     {
-        if (!process_vote_arg(arg, source)) {
-            return false;
-        }
+        return true;
+    }
+
+    bool start(rf::Player* source)
+    {
         owner = source;
+        owner_name = source ? source->name.c_str() : "";
+        announced = true;
         send_vote_starting_msg(source);
 
         start_time = std::time(nullptr);
@@ -86,7 +157,8 @@ public:
     {
         if (player == owner) {
             early_finish_check_timer.invalidate();
-            af_broadcast_automated_chat_msg("Vote canceled: owner left the game!");
+            broadcast_vote_legacy_msg("Vote canceled: owner left the game!");
+            broadcast_vote_end(AfVoteResult::Canceled);
             return false;
         }
         players_who_voted.erase(player);
@@ -106,16 +178,11 @@ public:
         else {
             players_who_voted[source] = is_yes_vote;
 
-            const auto current_player_list = get_clients(false, false);
+            const VoteTally tally = compute_tally();
 
-            auto yes_votes = std::count_if(players_who_voted.begin(), players_who_voted.end(), [](const auto& pair) {
-                return pair.second;
-            });
-            auto no_votes = players_who_voted.size() - yes_votes;
-
-            auto msg = std::format("Vote status: Yes: {} No: {} Waiting: {}", yes_votes, no_votes,
-                                   current_player_list.size() - players_who_voted.size());
-            af_broadcast_automated_chat_msg(msg);
+            auto msg = std::format("Vote status: Yes: {} No: {} Waiting: {}", tally.yes, tally.no, tally.remaining);
+            broadcast_vote_legacy_msg(msg);
+            broadcast_vote_update(tally);
             return check_for_early_vote_finish();
         }
         return true;
@@ -135,27 +202,14 @@ public:
 
         std::time_t passed_time_sec = std::time(nullptr) - start_time;
         if (passed_time_sec >= vote_config.time_limit_seconds) {
-            int yes_votes = std::count_if(players_who_voted.begin(), players_who_voted.end(), [](auto& p) {
-                return p.second;
-            });
-            int no_votes = std::count_if(players_who_voted.begin(), players_who_voted.end(), [](auto& p) {
-                return !p.second;
-            });
-
-            const auto current = get_clients(false, false);
-            int remaining = 0;
-            for (auto* p : current) {
-                if (is_eligible_voter(p) && players_who_voted.count(p) == 0) {
-                    ++remaining;
-                }
-            }
+            VoteTally tally = compute_tally();
 
             if (!vote_config.ignore_nonvoters) {
-                no_votes += remaining;
+                tally.no += tally.remaining;
             }
 
-            af_broadcast_automated_chat_msg("Vote timed out!");
-            finish_vote(yes_votes > no_votes);
+            broadcast_vote_legacy_msg("Vote timed out!");
+            finish_vote(tally.yes > tally.no, AfVoteResult::TimedOut);
             return false;
         }
         if (passed_time_sec >= vote_config.time_limit_seconds / 2 && !reminder_sent) {
@@ -181,8 +235,68 @@ public:
         }
 
         early_finish_check_timer.invalidate();
-        af_broadcast_automated_chat_msg("Vote canceled!");
+        broadcast_vote_legacy_msg("Vote canceled!");
+        broadcast_vote_end(AfVoteResult::Canceled);
         return true;
+    }
+
+    void cancel_for_limbo()
+    {
+        early_finish_check_timer.invalidate();
+        broadcast_vote_legacy_msg("Vote canceled!");
+        broadcast_vote_end(AfVoteResult::Canceled);
+    }
+
+    // Bring a player who joined mid-vote up to date.
+    void send_start_state_to(rf::Player* player)
+    {
+        if (!player || !player_uses_vote_packets(player) || !player_meets_alpine_restrict(player)) {
+            return;
+        }
+
+        const auto elapsed = static_cast<int>(std::time(nullptr) - start_time);
+        const int seconds_left = std::max(0, get_config().time_limit_seconds - elapsed);
+        const VoteTally tally = compute_tally();
+
+        // An owner who left cancels the vote, but never trust a stale pointer:
+        // an unresolvable owner is reported as an empty name.
+        const std::string_view initiator = player_is_connected(owner) ? std::string_view{owner_name}
+                                                                     : std::string_view{};
+
+        af_send_vote_state_start(player, vote_type_to_wire(get_type()),
+                                 static_cast<uint16_t>(seconds_left), clamp_to_u8(tally.yes),
+                                 clamp_to_u8(tally.no), clamp_to_u8(tally.remaining),
+                                 player == owner, initiator, get_title());
+    }
+
+    // Run whatever finish_vote() decided. Only VoteMgr calls this, and only on a
+    // vote it has already detached from `active_vote`.
+    void run_pending_outcome()
+    {
+        const Outcome outcome = std::exchange(pending_outcome, Outcome::None);
+        if (outcome == Outcome::Accepted) {
+            on_accepted();
+        }
+        else if (outcome == Outcome::Rejected) {
+            on_rejected();
+        }
+    }
+
+    // Tell every structured client the vote is over. Idempotent: a vote that
+    // disappears for any other reason (kick target left, limbo, ...) still gets
+    // exactly one end event.
+    void broadcast_vote_end(AfVoteResult result)
+    {
+        if (end_event_sent || !announced) {
+            return; // a vote rejected during validation was never announced
+        }
+        end_event_sent = true;
+
+        for (rf::Player& player : SinglyLinkedList{rf::player_list}) {
+            if (player_uses_vote_packets(&player)) {
+                af_send_vote_state_end(&player, result);
+            }
+        }
     }
 
     static bool player_meets_alpine_restrict(rf::Player* p) {
@@ -195,19 +309,48 @@ protected:
     [[nodiscard]] virtual std::string get_title() const = 0;
     [[nodiscard]] virtual const VoteConfig& get_config() const = 0;
 
-    virtual bool process_vote_arg([[maybe_unused]] std::string_view arg, [[maybe_unused]] rf::Player* source)
-    {
-        return true;
-    }
-
     virtual void on_accepted()
     {
-        af_broadcast_automated_chat_msg("Vote passed!");
+        broadcast_vote_legacy_msg("Vote passed!");
     }
 
     virtual void on_rejected()
     {
-        af_broadcast_automated_chat_msg("Vote failed!");
+        broadcast_vote_legacy_msg("Vote failed!");
+    }
+
+    static uint8_t clamp_to_u8(int value)
+    {
+        return static_cast<uint8_t>(std::clamp(value, 0, 255));
+    }
+
+    // Vote chat text goes only to clients that can't receive the structured
+    // events; their sniffing contract depends on these exact strings. The
+    // console line matches af_broadcast_automated_chat_msg so dedicated server
+    // output is unchanged.
+    static void broadcast_vote_legacy_msg(std::string_view msg)
+    {
+        rf::console::print("Server: {}", msg);
+
+        for (rf::Player& player : SinglyLinkedList{rf::player_list}) {
+            if (&player == rf::local_player) {
+                continue;
+            }
+            if (player_uses_vote_packets(&player)) {
+                continue;
+            }
+            af_send_automated_chat_msg(msg, &player);
+        }
+    }
+
+    void broadcast_vote_update(const VoteTally& tally)
+    {
+        for (rf::Player& player : SinglyLinkedList{rf::player_list}) {
+            if (player_uses_vote_packets(&player)) {
+                af_send_vote_state_update(&player, clamp_to_u8(tally.yes), clamp_to_u8(tally.no),
+                                          clamp_to_u8(tally.remaining));
+            }
+        }
     }
 
     void send_vote_starting_msg(rf::Player* source)
@@ -219,47 +362,58 @@ protected:
         auto title = get_title();
         std::string base_msg = std::format("{} vote started by {}.\n", title, source->name);
 
-        // Notify the player who started the vote
-        af_send_automated_chat_msg(base_msg, source);
-
         // print to server console
-        rf::console::printf(base_msg.c_str()); 
+        rf::console::printf(base_msg.c_str());
 
-        // Prepare messages for other players
+        // Prepare messages for legacy players
         std::string msg_non_alpine = "\n=============== VOTE STARTING ===============\n" + base_msg +
                                      "Send message \"/vote yes\" or \"/vote no\" to participate.";
 
         std::string msg_alpine = "\n=============== VOTE STARTING ===============\n" + base_msg;
 
-        // Send the message to other players
-        for (rf::Player* player : get_clients(false, false)) {
-            if (!player || player == source) {
-                continue; // skip the player who started the vote
-            }
+        const int time_limit = std::max(0, get_config().time_limit_seconds);
 
-            if (!player_meets_alpine_restrict(player)) {
+        for (rf::Player* player : get_clients(false, false)) {
+            if (!player) {
                 continue;
             }
 
-            const std::string& message_to_send =
-                player->version_info.software == ClientSoftware::AlpineFaction
-                    ? msg_alpine
-                    : msg_non_alpine;
+            if (player != source && !player_meets_alpine_restrict(player)) {
+                continue;
+            }
 
-            af_send_automated_chat_msg(message_to_send, player);
+            if (player_uses_vote_packets(player)) {
+                // The vote owner's own yes vote is already counted.
+                af_send_vote_state_start(player, vote_type_to_wire(get_type()),
+                                         static_cast<uint16_t>(time_limit), 1, 0,
+                                         clamp_to_u8(count_eligible_voters() - 1), player == source,
+                                         owner_name, title);
+                continue;
+            }
+
+            if (player == source) {
+                af_send_automated_chat_msg(base_msg, source);
+                continue;
+            }
+
+            af_send_automated_chat_msg(player->version_info.software == ClientSoftware::AlpineFaction
+                                           ? msg_alpine
+                                           : msg_non_alpine,
+                                       player);
         }
     }
 
-    void finish_vote(bool is_accepted)
+    // Concludes the vote and records what should happen. The outcome handler
+    // itself is deliberately NOT run here: it changes the level / kicks a player
+    // / starts a match, any of which can re-enter the vote system. VoteMgr
+    // detaches the vote first and then calls run_pending_outcome().
+    void finish_vote(bool is_accepted, std::optional<AfVoteResult> result = std::nullopt)
     {
         early_finish_check_timer.invalidate();
 
-        if (is_accepted) {
-            on_accepted();
-        }
-        else {
-            on_rejected();
-        }
+        broadcast_vote_end(result.value_or(is_accepted ? AfVoteResult::Passed : AfVoteResult::Failed));
+
+        pending_outcome = is_accepted ? Outcome::Accepted : Outcome::Rejected;
     }
 
     static bool is_eligible_voter(rf::Player* const p) {
@@ -275,28 +429,49 @@ protected:
         return true;
     }
 
-    bool check_for_early_vote_finish()
+    static int count_eligible_voters()
     {
-        int yes_votes = std::count_if(players_who_voted.begin(), players_who_voted.end(),
-            [](const auto& p) {
-                return p.second && is_eligible_voter(p.first);
-            });
+        int count = 0;
+        for (auto* p : get_clients(false, false)) {
+            if (is_eligible_voter(p)) {
+                ++count;
+            }
+        }
+        return count;
+    }
 
-        int no_votes = std::count_if(players_who_voted.begin(), players_who_voted.end(),
-            [](const auto& p) {
-                return !p.second && is_eligible_voter(p.first);
-            });
+    [[nodiscard]] VoteTally compute_tally() const
+    {
+        VoteTally tally;
 
-        const auto current = get_clients(false, false);
-        int remaining = 0;
-        for (auto* p : current) {
-            if (is_eligible_voter(p) && players_who_voted.count(p) == 0)
-                ++remaining;
+        for (const auto& [player, is_yes] : players_who_voted) {
+            if (!is_eligible_voter(player)) {
+                continue;
+            }
+            if (is_yes) {
+                ++tally.yes;
+            }
+            else {
+                ++tally.no;
+            }
         }
 
-        const bool can_pass = yes_votes > no_votes + remaining;
-        const bool can_fail = no_votes > yes_votes + remaining;
-        const bool all_have_voted = remaining == 0;
+        for (auto* p : get_clients(false, false)) {
+            if (is_eligible_voter(p) && players_who_voted.count(p) == 0) {
+                ++tally.remaining;
+            }
+        }
+
+        return tally;
+    }
+
+    bool check_for_early_vote_finish()
+    {
+        const VoteTally tally = compute_tally();
+
+        const bool can_pass = tally.yes > tally.no + tally.remaining;
+        const bool can_fail = tally.no > tally.yes + tally.remaining;
+        const bool all_have_voted = tally.remaining == 0;
 
         if (can_pass) {
             finish_vote(true);
@@ -307,7 +482,7 @@ protected:
             return false;
         }
         if (all_have_voted) {
-            finish_vote(yes_votes > no_votes);
+            finish_vote(tally.yes > tally.no);
             return false;
         }
 
@@ -315,48 +490,8 @@ protected:
     }
 };
 
-std::tuple<int, bool, std::string, std::optional<std::string>> parse_match_vote_info(std::string_view arg)
+static bool does_level_match_gametype_prefix(const std::string& level_name, rf::NetGameType game_type)
 {
-    arg = trim(arg);
-    if (arg.size() < 3)
-        return {-1, false, "", std::nullopt};
-
-    auto [size_part, rest] = split_once_whitespace(arg);
-
-    if (size_part.size() != 3 || size_part[1] != 'v' || size_part[0] < '1' || size_part[0] > '8' ||
-        size_part[2] != size_part[0]) {
-        return {-1, false, "", std::nullopt};
-    }
-
-    const int team_size = size_part[0] - '0';
-
-    bool valid_level = false;
-    std::string level_name;
-    std::optional<std::string> preset_alias;
-
-    if (!rest.empty()) {
-        auto [level_part, preset_part] = split_once_whitespace(rest);
-
-        if (!level_part.empty()) {
-            auto [is_valid, normalized_name] = is_level_name_valid(level_part);
-            valid_level = is_valid;
-            level_name = std::move(normalized_name);
-        }
-
-        if (!preset_part.empty()) {
-            // take the first token for preset alias
-            auto [alias, _discard] = split_once_whitespace(preset_part);
-            if (!alias.empty())
-                preset_alias = std::string(alias);
-        }
-    }
-
-    return {team_size, valid_level, level_name, preset_alias};
-}
-
-static bool does_level_match_gametype_prefix(const std::string& level_name)
-{
-    const auto game_type = rf::multi_get_game_type();
     std::string map_name = level_name;
 
     if (!string_iends_with(map_name, ".rfl")) {
@@ -394,12 +529,89 @@ static bool does_level_match_gametype_prefix(const std::string& level_name)
     return false;
 }
 
-static bool is_level_allowed_for_vote(const std::string& level_name, rf::Player* source, bool check_gametype = true)
+// The union of the rotation and the vote-allowed list, in rotation order, with
+// case-insensitive dedup. Also what the vote-options blob advertises.
+static std::vector<std::string> build_votable_level_list()
 {
     const auto& vote_level_cfg = g_alpine_server_config.vote_level;
 
-    if (check_gametype && vote_level_cfg.only_allow_gametype_prefix && !does_level_match_gametype_prefix(level_name)) {
-        auto msg = std::format("Cannot start vote: level {} does not match the current gametype!", level_name);
+    std::vector<std::string> levels;
+    std::set<std::string> seen;
+
+    const auto add = [&](const std::string& name) {
+        if (name.empty()) {
+            return;
+        }
+        if (seen.insert(string_to_lower(name)).second) {
+            levels.push_back(name);
+        }
+    };
+
+    for (const auto& level_entry : g_alpine_server_config.levels) {
+        add(level_entry.level_filename);
+    }
+    for (const auto& allowed : vote_level_cfg.allowed_maps) {
+        add(allowed);
+    }
+
+    return levels;
+}
+
+// The game type the voted level will actually run with, mirroring
+// load_vote_rules_override's inheritance: a voted game type wins; otherwise a
+// vote that builds an override rebases onto the level's natural rules, and a
+// vote that builds no override leaves the level running exactly as it is.
+static rf::NetGameType resolve_effective_vote_game_type(const std::string& level_name,
+                                                        std::optional<rf::NetGameType> gametype,
+                                                        bool builds_override, bool keeps_current_level)
+{
+    if (gametype) {
+        return *gametype;
+    }
+    if (!builds_override && keeps_current_level) {
+        return g_alpine_server_config_active_rules.game_type;
+    }
+    return vote_natural_rules_for_level(level_name).game_type;
+}
+
+// Enforcement-aware answer to "would the server accept this level voted with this
+// game type?" — the call-time validation gate. A server with
+// only_allow_gametype_prefix off accepts everything.
+static bool is_level_valid_for_vote_gametype(const std::string& level_name, rf::NetGameType game_type)
+{
+    if (!g_alpine_server_config.vote_level.only_allow_gametype_prefix) {
+        return true;
+    }
+    return does_level_match_gametype_prefix(level_name, game_type);
+}
+
+// bit N (matching NetGameType N) = this level matches that game type's level
+// prefix rules. Deliberately NOT enforcement-aware: the mask always describes
+// prefix-match validity so a client can offer an opt-in "filter by gametype" view
+// even on a server that doesn't enforce it. Whether the server actually enforces
+// the rules is advertised separately via AF_VOTE_SERVER_FLAG_GAMETYPE_PREFIX.
+// 32 bits so future game types beyond NG_TYPE_GG still fit.
+static uint32_t build_level_valid_gametype_mask(const std::string& level_name)
+{
+    uint32_t mask = 0;
+    for (int i = 0; i <= static_cast<int>(rf::NG_TYPE_GG); ++i) {
+        if (does_level_match_gametype_prefix(level_name, static_cast<rf::NetGameType>(i))) {
+            mask |= (1u << i);
+        }
+    }
+    return mask;
+}
+
+static bool is_level_allowed_for_vote(const std::string& level_name, rf::Player* source,
+                                      rf::NetGameType effective_game_type)
+{
+    const auto& vote_level_cfg = g_alpine_server_config.vote_level;
+
+    // Checked against the game type the level will run with once the vote
+    // applies, not the one currently running.
+    if (!is_level_valid_for_vote_gametype(level_name, effective_game_type)) {
+        auto msg = std::format("Cannot start vote: level {} does not match the {} gametype!", level_name,
+                               multi_game_type_name_short(effective_game_type));
         af_send_automated_chat_msg(msg, source);
         return false; // level does not match gametype prefix
     }
@@ -432,71 +644,70 @@ static bool is_level_allowed_for_vote(const std::string& level_name, rf::Player*
     return true;
 }
 
+// "(CTF)" / "[Instagib, Rails]" suffixes appended to level and match vote titles.
+static std::string build_rules_title_suffix(std::optional<rf::NetGameType> gametype,
+                                            const std::string& mutator_labels)
+{
+    std::string suffix;
+    if (gametype) {
+        suffix += std::format(" ({})", multi_game_type_name_short(*gametype));
+    }
+    if (!mutator_labels.empty()) {
+        suffix += std::format(" [{}]", mutator_labels);
+    }
+    return suffix;
+}
+
 struct VoteMatch : public Vote
 {
+    int m_team_size;
+    std::string m_level_name;
+    std::optional<rf::NetGameType> m_gametype;
+    std::vector<MutatorDeclaration> m_mutators;
     std::optional<ManualRulesOverride> m_manual_rules_override;
-    std::optional<std::string> m_manual_rules_alias;
-    bool m_override_is_mutator = false;
+    std::string m_mutator_labels;
+
+    VoteMatch(int team_size, std::string level_name, std::optional<rf::NetGameType> gametype,
+              std::vector<MutatorDeclaration> mutators)
+        : m_team_size(team_size), m_level_name(std::move(level_name)), m_gametype(gametype),
+          m_mutators(std::move(mutators))
+    {}
 
     VoteType get_type() const override
     {
         return VoteType::Match;
     }
 
-    bool process_vote_arg(std::string_view arg, rf::Player* source) override
+    bool validate(rf::Player* source) override
     {
-        auto [team_size, valid_level, match_level_name, preset_alias] = parse_match_vote_info(arg);
-        g_match_info.team_size = team_size;
-
-        if (valid_level) {
-            g_match_info.match_level_name = match_level_name;
-        }
-        else if (match_level_name == "") {
-            g_match_info.match_level_name = rf::level.filename.c_str();
-        }
-        else {
-            af_send_automated_chat_msg("Invalid level specified! Try again, or omit level filename to use the current level.", source);
-            return false;
-        }
-
-        if (!is_level_allowed_for_vote(g_match_info.match_level_name, source)) {
-            return false;
-        }
-
-        if (g_match_info.team_size == -1) {
+        if (m_team_size < 1 || m_team_size > 8) {
             af_send_automated_chat_msg("Invalid match size! Supported sizes are 1v1 up to 8v8.", source);
             return false;
         }
 
-        m_manual_rules_override.reset();
-        m_manual_rules_alias.reset();
-        m_override_is_mutator = false;
-
-        if (preset_alias) {
-            // Mutators are checked first: a mutator name wins over a same-named preset.
-            if (auto mutator_override = load_mutator_rules_override(*preset_alias)) {
-                m_manual_rules_alias = mutator_override->preset_alias; // canonical mutator label
-                m_manual_rules_override = std::move(*mutator_override);
-                m_override_is_mutator = true;
+        if (m_level_name.empty()) {
+            m_level_name = rf::level.filename.c_str();
+        }
+        else {
+            auto [is_valid, normalized_name] = is_level_name_valid(m_level_name);
+            if (!is_valid) {
+                af_send_automated_chat_msg(
+                    "Invalid level specified! Try again, or omit level filename to use the current level.", source);
+                return false;
             }
-            else {
-                auto alias_it = g_alpine_server_config.rules_preset_aliases.find(*preset_alias);
-                if (alias_it == g_alpine_server_config.rules_preset_aliases.end()) {
-                    auto msg = std::format("Cannot start vote: '{}' is not a known mutator or rules preset!", *preset_alias);
-                    af_send_automated_chat_msg(msg, source);
-                    return false;
-                }
+            m_level_name = std::move(normalized_name);
+        }
 
-                auto preset_result = load_rules_preset_alias(*preset_alias);
-                if (!preset_result) {
-                    auto msg = std::format("Cannot start vote: failed to load rules preset '{}'", *preset_alias);
-                    af_send_automated_chat_msg(msg, source);
-                    return false;
-                }
+        // A match on the current level with no rules override keeps the level
+        // (and therefore its active rules) exactly as they are; anything else
+        // re-resolves from the level's natural rules.
+        const bool builds_override = !m_mutators.empty() || m_gametype.has_value();
+        const bool using_current_level = m_level_name == rf::level.filename.c_str();
+        const rf::NetGameType effective_game_type = resolve_effective_vote_game_type(
+            m_level_name, m_gametype, builds_override, using_current_level);
 
-                m_manual_rules_alias = std::move(*preset_alias);
-                m_manual_rules_override = std::move(*preset_result);
-            }
+        if (!is_level_allowed_for_vote(m_level_name, source, effective_game_type)) {
+            return false;
         }
 
         if (!multi_game_type_is_team_type(g_alpine_server_config.base_rules.game_type)) {
@@ -504,31 +715,26 @@ struct VoteMatch : public Vote
             return false;
         }
 
-        const bool using_current_level = g_match_info.match_level_name == rf::level.filename.c_str();
-
-        const auto desired_game_type =
-            m_manual_rules_override
-            ? m_manual_rules_override->rules.game_type
-            : (using_current_level ? g_alpine_server_config_active_rules.game_type
-                                   : g_alpine_server_config.base_rules.game_type);
-
-        if (!multi_game_type_is_team_type(desired_game_type)) {
+        // The match must end up on a team game type — evaluated against what will
+        // actually apply, not the base rules.
+        if (!multi_game_type_is_team_type(effective_game_type)) {
             af_send_automated_chat_msg("Cannot start vote: matches must be played on a team game type.", source);
             return false;
         }
 
+        m_manual_rules_override = load_vote_rules_override(m_level_name, m_mutators, m_gametype);
+        m_mutator_labels = mutators_join_labels(m_mutators);
+
+        // Only touch the shared match state once every check has passed.
+        g_match_info.team_size = m_team_size;
+        g_match_info.match_level_name = m_level_name;
         return true;
     }
 
     [[nodiscard]] std::string get_title() const override
     {
-        if (m_manual_rules_alias)
-            return std::format("START {}v{} MATCH on {} ({} '{}')",
-                               g_match_info.team_size, g_match_info.team_size,
-                               g_match_info.match_level_name,
-                               m_override_is_mutator ? "MUTATOR" : "PRESET", *m_manual_rules_alias);
-        return std::format("START {}v{} MATCH on {}",
-            g_match_info.team_size, g_match_info.team_size, g_match_info.match_level_name);
+        return std::format("START {}v{} MATCH on {}{}", m_team_size, m_team_size, m_level_name,
+                           build_rules_title_suffix(m_gametype, m_mutator_labels));
     }
 
     void on_accepted() override
@@ -553,12 +759,11 @@ struct VoteMatch : public Vote
                                  : "Changing to match level, then entering pre-match ready up phase";
 
         std::string msg;
-        if (m_manual_rules_alias)
-            msg = std::format("Vote passed. {} ({} '{}').", detail,
-                              m_override_is_mutator ? "mutator" : "rules preset", *m_manual_rules_alias);
+        if (!m_mutator_labels.empty())
+            msg = std::format("Vote passed. {} (mutators: {}).", detail, m_mutator_labels);
         else
             msg = std::format("Vote passed. {}.", detail);
-        af_broadcast_automated_chat_msg(msg);
+        broadcast_vote_legacy_msg(msg);
 
         g_match_info.pre_match_queued = true;
 
@@ -573,17 +778,14 @@ struct VoteMatch : public Vote
         else if (!g_match_info.match_level_name.empty()) {
             if (!m_manual_rules_override)
                 clear_manual_rules_override();
+            if (m_gametype)
+                set_upcoming_game_type(*m_gametype, UpcomingGameTypeSelection::ExplicitRequest);
             multi_change_level_alpine(g_match_info.match_level_name.c_str());
             if (m_manual_rules_override) {
                 set_manual_rules_override(std::move(*m_manual_rules_override));
                 m_manual_rules_override.reset();
             }
         }
-    }
-
-    bool on_player_leave(rf::Player* player) override
-    {        
-        return Vote::on_player_leave(player);
     }
 
     [[nodiscard]] const VoteConfig& get_config() const override
@@ -604,7 +806,7 @@ struct VoteCancelMatch : public Vote
         return "CANCEL CURRENT MATCH";
     }
 
-    bool process_vote_arg(std::string_view arg, rf::Player* source) override
+    bool validate(rf::Player* source) override
     {
         if (!g_match_info.match_active && !g_match_info.pre_match_active) {
             af_send_automated_chat_msg("No active or queued match to cancel.", source);
@@ -616,7 +818,7 @@ struct VoteCancelMatch : public Vote
 
     void on_accepted() override
     {
-        af_broadcast_automated_chat_msg("Vote passed: The match has been canceled.");
+        broadcast_vote_legacy_msg("Vote passed: The match has been canceled.");
 
         cancel_match();
     }
@@ -632,16 +834,20 @@ struct VoteKick : public Vote
 {
     rf::Player* m_target_player;
 
+    explicit VoteKick(rf::Player* target) : m_target_player(target) {}
+
     VoteType get_type() const override
     {
         return VoteType::Kick;
     }
 
-    bool process_vote_arg(std::string_view arg, [[ maybe_unused ]] rf::Player* source) override
+    bool validate(rf::Player* source) override
     {
-        std::string player_name{arg};
-        m_target_player = find_best_matching_player(player_name.c_str());
-        return m_target_player != nullptr;
+        if (!m_target_player) {
+            af_send_automated_chat_msg("Cannot start vote: that player is no longer on the server.", source);
+            return false;
+        }
+        return true;
     }
 
     [[nodiscard]] std::string get_title() const override
@@ -651,14 +857,14 @@ struct VoteKick : public Vote
 
     void on_accepted() override
     {
-        af_broadcast_automated_chat_msg("Vote passed: kicking player");
+        broadcast_vote_legacy_msg("Vote passed: kicking player");
         rf::multi_kick_player(m_target_player);
     }
 
     bool on_player_leave(rf::Player* player) override
     {
         if (m_target_player == player) {
-            return false;
+            return false; // the end event goes out when the vote is destroyed
         }
         return Vote::on_player_leave(player);
     }
@@ -671,8 +877,6 @@ struct VoteKick : public Vote
 
 struct VoteExtend : public Vote
 {
-    rf::Player* m_target_player;
-
     VoteType get_type() const override
     {
         return VoteType::Extend;
@@ -685,7 +889,7 @@ struct VoteExtend : public Vote
 
     void on_accepted() override
     {
-        af_broadcast_automated_chat_msg("Vote passed: extending round");
+        broadcast_vote_legacy_msg("Vote passed: extending round");
         extend_round_time(5);
     }
 
@@ -703,20 +907,24 @@ struct VoteExtend : public Vote
 struct VoteLevel : public Vote
 {
     std::string m_level_name;
+    std::optional<rf::NetGameType> m_gametype;
+    std::vector<MutatorDeclaration> m_mutators;
     std::optional<ManualRulesOverride> m_manual_rules_override;
-    bool m_override_is_mutator = false;
+    std::string m_mutator_labels;
+
+    VoteLevel(std::string level_name, std::optional<rf::NetGameType> gametype,
+              std::vector<MutatorDeclaration> mutators)
+        : m_level_name(std::move(level_name)), m_gametype(gametype), m_mutators(std::move(mutators))
+    {}
 
     VoteType get_type() const override
     {
         return VoteType::Level;
     }
 
-    bool process_vote_arg(std::string_view arg, rf::Player* source) override
+    bool validate(rf::Player* source) override
     {
-        arg = trim(arg);
-
-        auto [level_part, preset_part] = split_once_whitespace(arg);
-        auto [is_valid, level_name] = is_level_name_valid(level_part);
+        auto [is_valid, level_name] = is_level_name_valid(m_level_name);
 
         if (!is_valid) {
             auto msg = std::format("Cannot start vote: level {} is not available on the server!", level_name);
@@ -724,63 +932,41 @@ struct VoteLevel : public Vote
             return false;
         }
 
-        if (!is_level_allowed_for_vote(level_name, source)) {
+        m_level_name = std::move(level_name);
+
+        // A level vote always reloads the level, so it never keeps the currently
+        // active rules — the target always re-resolves from rotation/base.
+        const bool builds_override = !m_mutators.empty() || m_gametype.has_value();
+        const rf::NetGameType effective_game_type = resolve_effective_vote_game_type(
+            m_level_name, m_gametype, builds_override, /*keeps_current_level*/ false);
+
+        if (!is_level_allowed_for_vote(m_level_name, source, effective_game_type)) {
             return false;
         }
 
-        m_manual_rules_override.reset();
-        m_override_is_mutator = false;
-
-        if (!preset_part.empty()) {
-            std::string preset_name{preset_part};
-            // Mutators are checked first: a mutator name wins over a same-named preset.
-            if (auto mutator_override = load_mutator_rules_override(preset_name)) {
-                m_manual_rules_override = std::move(*mutator_override);
-                m_override_is_mutator = true;
-            }
-            else {
-                auto alias_it = g_alpine_server_config.rules_preset_aliases.find(preset_name);
-                if (alias_it == g_alpine_server_config.rules_preset_aliases.end()) {
-                    auto msg = std::format("Cannot start vote: '{}' is not a known mutator or rules preset!", preset_name);
-                    af_send_automated_chat_msg(msg, source);
-                    return false;
-                }
-
-                auto preset_result = load_rules_preset_alias(preset_name);
-                if (!preset_result) {
-                    auto msg = std::format("Cannot start vote: failed to load rules preset '{}'", preset_name);
-                    af_send_automated_chat_msg(msg, source);
-                    return false;
-                }
-
-                m_manual_rules_override = std::move(*preset_result);
-            }
-        }
-
-        m_level_name = std::move(level_name);
+        m_manual_rules_override = load_vote_rules_override(m_level_name, m_mutators, m_gametype);
+        m_mutator_labels = mutators_join_labels(m_mutators);
         return true;
     }
 
     [[nodiscard]] std::string get_title() const override
     {
-        if (m_manual_rules_override && m_manual_rules_override->preset_alias)
-            return std::format("LOAD LEVEL '{}' ({} '{}')", m_level_name,
-                               m_override_is_mutator ? "MUTATOR" : "PRESET", *m_manual_rules_override->preset_alias);
-        return std::format("LOAD LEVEL '{}'", m_level_name);
+        return std::format("LOAD LEVEL '{}'{}", m_level_name,
+                           build_rules_title_suffix(m_gametype, m_mutator_labels));
     }
 
     void on_accepted() override
     {
         clear_manual_rules_override();
 
-        std::string msg;
-        if (m_manual_rules_override && m_manual_rules_override->preset_alias)
-            msg = std::format("Vote passed: changing level to {} with {} {}",
-                              m_level_name, m_override_is_mutator ? "mutator" : "preset",
-                              *m_manual_rules_override->preset_alias);
-        else
-            msg = std::format("Vote passed: changing level to {}", m_level_name);
-        af_broadcast_automated_chat_msg(msg);
+        std::string msg = std::format("Vote passed: changing level to {}{}", m_level_name,
+                                      build_rules_title_suffix(m_gametype, m_mutator_labels));
+        broadcast_vote_legacy_msg(msg);
+
+        if (m_gametype) {
+            set_upcoming_game_type(*m_gametype, UpcomingGameTypeSelection::ExplicitRequest);
+        }
+
         multi_change_level_alpine(m_level_name.c_str());
 
         if (m_manual_rules_override) {
@@ -800,88 +986,6 @@ struct VoteLevel : public Vote
     }
 };
 
-struct VoteGametype : public Vote
-{
-    std::string m_gametype_name;
-    std::string m_level_name;
-
-    VoteType get_type() const override
-    {
-        return VoteType::Gametype;
-    }
-
-    bool process_vote_arg(std::string_view arg, rf::Player* source) override
-    {
-        arg = trim(arg);
-        if (arg.empty()) {
-            af_send_automated_chat_msg("You must specify a gametype.", source);
-            return false;
-        }
-
-        auto [gametype_part, level_part] = split_once_whitespace(arg);
-        gametype_part = trim(gametype_part);
-
-        if (gametype_part.empty()) {
-            af_send_automated_chat_msg("You must specify a gametype name.", source);
-            return false;
-        }
-
-        if (!is_gametype_name_valid(gametype_part)) {
-            auto msg = std::format("Invalid gametype '{}'!", gametype_part);
-            af_send_automated_chat_msg(msg, source);
-            return false;
-        }
-
-        m_gametype_name.assign(gametype_part);
-
-        if (level_part.empty()) {
-            m_level_name = rf::level.filename.c_str();
-        }
-        else {
-            auto [is_valid, normalized_level_name] = is_level_name_valid(level_part);
-            if (!is_valid) {
-                auto msg = std::format("Cannot start vote: level {} is not available on the server!", normalized_level_name);
-                af_send_automated_chat_msg(msg, source);
-                return false;
-            }
-
-            m_level_name = std::move(normalized_level_name);
-        }
-
-        if (string_iequals(m_level_name, rf::level.filename.c_str())) {
-            return true; // level is current level, skip further checks
-        }
-
-        return is_level_allowed_for_vote(m_level_name, source, false); // skip gametype prefix check for gametype votes
-    }
-
-    [[nodiscard]] std::string get_title() const override
-    {
-        return std::format("SWITCH TO {} ON {}", string_to_upper(m_gametype_name), m_level_name);
-    }
-
-    void on_accepted() override
-    {
-        auto msg = std::format("Vote passed: switching to {} on {}", string_to_upper(m_gametype_name), m_level_name);
-        af_broadcast_automated_chat_msg(msg);
-
-        multi_set_gametype_alpine(m_gametype_name);
-
-        clear_manual_rules_override();
-        multi_change_level_alpine(m_level_name.c_str());
-    }
-
-    [[nodiscard]] bool is_allowed_in_limbo_state() const override
-    {
-        return false;
-    }
-
-    [[nodiscard]] const VoteConfig& get_config() const override
-    {
-        return g_alpine_server_config.vote_gametype;
-    }
-};
-
 struct VoteRestart : public Vote
 {
 
@@ -897,7 +1001,7 @@ struct VoteRestart : public Vote
 
     void on_accepted() override
     {
-        af_broadcast_automated_chat_msg("Vote passed: restarting level");
+        broadcast_vote_legacy_msg("Vote passed: restarting level");
         restart_current_level();
     }
 
@@ -926,7 +1030,7 @@ struct VoteNext : public Vote
 
     void on_accepted() override
     {
-        af_broadcast_automated_chat_msg("Vote passed: loading next level");
+        broadcast_vote_legacy_msg("Vote passed: loading next level");
         load_next_level();
     }
 
@@ -955,7 +1059,7 @@ struct VoteRandom : public Vote
 
     void on_accepted() override
     {
-        af_broadcast_automated_chat_msg("Vote passed: loading random level from rotation");
+        broadcast_vote_legacy_msg("Vote passed: loading random level from rotation");
 
         // if dynamic rotation is on, just load the next level
         g_alpine_server_config.dynamic_rotation ? load_next_level() : load_rand_level();
@@ -986,7 +1090,7 @@ struct VotePrevious : public Vote
 
     void on_accepted() override
     {
-        af_broadcast_automated_chat_msg("Vote passed: loading previous level");
+        broadcast_vote_legacy_msg("Vote passed: loading previous level");
         load_prev_level();
     }
 
@@ -1004,18 +1108,35 @@ struct VotePrevious : public Vote
 class VoteMgr
 {
 private:
-    std::optional<std::unique_ptr<Vote>> active_vote;
+    std::unique_ptr<Vote> active_vote;
+
+    // A concluded vote's outcome handler changes the level, kicks a player or
+    // starts a match — any of which can re-enter the vote system (a kick makes
+    // the engine call server_vote_on_player_leave; a level change eventually
+    // reaches server_vote_on_limbo_state_enter). Detaching the vote from the
+    // manager BEFORE running its outcome means those re-entrant paths see no
+    // active vote and can never destroy the object whose method is running.
+    static void conclude(std::unique_ptr<Vote> vote)
+    {
+        if (!vote) {
+            return;
+        }
+        // Guarantees exactly one end event on every path that drops a vote,
+        // including the ones with no outcome (kick target left, limbo).
+        vote->broadcast_vote_end(AfVoteResult::Canceled);
+        vote->run_pending_outcome();
+    }
 
 public:
-    template<typename T>
-    bool StartVote(std::string_view arg, rf::Player* source)
+    template<typename T, typename... Args>
+    bool StartVote(rf::Player* source, Args&&... args)
     {
         if (active_vote) {
             af_send_automated_chat_msg("Another vote is currently in progress!", source);
             return false;
         }
 
-        auto vote = std::make_unique<T>();
+        auto vote = std::make_unique<T>(std::forward<Args>(args)...);
 
         if (!vote->get_config().enabled) {
             af_send_automated_chat_msg("This vote type is disabled!", source);
@@ -1033,26 +1154,34 @@ public:
             return false;
         }
 
-        if (!vote->start(arg, source)) {
+        if (!vote->validate(source)) {
             return false;
         }
 
-        active_vote = {std::move(vote)};
+        // A vote that resolves immediately (sole eligible voter) never becomes
+        // the active vote: start() reports it finished and conclude() runs the
+        // outcome on the detached object.
+        if (!vote->start(source)) {
+            conclude(std::move(vote));
+            return false;
+        }
+
+        active_vote = std::move(vote);
         return true;
-    }    
+    }
 
     void on_player_leave(rf::Player* player)
     {
-        if (active_vote && !active_vote.value()->on_player_leave(player)) {
-            active_vote.reset();
+        if (active_vote && !active_vote->on_player_leave(player)) {
+            conclude(std::move(active_vote));
         }
     }
 
     void OnLimboStateEnter()
     {
-        if (active_vote && !active_vote.value()->is_allowed_in_limbo_state()) {
-            af_broadcast_automated_chat_msg("Vote canceled!");
-            active_vote.reset();
+        if (active_vote && !active_vote->is_allowed_in_limbo_state()) {
+            std::unique_ptr<Vote> vote = std::move(active_vote);
+            vote->cancel_for_limbo();
         }
     }
 
@@ -1063,8 +1192,8 @@ public:
             return;
         }
 
-        if (!active_vote.value()->add_player_vote(is_yes_vote, source)) {
-            active_vote.reset();
+        if (!active_vote->add_player_vote(is_yes_vote, source)) {
+            conclude(std::move(active_vote));
         }
     }
 
@@ -1075,8 +1204,15 @@ public:
             return;
         }
 
-        if (active_vote.value()->try_cancel_vote(source)) {
-            active_vote.reset();
+        if (active_vote->try_cancel_vote(source)) {
+            conclude(std::move(active_vote));
+        }
+    }
+
+    void send_state_to_player(rf::Player* player)
+    {
+        if (active_vote) {
+            active_vote->send_start_state_to(player);
         }
     }
 
@@ -1085,58 +1221,334 @@ public:
         if (!active_vote)
             return;
 
-        if (!active_vote.value()->do_frame()) {
-            active_vote.reset();
+        if (!active_vote->do_frame()) {
+            conclude(std::move(active_vote));
         }
     }
 };
 
 VoteMgr g_vote_mgr;
 
-void handle_vote_command(std::string_view vote_name, std::string_view vote_arg, rf::Player* sender)
+// ============================================================================
+// Vote-options blob (server -> client schema of what can be voted for)
+// ============================================================================
+
+static std::vector<uint8_t> g_vote_options_blob;
+static uint8_t g_vote_options_generation = 0;
+static bool g_vote_options_blob_valid = false;
+
+static void blob_u8(std::vector<uint8_t>& blob, uint8_t value)
+{
+    blob.push_back(value);
+}
+
+static void blob_u16(std::vector<uint8_t>& blob, uint16_t value)
+{
+    blob.push_back(static_cast<uint8_t>(value & 0xFF));
+    blob.push_back(static_cast<uint8_t>((value >> 8) & 0xFF));
+}
+
+static void blob_u32(std::vector<uint8_t>& blob, uint32_t value)
+{
+    uint8_t bytes[sizeof(value)];
+    std::memcpy(bytes, &value, sizeof(value));
+    blob.insert(blob.end(), bytes, bytes + sizeof(value));
+}
+
+static void blob_i32(std::vector<uint8_t>& blob, int32_t value)
+{
+    uint8_t bytes[sizeof(value)];
+    std::memcpy(bytes, &value, sizeof(value));
+    blob.insert(blob.end(), bytes, bytes + sizeof(value));
+}
+
+static void blob_f32(std::vector<uint8_t>& blob, float value)
+{
+    uint8_t bytes[sizeof(value)];
+    std::memcpy(bytes, &value, sizeof(value));
+    blob.insert(blob.end(), bytes, bytes + sizeof(value));
+}
+
+static void blob_str(std::vector<uint8_t>& blob, std::string_view value)
+{
+    const size_t len = std::min<size_t>(value.size(), 255);
+    blob.push_back(static_cast<uint8_t>(len));
+    blob.insert(blob.end(), value.begin(), value.begin() + len);
+}
+
+static uint16_t build_enabled_vote_mask()
+{
+    const auto& cfg = g_alpine_server_config;
+    const auto bit = [](AfVoteType type) { return static_cast<uint16_t>(1u << static_cast<unsigned>(type)); };
+
+    uint16_t mask = 0;
+    if (cfg.vote_kick.enabled) mask |= bit(AfVoteType::Kick);
+    if (cfg.vote_level.enabled) mask |= bit(AfVoteType::Level);
+    if (cfg.vote_match.enabled) mask |= bit(AfVoteType::Match) | bit(AfVoteType::CancelMatch);
+    if (cfg.vote_extend.enabled) mask |= bit(AfVoteType::Extend);
+    if (cfg.vote_restart.enabled) mask |= bit(AfVoteType::Restart);
+    if (cfg.vote_next.enabled) mask |= bit(AfVoteType::Next);
+    if (cfg.vote_rand.enabled) mask |= bit(AfVoteType::Random);
+    if (cfg.vote_previous.enabled) mask |= bit(AfVoteType::Previous);
+    return mask;
+}
+
+static void build_vote_options_blob(std::vector<uint8_t>& blob)
+{
+    blob.clear();
+    blob_u8(blob, af_vote_options_blob_version);
+    blob_u16(blob, build_enabled_vote_mask());
+
+    // server-wide vote flags
+    uint8_t server_flags = 0;
+    if (g_alpine_server_config.vote_level.only_allow_gametype_prefix) {
+        server_flags |= AF_VOTE_SERVER_FLAG_GAMETYPE_PREFIX;
+    }
+    blob_u8(blob, server_flags);
+
+    // game types
+    const int gametype_count = static_cast<int>(rf::NG_TYPE_GG) + 1;
+    blob_u8(blob, static_cast<uint8_t>(gametype_count));
+    for (int i = 0; i < gametype_count; ++i) {
+        const auto game_type = static_cast<rf::NetGameType>(i);
+        blob_u8(blob, static_cast<uint8_t>(i));
+        blob_u8(blob, multi_game_type_is_team_type(game_type) ? AF_VOTE_GAMETYPE_FLAG_TEAM : 0);
+        blob_str(blob, multi_game_type_name(game_type));
+    }
+
+    // mutators
+    const auto& registry = mutators_get_registry();
+    blob_u8(blob, static_cast<uint8_t>(std::min<size_t>(registry.size(), 255)));
+    for (const auto& mutator : registry) {
+        blob_u8(blob, static_cast<uint8_t>(mutator.id));
+        blob_str(blob, mutator.name);
+        blob_str(blob, mutator.label);
+        blob_u8(blob, static_cast<uint8_t>(std::min<size_t>(mutator.options.size(), 255)));
+        for (const auto& option : mutator.options) {
+            blob_u8(blob, option.id);
+            blob_str(blob, option.name);
+            blob_str(blob, option.label);
+            blob_u8(blob, static_cast<uint8_t>(option.type));
+            switch (option.type) {
+                case MutatorOptionType::Bool:
+                    blob_u8(blob, option.default_bool ? 1 : 0);
+                    break;
+                case MutatorOptionType::Choice:
+                    blob_u8(blob, option.default_choice);
+                    break;
+                case MutatorOptionType::Int:
+                    blob_i32(blob, option.default_int);
+                    break;
+                case MutatorOptionType::Float:
+                    blob_f32(blob, option.default_float);
+                    break;
+                case MutatorOptionType::String:
+                    blob_str(blob, option.default_string);
+                    break;
+            }
+            if (option.type == MutatorOptionType::Choice) {
+                blob_u8(blob, static_cast<uint8_t>(std::min<size_t>(option.choices.size(), 255)));
+                for (const auto& choice : option.choices) {
+                    blob_str(blob, choice.label);
+                }
+            }
+        }
+    }
+
+    // votable levels, each with the game type it would run with by default and
+    // the set of game types whose prefix rules it matches
+    const std::vector<std::string> levels = build_votable_level_list();
+    blob_u16(blob, static_cast<uint16_t>(std::min<size_t>(levels.size(), 65535)));
+    for (const auto& level : levels) {
+        blob_str(blob, level);
+        blob_u8(blob, static_cast<uint8_t>(vote_natural_rules_for_level(level).game_type));
+        blob_u32(blob, build_level_valid_gametype_mask(level));
+    }
+}
+
+void server_vote_invalidate_options_blob()
+{
+    g_vote_options_blob_valid = false;
+}
+
+const std::vector<uint8_t>& server_vote_get_options_blob(uint8_t& generation)
+{
+    if (!g_vote_options_blob_valid) {
+        build_vote_options_blob(g_vote_options_blob);
+        ++g_vote_options_generation;
+        g_vote_options_blob_valid = true;
+        xlog::debug("vote options: rebuilt blob ({} bytes, generation {})",
+                    g_vote_options_blob.size(), g_vote_options_generation);
+    }
+    generation = g_vote_options_generation;
+    return g_vote_options_blob;
+}
+
+// ============================================================================
+// Entry points
+// ============================================================================
+
+// Shared gate for chat and packet vote actions.
+static bool check_voter_eligibility(rf::Player* sender)
 {
     if (sender->version_info.software == ClientSoftware::Browser || sender->is_bot) {
         af_send_automated_chat_msg("Browsers and bots are not allowed to vote!", sender, true);
-        return;
-    } else if (!Vote::player_meets_alpine_restrict(sender)) {
+        return false;
+    }
+    if (!Vote::player_meets_alpine_restrict(sender)) {
         af_send_automated_chat_msg(
             "You can't vote, because your client does not meet the server's requirements. Visit alpinefaction.com to upgrade.",
             sender, true
         );
-        return;
-    } else if (player_is_idle(sender)) {
+        return false;
+    }
+    if (player_is_idle(sender)) {
         af_send_automated_chat_msg("Idle players are not allowed to vote!", sender, true);
+        return false;
+    }
+    return true;
+}
+
+void handle_vote_command(std::string_view vote_name, [[maybe_unused]] std::string_view vote_arg, rf::Player* sender)
+{
+    if (!check_voter_eligibility(sender)) {
         return;
     }
 
-    if (vote_name == "kick")
-        g_vote_mgr.StartVote<VoteKick>(vote_arg, sender);
-    else if (vote_name == "level" || vote_name == "map")
-        g_vote_mgr.StartVote<VoteLevel>(vote_arg, sender);
-    else if (vote_name == "extend" || vote_name == "ext")
-        g_vote_mgr.StartVote<VoteExtend>(vote_arg, sender);
-    else if (vote_name == "gametype" || vote_name == "gamemode" || vote_name == "type" || vote_name == "gt")
-        g_vote_mgr.StartVote<VoteGametype>(vote_arg, sender);
-    else if (vote_name == "restart" || vote_name == "rest")
-        g_vote_mgr.StartVote<VoteRestart>(vote_arg, sender);
-    else if (vote_name == "next")
-        g_vote_mgr.StartVote<VoteNext>(vote_arg, sender);
-    else if (vote_name == "random" || vote_name == "rand")
-        g_vote_mgr.StartVote<VoteRandom>(vote_arg, sender);
-    else if (vote_name == "previous" || vote_name == "prev")
-        g_vote_mgr.StartVote<VotePrevious>(vote_arg, sender);
-    else if (vote_name == "match")
-        g_vote_mgr.StartVote<VoteMatch>(vote_arg, sender);
-    else if (vote_name == "cancelmatch" || vote_name == "nomatch")
-        g_vote_mgr.StartVote<VoteCancelMatch>(vote_arg, sender);
-    else if (vote_name == "yes" || vote_name == "y")
+    if (vote_name == "yes" || vote_name == "y")
         g_vote_mgr.add_player_vote(true, sender);
     else if (vote_name == "no" || vote_name == "n")
         g_vote_mgr.add_player_vote(false, sender);
     else if (vote_name == "cancel")
         g_vote_mgr.try_cancel_vote(sender);
     else
-        af_send_automated_chat_msg("Unrecognized vote type!", sender);
+        af_send_automated_chat_msg(
+            "Calling votes via chat is no longer supported. Vote calling requires Alpine Faction 1.4+ - "
+            "upgrade at alpinefaction.com. You can still vote with /vote yes or /vote no.",
+            sender, true);
+}
+
+// 0xFF means "server default rules"; anything else must name a real game type.
+static bool resolve_vote_gametype(uint8_t wire_value, rf::Player* sender, std::optional<rf::NetGameType>& out)
+{
+    if (wire_value == af_vote_gametype_none) {
+        out = std::nullopt;
+        return true;
+    }
+    if (wire_value > static_cast<uint8_t>(rf::NG_TYPE_GG)) {
+        af_send_automated_chat_msg("Cannot start vote: this server does not support that game type.", sender);
+        return false;
+    }
+    out = static_cast<rf::NetGameType>(wire_value);
+    return true;
+}
+
+static bool resolve_vote_mutators(const std::vector<VoteMutatorInput>& input, rf::Player* sender,
+                                  std::vector<MutatorDeclaration>& out)
+{
+    if (auto error = mutators_build_declarations_from_vote(input, out)) {
+        af_send_automated_chat_msg(std::format("Cannot start vote: {}", *error), sender);
+        return false;
+    }
+    return true;
+}
+
+void handle_vote_call_packet(rf::Player* sender, AfVoteCallParams&& params)
+{
+    if (!rf::is_server || !sender) {
+        return;
+    }
+
+    if (!check_voter_eligibility(sender)) {
+        return;
+    }
+
+    switch (params.type) {
+        case AfVoteType::Kick: {
+            // The id is a parameter, not an identity claim; the sender is always
+            // resolved from the packet source address.
+            rf::Player* target = rf::multi_find_player_by_id(params.target_player_id);
+            g_vote_mgr.StartVote<VoteKick>(sender, target);
+            break;
+        }
+        case AfVoteType::Level: {
+            std::optional<rf::NetGameType> gametype;
+            if (!resolve_vote_gametype(params.gametype, sender, gametype)) {
+                return;
+            }
+            std::vector<MutatorDeclaration> mutators;
+            if (!resolve_vote_mutators(params.mutators, sender, mutators)) {
+                return;
+            }
+            if (params.level.empty()) {
+                af_send_automated_chat_msg("Cannot start vote: no level was specified.", sender);
+                return;
+            }
+            g_vote_mgr.StartVote<VoteLevel>(sender, std::move(params.level), gametype, std::move(mutators));
+            break;
+        }
+        case AfVoteType::Match: {
+            std::optional<rf::NetGameType> gametype;
+            if (!resolve_vote_gametype(params.gametype, sender, gametype)) {
+                return;
+            }
+            std::vector<MutatorDeclaration> mutators;
+            if (!resolve_vote_mutators(params.mutators, sender, mutators)) {
+                return;
+            }
+            g_vote_mgr.StartVote<VoteMatch>(sender, static_cast<int>(params.team_size),
+                                            std::move(params.level), gametype, std::move(mutators));
+            break;
+        }
+        case AfVoteType::Extend:
+            g_vote_mgr.StartVote<VoteExtend>(sender);
+            break;
+        case AfVoteType::Restart:
+            g_vote_mgr.StartVote<VoteRestart>(sender);
+            break;
+        case AfVoteType::Next:
+            g_vote_mgr.StartVote<VoteNext>(sender);
+            break;
+        case AfVoteType::Random:
+            g_vote_mgr.StartVote<VoteRandom>(sender);
+            break;
+        case AfVoteType::Previous:
+            g_vote_mgr.StartVote<VotePrevious>(sender);
+            break;
+        case AfVoteType::CancelMatch:
+            g_vote_mgr.StartVote<VoteCancelMatch>(sender);
+            break;
+        default:
+            xlog::warn("handle_vote_call_packet: unhandled vote type {}", static_cast<int>(params.type));
+            break;
+    }
+}
+
+void handle_vote_cast_packet(rf::Player* sender, bool is_yes_vote)
+{
+    if (!rf::is_server || !sender) {
+        return;
+    }
+    if (!check_voter_eligibility(sender)) {
+        return;
+    }
+    g_vote_mgr.add_player_vote(is_yes_vote, sender);
+}
+
+void handle_vote_cancel_packet(rf::Player* sender)
+{
+    if (!rf::is_server || !sender) {
+        return;
+    }
+    g_vote_mgr.try_cancel_vote(sender);
+}
+
+void server_vote_send_state_to_new_player(rf::Player* player)
+{
+    if (!rf::is_server) {
+        return;
+    }
+    g_vote_mgr.send_state_to_player(player);
 }
 
 void server_vote_do_frame()

--- a/game_patch/multi/wipeout.cpp
+++ b/game_patch/multi/wipeout.cpp
@@ -373,7 +373,7 @@ void wipeout_do_frame()
     g_internal_spawn_in_progress = false;
 }
 
-bool wipeout_can_player_spawn(rf::Player* player)
+bool wipeout_can_player_spawn(rf::Player* player, bool notify)
 {
     if (!gt_is_wipeout()) return true; // not our problem
     if (!player) return true;
@@ -386,8 +386,11 @@ bool wipeout_can_player_spawn(rf::Player* player)
     const bool between_rounds = rounds_is_between_rounds();
     if (between_rounds || player->round_is_out) {
         // Throttle the notice: the client re-requests a spawn every frame while
-        // the fire button is held, which would otherwise spam chat.
-        if (!player->waiting_msg_timer.valid() || player->waiting_msg_timer.elapsed()) {
+        // the fire button is held, which would otherwise spam chat. With
+        // notify = false the caller only wants the verdict, so nothing is sent
+        // and waiting_msg_timer is left untouched.
+        if (notify
+            && (!player->waiting_msg_timer.valid() || player->waiting_msg_timer.elapsed())) {
             af_send_automated_chat_msg(
                 between_rounds ? "Wait - the next round is starting shortly."
                                : "You're waiting for the next round to begin.",

--- a/game_patch/multi/wipeout.h
+++ b/game_patch/multi/wipeout.h
@@ -9,7 +9,9 @@ namespace rf
 void wipeout_level_init();
 void wipeout_level_init_post();
 void wipeout_do_frame();
-bool wipeout_can_player_spawn(rf::Player* player);
+// `notify` = false queries the gate without sending the player the throttled
+// "wait for the next round" notice.
+bool wipeout_can_player_spawn(rf::Player* player, bool notify = true);
 bool wipeout_is_subsequent_spawn(rf::Player* player);
 int wipeout_get_red_team_score();
 int wipeout_get_blue_team_score();

--- a/game_patch/rf/player/control_config.h
+++ b/game_patch/rf/player/control_config.h
@@ -57,7 +57,8 @@ namespace rf
         AF_ACTION_SPECTATE_TOGGLE = 0x10,
         AF_ACTION_SPECTATE_CHANGE_VIEW = 0x11,
         AF_ACTION_SPRAY = 0x12,
-        _AF_ACTION_LAST_VARIANT = AF_ACTION_SPRAY
+        AF_ACTION_VOTE_MENU = 0x13,
+        _AF_ACTION_LAST_VARIANT = AF_ACTION_VOTE_MENU
     };
 
     struct ControlConfigItem

--- a/game_patch/rf/player/player.h
+++ b/game_patch/rf/player/player.h
@@ -92,9 +92,17 @@ struct PlayerAdditionalData {
     std::optional<rf::Player*> spectatee{};
     bool remote_server_cfg_sent = false;
 
-    // Rate limit for af_req_vote_options: the blob is chunked over the deferred
-    // reliable queue, so a client must not be able to spam it.
+    // Floor rate limit for af_req_vote_options: the blob is streamed over the
+    // deferred reliable queue, so a client must not be able to spam it.
     rf::TimestampRealtime vote_options_req_timer{};
+
+    // Generation of the vote-options blob last streamed to this player, so an
+    // identical one is never sent twice.
+    // 0 = nothing sent yet; generations start at 1.
+    uint32_t vote_options_sent_generation = 0;
+
+    // Rate limit for vote rejection replies.
+    rf::TimestampRealtime vote_reject_msg_timer{};
 
     // Server side rail gun reload cooldown, used for force_rail_reload
     // needed because entity_is_reloading is unreliable on server
@@ -113,12 +121,13 @@ struct PlayerAdditionalData {
     // subsequent-spawn (cluster near teammates) logic. Both reset each round.
     int wipeout_round_deaths = 0;
     bool wipeout_spawned_this_round = false;
-    // Throttles every spawn-denied chat line so repeated spawn requests (e.g.
-    // holding fire while dead) don't spam them. Shared by Wipeout, Pit and the
-    // spawn gates in multi_spawn_player_server_side (see
-    // send_spawn_decline_msg) so two different decline reasons can't alternate
-    // and double the rate.
+    // Throttles the Wipeout / Pit "you can't spawn yet" lines, which have their own
+    // ~3s cadence. Deliberately NOT shared with send_spawn_decline_msg, which uses
+    // a different timer (5s).
     rf::Timestamp waiting_msg_timer{};
+    // Throttles the spawn-decline notices in multi_spawn_player_server_side
+    // (Alpine restriction, anti-cheat, match in progress, bot, respawn delay).
+    rf::Timestamp spawn_decline_msg_timer{};
 };
 static_assert(alignof(PlayerAdditionalData) == 0x8);
 #endif

--- a/game_patch/rf/player/player.h
+++ b/game_patch/rf/player/player.h
@@ -92,6 +92,10 @@ struct PlayerAdditionalData {
     std::optional<rf::Player*> spectatee{};
     bool remote_server_cfg_sent = false;
 
+    // Rate limit for af_req_vote_options: the blob is chunked over the deferred
+    // reliable queue, so a client must not be able to spam it.
+    rf::TimestampRealtime vote_options_req_timer{};
+
     // Server side rail gun reload cooldown, used for force_rail_reload
     // needed because entity_is_reloading is unreliable on server
     rf::Timestamp rail_gun_reload_timer{};
@@ -109,9 +113,11 @@ struct PlayerAdditionalData {
     // subsequent-spawn (cluster near teammates) logic. Both reset each round.
     int wipeout_round_deaths = 0;
     bool wipeout_spawned_this_round = false;
-    // Throttles the "you're waiting" spawn-denied chat line so repeated spawn
-    // requests (e.g. holding fire while waiting) don't spam it. Shared by
-    // Wipeout and Pit.
+    // Throttles every spawn-denied chat line so repeated spawn requests (e.g.
+    // holding fire while dead) don't spam them. Shared by Wipeout, Pit and the
+    // spawn gates in multi_spawn_player_server_side (see
+    // send_spawn_decline_msg) so two different decline reasons can't alternate
+    // and double the rate.
     rf::Timestamp waiting_msg_timer{};
 };
 static_assert(alignof(PlayerAdditionalData) == 0x8);

--- a/game_patch/rf/ui.h
+++ b/game_patch/rf/ui.h
@@ -235,6 +235,7 @@ namespace rf::ui
     static auto& popup_abort = addr_as_ref<void()>(0x004559C0);
     static auto& popup_set_text = addr_as_ref<void(const char *text)>(0x00455A50);
     static auto& popup_get_input = addr_as_ref<void(char* string, int max_len)>(0x004566A0);
+    static auto& popup_is_active = addr_as_ref<bool()>(0x00456680);
 
     static auto& mainmenu_quit_game_confirmed = addr_as_ref<void()>(0x00443CB0);
 


### PR DESCRIPTION
- Rework multiplayer voting to use a GUI-based system instead of chat commands
  - Servers describe their votable levels, game types, and mutator options to clients
  - `vote level` and `vote match` can now select a game type and any number of mutators (with their options) for the voted level
  - Add a vote panel for calling any vote the server allows, opened during gameplay with the bindable `Call Vote Menu` control (`F4` by default)
  - Vote HUD notification now shows live tally, time remaining, and whether you have already voted

- Rate limit spawn-denied notifications (Alpine restriction, anti-cheat, match in progress, respawn delay) to one message per 5 seconds per player so repeated spawn attempts no longer flood chat
- Truncate over-long names from dedicated server config files when they are quoted in console warnings
- Remove `vote gametype`, game type selection is now part of `vote level`
- No longer allow a player to call a vote to kick themselves
- Change default inactive time before a player is set as idle to 60 seconds (from 30 seconds)
- Stop labeling players as inactive if they are unable to spawn due to a server or gameplay rule
- Fix server version checks comparing each version field independently, which would have rejected a future major version
- Fix out of bounds read when applying level rules if the rotation shrank while a level was running
- Fix the remote server config display sometimes being treated as complete before all of its content had arrived

Also adds the Vampire mutator