### PR TITLE
fixed msvc compile build inorder to prevent `vendor` compile their own utf-8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,18 @@
 # CMake 3.15 is required for CMAKE_MSVC_RUNTIME_LIBRARY.
 cmake_minimum_required(VERSION 3.15)
+
+if(MSVC)
+    # Pin both charsets. Sources are UTF-8; narrow string literals are Windows-1252,
+    # because the .vf bitmap fonts are indexed by Windows-1252 byte value and several
+    # literals embed those bytes directly (\x95 bullet, \xA6 chat prefix, ...).
+    # Without this the ordinary literal encoding follows the build machine's system
+    # code page: on a DBCS locale such as 932 those bytes become invalid multi-byte
+    # sequences and std::format throws std::format_error at runtime.
+    # Set via _INIT variables before project() to prevent CMake 3.23+ /utf-8 conflict.
+    set(CMAKE_C_FLAGS_INIT "/source-charset:utf-8 /execution-charset:windows-1252")
+    set(CMAKE_CXX_FLAGS_INIT "/source-charset:utf-8 /execution-charset:windows-1252")
+endif()
+
 project(AlpineFaction)
 
 if(NOT "${CMAKE_SIZEOF_VOID_P}" STREQUAL "4")
@@ -35,13 +48,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 if(MSVC)
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
     add_compile_options(/arch:SSE2)
-    # Pin both charsets. Sources are UTF-8; narrow string literals are Windows-1252,
-    # because the .vf bitmap fonts are indexed by Windows-1252 byte value and several
-    # literals embed those bytes directly (\x95 bullet, \xA6 chat prefix, ...).
-    # Without this the ordinary literal encoding follows the build machine's system
-    # code page: on a DBCS locale such as 932 those bytes become invalid multi-byte
-    # sequences and std::format throws std::format_error at runtime.
-    add_compile_options(/source-charset:utf-8 /execution-charset:windows-1252)
+    # Charset flags set via CMAKE_*_FLAGS_INIT before project() to prevent CMake 3.23+
+    # from adding conflicting /utf-8. See preamble for detailed explanation.
     # Statically link Microsoft's CRT.
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,9 +74,12 @@ endmacro()
 
 add_subdirectory(vendor)
 
-# Pin charsets to Alpine Faction code only (applied after vendor/ to avoid conflicts).
-# UTF-8 sources, Windows-1252 literals for .vf bitmap font indexing.
-# Prevents std::format_error on DBCS locales.
+# Pin both charsets for Alpine Faction's own code. Sources are UTF-8; narrow string literals are Windows-1252,
+# because the .vf bitmap fonts are indexed by Windows-1252 byte value and several literals embed those bytes
+# directly (\x95 bullet, \xA6 chat prefix, ...). Without this the ordinary literal encoding follows the build
+# machine's system code page: on a DBCS locale such as 932 those bytes become invalid multi-byte sequences and
+# std::format throws std::format_error at runtime.
+# This is applied AFTER vendor/ so third-party code keeps its own charset settings.
 if(MSVC)
     add_compile_options(/source-charset:utf-8 /execution-charset:windows-1252)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,5 @@
 # CMake 3.15 is required for CMAKE_MSVC_RUNTIME_LIBRARY.
 cmake_minimum_required(VERSION 3.15)
-
-if(MSVC)
-    # Pin both charsets. Sources are UTF-8; narrow string literals are Windows-1252,
-    # because the .vf bitmap fonts are indexed by Windows-1252 byte value and several
-    # literals embed those bytes directly (\x95 bullet, \xA6 chat prefix, ...).
-    # Without this the ordinary literal encoding follows the build machine's system
-    # code page: on a DBCS locale such as 932 those bytes become invalid multi-byte
-    # sequences and std::format throws std::format_error at runtime.
-    # Set via _INIT variables before project() to prevent CMake 3.23+ /utf-8 conflict.
-    set(CMAKE_C_FLAGS_INIT "/source-charset:utf-8 /execution-charset:windows-1252")
-    set(CMAKE_CXX_FLAGS_INIT "/source-charset:utf-8 /execution-charset:windows-1252")
-endif()
-
 project(AlpineFaction)
 
 if(NOT "${CMAKE_SIZEOF_VOID_P}" STREQUAL "4")
@@ -48,13 +35,10 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 if(MSVC)
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
     add_compile_options(/arch:SSE2)
-    # Charset flags set via CMAKE_*_FLAGS_INIT before project() to prevent CMake 3.23+
-    # from adding conflicting /utf-8. See preamble for detailed explanation.
     # Statically link Microsoft's CRT.
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 else()
     add_compile_options(-msse2)
-    add_compile_options(-finput-charset=UTF-8 -fexec-charset=WINDOWS-1252)
 endif()
 
 # Macros
@@ -89,6 +73,19 @@ macro(setup_debug_info target)
 endmacro()
 
 add_subdirectory(vendor)
+
+# Pin both charsets for Alpine Faction's own code. Sources are UTF-8; narrow string literals are Windows-1252,
+# because the .vf bitmap fonts are indexed by Windows-1252 byte value and several literals embed those bytes
+# directly (\x95 bullet, \xA6 chat prefix, ...). Without this the ordinary literal encoding follows the build
+# machine's system code page: on a DBCS locale such as 932 those bytes become invalid multi-byte sequences and
+# std::format throws std::format_error at runtime.
+# This is applied AFTER vendor/ so third-party code keeps its own charset settings.
+if(MSVC)
+    add_compile_options(/source-charset:utf-8 /execution-charset:windows-1252)
+else()
+    add_compile_options(-finput-charset=UTF-8 -fexec-charset=WINDOWS-1252)
+endif()
+
 add_subdirectory(launcher_common)
 add_subdirectory(launcher)
 add_subdirectory(common)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,12 +74,9 @@ endmacro()
 
 add_subdirectory(vendor)
 
-# Pin both charsets for Alpine Faction's own code. Sources are UTF-8; narrow string literals are Windows-1252,
-# because the .vf bitmap fonts are indexed by Windows-1252 byte value and several literals embed those bytes
-# directly (\x95 bullet, \xA6 chat prefix, ...). Without this the ordinary literal encoding follows the build
-# machine's system code page: on a DBCS locale such as 932 those bytes become invalid multi-byte sequences and
-# std::format throws std::format_error at runtime.
-# This is applied AFTER vendor/ so third-party code keeps its own charset settings.
+# Pin charsets to Alpine Faction code only (applied after vendor/ to avoid conflicts).
+# UTF-8 sources, Windows-1252 literals for .vf bitmap font indexing.
+# Prevents std::format_error on DBCS locales.
 if(MSVC)
     add_compile_options(/source-charset:utf-8 /execution-charset:windows-1252)
 else()


### PR DESCRIPTION
`cl : Command line error D8016 : '/source-charset:utf-8' and '/utf-8' command-line options are incompatible`

basically, a msvc-specific bug introduced in #400 causes SDL3 CMake to conflict in the process, which will become problematic for #295. this pr attempts to address said issue while trying to retain the intended fix