### PR TITLE
Bounds-check TTF font ids and fix the glyph table desync

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -181,6 +181,8 @@ Version 1.4.0 (Lupin): Not yet released
 
 [@jyh9521](https://github.com/jyh9521)
 - Fix crash on join for builds compiled on Windows systems using a Japanese, Chinese, or Korean locale
+- Fix crash when a HUD element requests an out of range TrueType font id
+- Fix TrueType fonts rendering the wrong glyphs when a character fails to load
 
 Version 1.3.0 (Bakeapple): Released Apr-22-2026
 --------------------------------

--- a/game_patch/graphics/gr_font.cpp
+++ b/game_patch/graphics/gr_font.cpp
@@ -1,5 +1,6 @@
 #include <memory>
 #include <unordered_map>
+#include <unordered_set>
 #include <cstddef>
 #include <exception>
 #include <cctype>
@@ -322,7 +323,13 @@ GrNewFont::GrNewFont(std::string_view name) :
     for (auto codepoint : unicode_code_points) {
         error = FT_Load_Char(face, codepoint, FT_LOAD_RENDER);
         if (error) {
-            xlog::error("FT_Load_Char failed: {}", error);
+            // char_map_ stores indices into unicode_code_points, so glyphs_ has to stay
+            // index aligned with it. Skipping an entry here would shift every later glyph
+            // by one and push the last char_map_ entries past the end of glyphs_ -- an out
+            // of range operator[] read that does not throw and is not otherwise detectable.
+            // A zero filled glyph draws nothing and advances the pen by nothing.
+            xlog::error("FT_Load_Char failed for codepoint {:#x}: {}", codepoint, error);
+            glyphs_.push_back(GlyphInfo{});
             continue;
         }
         FT_GlyphSlot slot = face->glyph;
@@ -498,6 +505,15 @@ FunHook<bool(const char*)> gr_set_default_font_hook{
     },
 };
 
+// A bad font id is typically a stuck value in a HUD element, so it recurs every frame.
+// The log appender flushes synchronously, so reporting it unconditionally would be
+// thousands of disk writes per second. Report each distinct id once.
+static bool report_bad_font_id_once(int font_num)
+{
+    static std::unordered_set<int> reported;
+    return reported.insert(font_num).second;
+}
+
 FunHook<int(int)> gr_get_font_height_hook{
     0x0051F4D0,
     [](int font_num) {
@@ -505,8 +521,15 @@ FunHook<int(int)> gr_get_font_height_hook{
             font_num = g_default_font_id;
         }
         if (font_num & ttf_font_flag) {
-            auto& font = g_fonts[font_num & ~ttf_font_flag];
-            return font.get_height();
+            unsigned idx = static_cast<unsigned>(font_num & ~ttf_font_flag);
+            if (idx >= g_fonts.size()) {
+                if (report_bad_font_id_once(font_num)) {
+                    xlog::error("gr_get_font_height: bad TTF font id {:#x} (have {})",
+                        font_num, g_fonts.size());
+                }
+                return 0;
+            }
+            return g_fonts[idx].get_height();
         }
         return gr_get_font_height_hook.call_target(font_num);
     },
@@ -519,8 +542,15 @@ FunHook<void(int, int, const char*, int, rf::gr::Mode)> gr_string_hook{
             font_num = g_default_font_id;
         }
         if (font_num & ttf_font_flag) {
-            auto& font = g_fonts[font_num & ~ttf_font_flag];
-            font.draw(x, y, text, mode);
+            unsigned idx = static_cast<unsigned>(font_num & ~ttf_font_flag);
+            if (idx >= g_fonts.size()) {
+                if (report_bad_font_id_once(font_num)) {
+                    xlog::error("gr_string: bad TTF font id {:#x} (have {})",
+                        font_num, g_fonts.size());
+                }
+                return;
+            }
+            g_fonts[idx].draw(x, y, text, mode);
         }
         else {
             gr_string_hook.call_target(x, y, text, font_num, mode);
@@ -535,7 +565,16 @@ FunHook<void(int*, int*, const char*, int, int)> gr_get_string_size_hook{
             font_num = g_default_font_id;
         }
         if (font_num & ttf_font_flag) {
-            auto& font = g_fonts[font_num & ~ttf_font_flag];
+            unsigned idx = static_cast<unsigned>(font_num & ~ttf_font_flag);
+            if (idx >= g_fonts.size()) {
+                if (report_bad_font_id_once(font_num)) {
+                    xlog::error("gr_get_string_size: bad TTF font id {:#x} (have {})",
+                        font_num, g_fonts.size());
+                }
+                *out_width = 0;
+                *out_height = 0;
+                return;
+            }
             std::string_view text_sv;
             if (text_len < 0) {
                 text_sv = std::string_view{text};
@@ -543,7 +582,7 @@ FunHook<void(int*, int*, const char*, int, int)> gr_get_string_size_hook{
             else {
                 text_sv = std::string_view{text, static_cast<size_t>(text_len)};
             }
-            font.get_size(out_width, out_height, text_sv);
+            g_fonts[idx].get_size(out_width, out_height, text_sv);
         }
         else {
             gr_get_string_size_hook.call_target(out_width, out_height, text, text_len, font_num);

--- a/game_patch/multi/alpine_packets.cpp
+++ b/game_patch/multi/alpine_packets.cpp
@@ -3995,7 +3995,7 @@ void af_broadcast_automated_chat_msg(const std::string_view msg) {
                 0
             );
         } else {
-            send_chat_line_packet(std::format("\xA6 {}", msg), &player);
+            send_chat_line_packet(std::string("\xA6 ") + std::string(msg), &player);
         }
     }
 }

--- a/game_patch/multi/multi.cpp
+++ b/game_patch/multi/multi.cpp
@@ -735,7 +735,7 @@ bool is_entity_out_of_ammo(rf::Entity *entity, int weapon_type, bool alt_fire)
 }
 void send_private_message_for_cancelled_shot(rf::Player* player, const std::string& reason)
 {
-    auto message = std::format("\xA6 Shot canceled: {}", reason);
+    auto message = std::string("\xA6 Shot canceled: ") + reason;
     af_send_automated_chat_msg(message, player);
 }
 


### PR DESCRIPTION
Two independent fixes, neither of them localization-specific. Split out of a
larger branch so they can be reviewed on their own.

### Bounds-check TTF font ids, and keep the glyph table in lockstep

`gr_string`, `gr_get_string_size` and `gr_get_font_height` mask off `ttf_font_flag`
and index `g_fonts` directly with the result, with no range check. Any negative
font id other than -1 passes the flag test (`-2 & 0x1000 == 0x1000`), so a stale id
was an unbounded out-of-range read rather than a diagnosable failure. They now fail
safe, and report each distinct bad id once so a recurring one cannot flush the log
every frame.

`GrNewFont`'s constructor had a related fault. `char_map_` stores indices into
`unicode_code_points`, but `glyphs_` was only appended to when `FT_Load_Char`
succeeded, so a single failed character shifted every later glyph by one — wrong
glyphs from that point on, and the tail of `char_map_` pointing past the end of
`glyphs_`. That last part is an out-of-range `operator[]` read that neither throws
nor is otherwise detectable. A zero-metric placeholder is now pushed on failure so
the two arrays stay index-aligned.

### Avoid std::format for the \xA6 automated-chat prefix

Hardening rather than a fix. #400 already pinned `/execution-charset:windows-1252`,
so this cannot throw with the current build configuration — but passing a raw
Windows-1252 byte through a format string leaves correctness depending on that flag.
Concatenating removes the dependency, and matches what the neighbouring call sites in
`alpine_packets.cpp` already do. The bytes on the wire are unchanged.

---

The message-log layout commit that was originally part of this PR has been dropped —
scaling the 640x480 column positions by the UI scale is correct arithmetically but
creates dead space with the stock bitmap font. That belongs with font-size-aware
layout, not here.

Tested at 1080p and 4K, Big HUD on and off, single player and multiplayer.