### PR TITLE
Log first-chance exceptions that RF's own SEH swallows

### DIFF
--- a/game_patch/CMakeLists.txt
+++ b/game_patch/CMakeLists.txt
@@ -123,6 +123,7 @@ set(SRCS
     debug/debugwinmsg.cpp
     debug/debug_cmd.cpp
     debug/debug.cpp
+    debug/exception_logger.cpp
     debug/obj_debug.cpp
     debug/debug.h
     debug/debug_internal.h

--- a/game_patch/debug/debug.h
+++ b/game_patch/debug/debug.h
@@ -2,6 +2,7 @@
 
 void debug_apply_patches();
 void debug_init();
+void exception_logger_init();
 void debug_cleanup();
 void debug_render();
 void debug_render_ui();

--- a/game_patch/debug/exception_logger.cpp
+++ b/game_patch/debug/exception_logger.cpp
@@ -1,0 +1,302 @@
+#include <windows.h>
+#include <dbghelp.h>
+#include <cstdint>
+#include <format>
+#include <string>
+#include <xlog/xlog.h>
+#include "debug.h"
+
+// Logs first-chance C++ exceptions and access violations before any SEH frame can
+// swallow them.
+//
+// Red Faction wraps large parts of the frame loop in its own __try/__except. When an
+// exception is raised in there the process dies (or silently continues) with nothing in
+// AlpineFaction.log: the log simply stops mid-frame. crash_handler_stub uses
+// SetUnhandledExceptionFilter, which by definition only runs for exceptions nobody
+// handled, so it never sees these either.
+//
+// A vectored exception handler runs ahead of every SEH frame, so it observes the throw
+// before RF gets a chance to eat it. This one only logs and always returns
+// EXCEPTION_CONTINUE_SEARCH, so exception handling behaviour is unchanged.
+//
+// These are *first-chance* exceptions: most are caught and handled a moment later, and
+// seeing them in the log is normal. They are logged at warn level and capped, so a hot
+// loop that throws cannot flood the file.
+
+static int g_num_logged = 0;
+constexpr int max_logged = 40;
+
+static void copy_str(char* dst, int dst_size, const char* src)
+{
+    int i = 0;
+    if (!src) {
+        dst[0] = 0;
+        return;
+    }
+    while (i < dst_size - 1 && src[i]) {
+        dst[i] = src[i];
+        ++i;
+    }
+    dst[i] = 0;
+}
+
+// Reading the type name out of a C++ throw is MSVC-specific in two ways, so the whole
+// probe is compiled only for MSVC:
+//
+//   - The 0xE06D7363 exception code and the ThrowInfo structures below are the MSVC C++
+//     ABI. A MinGW build uses a different mechanism entirely, so this parsing would be
+//     reading garbage.
+//   - Walking those structures means chasing pointers in a process that is already in
+//     trouble, so it needs SEH protection. __try/__except is MSVC syntax; GCC rejects it.
+//
+// Everything else in this file — access violations, the stack walk, symbol resolution —
+// is plain Win32 and works the same either way. On MinGW a C++ throw is still logged,
+// just without the type name.
+#ifdef _MSC_VER
+
+// Layout of the MSVC throw metadata (x86: all pointers are absolute).
+struct MsvcTypeDescriptor
+{
+    const void* vftable;
+    void* spare;
+    char name[1];
+};
+struct MsvcCatchableType
+{
+    unsigned properties;
+    MsvcTypeDescriptor* type_desc;
+};
+struct MsvcCatchableTypeArray
+{
+    int count;
+    MsvcCatchableType* types[1];
+};
+struct MsvcThrowInfo
+{
+    unsigned attributes;
+    void* unwind;
+    void* forward_compat;
+    MsvcCatchableTypeArray* catchable;
+};
+
+// True for mangled names ending in "@std@@", i.e. types inside namespace std.
+// Only those are safe to poke for what() through the vtable.
+static bool name_is_std(const char* name)
+{
+    int len = 0;
+    while (name[len] && len < 240) {
+        ++len;
+    }
+    return len >= 6 && name[len - 6] == '@' && name[len - 5] == 's' && name[len - 4] == 't'
+        && name[len - 3] == 'd' && name[len - 2] == '@' && name[len - 1] == '@';
+}
+
+// Must stay free of objects with destructors, otherwise MSVC rejects __try (C2712).
+static void probe_throw(const EXCEPTION_RECORD* rec, char* type_out, int type_size,
+                           char* what_out, int what_size)
+{
+    copy_str(type_out, type_size, "?");
+    copy_str(what_out, what_size, "");
+    if (rec->NumberParameters < 3) {
+        return;
+    }
+    __try {
+        const MsvcThrowInfo* ti = reinterpret_cast<const MsvcThrowInfo*>(rec->ExceptionInformation[2]);
+        if (!ti || !ti->catchable || ti->catchable->count <= 0) {
+            return;
+        }
+        const char* name = ti->catchable->types[0]->type_desc->name;
+        copy_str(type_out, type_size, name);
+        if (name_is_std(name)) {
+            void* obj = reinterpret_cast<void*>(rec->ExceptionInformation[1]);
+            if (obj) {
+                // std::exception vtable: [0] destructor, [1] what()
+                typedef const char*(__thiscall* WhatFn)(void*);
+                WhatFn fn = reinterpret_cast<WhatFn>((*reinterpret_cast<void***>(obj))[1]);
+                copy_str(what_out, what_size, fn(obj));
+            }
+        }
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER) {
+        copy_str(what_out, what_size, "<probe faulted>");
+    }
+}
+
+#else  // !_MSC_VER
+
+static void probe_throw(const EXCEPTION_RECORD*, char* type_out, int type_size,
+                        char* what_out, int what_size)
+{
+    copy_str(type_out, type_size, "<needs MSVC>");
+    copy_str(what_out, what_size, "");
+}
+
+#endif  // _MSC_VER
+
+// dbghelp is loaded dynamically so the build system needs no extra link library.
+typedef DWORD(WINAPI* SymSetOptionsFn)(DWORD);
+typedef BOOL(WINAPI* SymInitializeFn)(HANDLE, PCSTR, BOOL);
+typedef BOOL(WINAPI* SymFromAddrFn)(HANDLE, DWORD64, PDWORD64, PSYMBOL_INFO);
+typedef BOOL(WINAPI* SymGetLineFn)(HANDLE, DWORD64, PDWORD, PIMAGEHLP_LINE64);
+typedef BOOL(WINAPI* StackWalkFn)(DWORD, HANDLE, HANDLE, LPSTACKFRAME64, PVOID,
+    PREAD_PROCESS_MEMORY_ROUTINE64, PFUNCTION_TABLE_ACCESS_ROUTINE64,
+    PGET_MODULE_BASE_ROUTINE64, PTRANSLATE_ADDRESS_ROUTINE64);
+
+static SymFromAddrFn g_sym_from_addr = nullptr;
+static SymGetLineFn g_sym_get_line = nullptr;
+static StackWalkFn g_stack_walk = nullptr;
+static PFUNCTION_TABLE_ACCESS_ROUTINE64 g_table_access = nullptr;
+static PGET_MODULE_BASE_ROUTINE64 g_module_base = nullptr;
+
+static void sym_init()
+{
+    static bool tried = false;
+    if (tried) {
+        return;
+    }
+    tried = true;
+    HMODULE lib = LoadLibraryA("dbghelp.dll");
+    if (!lib) {
+        return;
+    }
+    auto set_options = reinterpret_cast<SymSetOptionsFn>(GetProcAddress(lib, "SymSetOptions"));
+    auto initialize = reinterpret_cast<SymInitializeFn>(GetProcAddress(lib, "SymInitialize"));
+    g_sym_from_addr = reinterpret_cast<SymFromAddrFn>(GetProcAddress(lib, "SymFromAddr"));
+    g_sym_get_line = reinterpret_cast<SymGetLineFn>(GetProcAddress(lib, "SymGetLineFromAddr64"));
+    g_stack_walk = reinterpret_cast<StackWalkFn>(GetProcAddress(lib, "StackWalk64"));
+    g_table_access = reinterpret_cast<PFUNCTION_TABLE_ACCESS_ROUTINE64>(
+        GetProcAddress(lib, "SymFunctionTableAccess64"));
+    g_module_base = reinterpret_cast<PGET_MODULE_BASE_ROUTINE64>(
+        GetProcAddress(lib, "SymGetModuleBase64"));
+    if (set_options) {
+        set_options(SYMOPT_DEFERRED_LOADS | SYMOPT_UNDNAME | SYMOPT_LOAD_LINES);
+    }
+    if (initialize) {
+        // nullptr search path + invade: picks up the .pdb sitting next to each module
+        initialize(GetCurrentProcess(), nullptr, TRUE);
+    }
+    xlog::info("[exception-logger] dbghelp: sym={} line={} walk={} tbl={} base={}",
+        g_sym_from_addr != nullptr, g_sym_get_line != nullptr, g_stack_walk != nullptr,
+        g_table_access != nullptr, g_module_base != nullptr);
+}
+
+// Resolve to "func+off [file:line]" when a PDB is available, else "module+RVA".
+static std::string addr_str(void* addr)
+{
+    sym_init();
+    if (g_sym_from_addr) {
+        char storage[sizeof(SYMBOL_INFO) + 256] = {};
+        SYMBOL_INFO* sym = reinterpret_cast<SYMBOL_INFO*>(storage);
+        sym->SizeOfStruct = sizeof(SYMBOL_INFO);
+        sym->MaxNameLen = 255;
+        DWORD64 sym_off = 0;
+        const DWORD64 addr64 = static_cast<DWORD64>(reinterpret_cast<uintptr_t>(addr));
+        if (g_sym_from_addr(GetCurrentProcess(), addr64, &sym_off, sym)) {
+            std::string out = std::format("{}+{:#x}", sym->Name, static_cast<uintptr_t>(sym_off));
+            if (g_sym_get_line) {
+                IMAGEHLP_LINE64 line = {};
+                line.SizeOfStruct = sizeof(line);
+                DWORD line_off = 0;
+                if (g_sym_get_line(GetCurrentProcess(), addr64, &line_off, &line)) {
+                    out += std::format(" [{}:{}]", line.FileName, line.LineNumber);
+                }
+            }
+            return out;
+        }
+    }
+    HMODULE mod = nullptr;
+    if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS
+                               | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                           reinterpret_cast<LPCSTR>(addr), &mod)
+        && mod) {
+        char path[MAX_PATH] = "";
+        GetModuleFileNameA(mod, path, MAX_PATH);
+        const char* base = path;
+        for (const char* p = path; *p; ++p) {
+            if (*p == '\\') {
+                base = p + 1;
+            }
+        }
+        return std::format("{}+{:#x}", base,
+            reinterpret_cast<uintptr_t>(addr) - reinterpret_cast<uintptr_t>(mod));
+    }
+    return std::format("{:#x}", reinterpret_cast<uintptr_t>(addr));
+}
+
+static LONG CALLBACK exception_logger(EXCEPTION_POINTERS* ep)
+{
+    const EXCEPTION_RECORD* rec = ep->ExceptionRecord;
+    const DWORD code = rec->ExceptionCode;
+    const bool is_cpp = code == 0xE06D7363u;
+    const bool is_av = code == 0xC0000005u;
+    if ((!is_cpp && !is_av) || g_num_logged >= max_logged) {
+        return EXCEPTION_CONTINUE_SEARCH;
+    }
+    ++g_num_logged;
+    // Load dbghelp now rather than lazily from addr_str(): the C++ throw branch below
+    // reaches the stack walk without ever calling addr_str(), and StackWalk64 would be
+    // skipped on the very first exception.
+    sym_init();
+
+    if (is_cpp) {
+        char type_name[192];
+        char what_msg[256];
+        probe_throw(rec, type_name, sizeof(type_name), what_msg, sizeof(what_msg));
+        xlog::warn("[first-chance {}] C++ throw type={} what={}", g_num_logged, type_name, what_msg);
+    }
+    else {
+        const char* op = "read";
+        if (rec->NumberParameters >= 1) {
+            if (rec->ExceptionInformation[0] == 1) {
+                op = "write";
+            }
+            else if (rec->ExceptionInformation[0] == 8) {
+                op = "execute";
+            }
+        }
+        const uintptr_t bad = rec->NumberParameters >= 2 ? rec->ExceptionInformation[1] : 0;
+        xlog::warn("[first-chance {}] access violation {} at {:#x}, pc={}", g_num_logged, op, bad,
+            addr_str(rec->ExceptionAddress));
+    }
+
+    // Release x86 omits frame pointers, so a naive EBP walk stops after a few frames.
+    // StackWalk64 uses the FPO/unwind data from the PDB and gets the whole chain.
+    std::string trace;
+    if (g_stack_walk && g_table_access && g_module_base) {
+        CONTEXT ctx = *ep->ContextRecord;  // StackWalk64 modifies it, so work on a copy
+        STACKFRAME64 sf = {};
+        sf.AddrPC.Offset = ctx.Eip;
+        sf.AddrPC.Mode = AddrModeFlat;
+        sf.AddrFrame.Offset = ctx.Ebp;
+        sf.AddrFrame.Mode = AddrModeFlat;
+        sf.AddrStack.Offset = ctx.Esp;
+        sf.AddrStack.Mode = AddrModeFlat;
+        for (int i = 0; i < 28; ++i) {
+            if (!g_stack_walk(IMAGE_FILE_MACHINE_I386, GetCurrentProcess(), GetCurrentThread(),
+                    &sf, &ctx, nullptr, g_table_access, g_module_base, nullptr)) {
+                break;
+            }
+            if (sf.AddrPC.Offset == 0) {
+                break;
+            }
+            trace += "\n    ";
+            trace += addr_str(reinterpret_cast<void*>(static_cast<uintptr_t>(sf.AddrPC.Offset)));
+        }
+    }
+    else {
+        void* frames[32] = {};
+        USHORT n = RtlCaptureStackBackTrace(0, 32, frames, nullptr);
+        for (USHORT i = 0; i < n; ++i) {
+            trace += "\n    ";
+            trace += addr_str(frames[i]);
+        }
+    }
+    xlog::warn("[first-chance {}]   stack:{}", g_num_logged, trace);
+
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+
+void exception_logger_init()
+{
+    AddVectoredExceptionHandler(1, exception_logger);
+}

--- a/game_patch/main/main.cpp
+++ b/game_patch/main/main.cpp
@@ -578,6 +578,7 @@ extern "C" DWORD __declspec(dllexport) Init([[maybe_unused]] void* unused)
     level_init_post_hook.install();
 
     // Init modules
+    exception_logger_init();
     console_apply_patches();
     gr_apply_patch();
     bm_apply_patch();


### PR DESCRIPTION
# Log first-chance exceptions that RF's own SEH swallows

Follow-up to the last point in #399.

## Problem

Red Faction wraps large parts of the frame loop in its own `__try`/`__except`. When an
exception is raised in there, `AlpineFaction.log` simply stops mid-frame — no error line,
no stack, nothing. `crash_handler_stub` uses `SetUnhandledExceptionFilter`, which by
definition only runs for exceptions nobody handled, so it never sees these either.

That is what made #399 take days to track down. The process vanished a second after
joining any server and the log ended mid-frame. The bug turned out to be a
`std::format_error` thrown deep under the scoreboard draw path — completely invisible
until I attached a vectored exception handler by hand.

## What this adds

`game_patch/debug/exception_logger.cpp`, ~250 lines, self-contained.

A vectored exception handler runs ahead of every SEH frame, so it observes the throw
before RF can eat it. For C++ throws (`0xE06D7363`) and access violations (`0xC0000005`)
it logs:

- the exception type, demangled from the MSVC throw metadata, plus `what()` when the
  thrown object derives from something in `namespace std`
- for access violations: read/write/execute, the faulting address, and the PC
- a stack trace

Everything else is passed through untouched.

Reverting the #400 fix locally and joining a server reproduces the original crash. This
is the actual log output, and it is the whole of what the log used to contain for this
crash — nothing:

```
[  11.97] INFO: [exception-logger] dbghelp: sym=true line=true walk=true tbl=true base=true
[  11.97] WARN: [first-chance 1] C++ throw type=.?AVformat_error@std@@ what=Invalid encoded character in format string.
[  12.00] WARN: [first-chance 1]   stack:
    RaiseException+0x64
    _CxxThrowException+0x67 [D:\a\_work\1\s\src\vctools\crt\vcruntime\src\eh\throw.cpp:79]
    std::_Throw_format_error+0x1e
    std::_Parse_format_string<char,std::__p2286::_Format_handler<char> &>+0x17e
    std::__p2286::vformat_to<std::back_insert_iterator<std::basic_string<char,std::char_traits<char>,std::allocator<char> > > >+0xb4
    std::__p2286::vformat<0>+0xc2
    draw_scoreboard_header+0x154
    draw_scoreboard_internal_new+0x770
    RF_120na.exe+0x70873
```

The log ends there — the process dies immediately after. Note the last three frames:
the trace walks out of the CRT and through Alpine's own functions to name
`draw_scoreboard_header` as the call site, then hits RF's own code where there are no
symbols and degrades to `module+RVA`. Landing on the exact function is what makes the
output actionable; when I hit this by hand in #399 the trace stopped at `vformat_to`
and I still had to find the call site myself.

## Design notes

**Behaviour is unchanged.** The handler only logs and always returns
`EXCEPTION_CONTINUE_SEARCH`. It never handles, swallows or alters an exception.

**These are first-chance exceptions.** Most are caught and handled a moment later, and
seeing them in the log is normal — there are ~60 `catch` sites in the tree. They are
logged at `warn`, not `error`, and the message says `first-chance` so a log reader does
not mistake them for crashes. Output is capped at 40 entries per session, so a hot loop
that throws cannot flood the file.

**No build system changes beyond the new source file.** dbghelp is resolved at runtime
with `LoadLibrary`/`GetProcAddress`, so there is no new link dependency and nothing
breaks if it is unavailable — symbol resolution just degrades to `module+RVA`.

**MinGW.** Everything except the C++ type-name probe is plain Win32 and builds either
way. That probe is `#ifdef _MSC_VER` for two independent reasons: the `0xE06D7363`
exception code and the `ThrowInfo` structures it walks are the MSVC C++ ABI, so on a
GCC build it would be parsing something that isn't there; and walking them safely needs
`__try`/`__except`, which GCC does not have. Under MinGW a C++ throw is still logged
with its stack, just without the type name. Access violations are unaffected.

**Stack walking.** Release x86 omits frame pointers, so a naive EBP walk stops after a
few frames. `StackWalk64` uses the FPO/unwind data from the PDB and gets the whole
chain; if dbghelp could not be loaded it falls back to
`RtlCaptureStackBackTrace`. Symbols resolve to `func+off [file:line]` when a PDB is
next to the module, otherwise `module+RVA`, which is still enough to locate a frame in
a disassembler.

**Reading the throw metadata is guarded.** `probe_throw` walks the MSVC `ThrowInfo`
structures and, for `std::` types, calls `what()` through the vtable. That is all
pointer-chasing into a process that is already in trouble, so it sits inside a
`__try`/`__except` and reports `<probe faulted>` rather than making a bad situation
worse. It deliberately contains no objects with destructors, otherwise MSVC rejects the
`__try` with C2712.

## Things you may want to change

- **Always on vs opt-in.** It is on by default here, since the whole point is to have
  the line already in the log when someone reports a mystery crash rather than asking
  them to reproduce it. If the first-chance noise bothers you, gating it behind a
  command line switch or an `alpine_settings.ini` option is a two-line change.
- **The 40-entry cap and the 28-frame depth** are arbitrary; adjust to taste.

## Testing

Built with MSVC toolset 14.44.35207, x86 Release, Ninja. Played through single player
and joined multiplayer servers.

On a clean tree the log is quiet — a normal session produces no first-chance entries at
all, so this does not add noise in practice.

To confirm it actually fires, I reverted the #400 fix, rebuilt, and joined a server.
That produced the output quoted above, and the game crashed exactly as it did in #399 —
behaviour is unchanged, the exception is simply recorded on its way past.
