### PR TITLE
Render text as UTF-8 so non-Latin scripts can be displayed

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -192,6 +192,12 @@ Version 1.4.0 (Lupin): Released Aug-25-2026
 - Reduce latency on continuous fire weapons by sending an object update immediately when one starts or stops firing instead of waiting for the next scheduled send
 - Add `spectate_povcomp` command for ping compensation while following a player in spectate mode - delays other players to approximate what the followed player saw when they aimed
 
+[@jyh9521](https://github.com/jyh9521)
+- Render text as UTF-8, so TrueType fonts can display non-Latin scripts
+  - Glyphs are rasterized on demand instead of up front, so a large character set does not cost hundreds of megabytes
+  - Line breaking and truncation happen on code point boundaries, including the usual CJK rules
+  - General purpose `.vf` bitmap fonts resolve to their TrueType equivalents
+
 ### Bug fixes
 [@GooberRF](https://github.com/GooberRF)
 - Fix team balance not properly randomizing the distribution order of equal-scoring human players

--- a/game_patch/graphics/gr.h
+++ b/game_patch/graphics/gr.h
@@ -16,6 +16,7 @@ void gr_bitmap_scaled_float(int bitmap_handle, float x, float y, float w, float 
 float gr_scale_fov_hor_plus(float horizontal_fov);
 bool gr_3d_bitmap_oriented_wh(const rf::Vector3* pnt, const rf::Matrix3* M, float half_w, float half_h, rf::gr::Mode mode);
 int gr_fit_string(std::string& text, int max_width, int font_id = -1, std::string_view suffix = "-");
+size_t gr_last_code_point_offset(std::string_view text);
 void explosion_flash_lights_level_init();
 void explosion_flash_lights_destroy_all();
 

--- a/game_patch/graphics/gr_font.cpp
+++ b/game_patch/graphics/gr_font.cpp
@@ -2,6 +2,9 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <string_view>
 #include <exception>
 #include <cctype>
 #include <stdexcept>
@@ -9,7 +12,11 @@
 #include <patch_common/FunHook.h>
 #include <patch_common/CodeInjection.h>
 #include <patch_common/AsmWriter.h>
+#include <format>
+#include <algorithm>
+#include <cmath>
 #include <common/utils/string-utils.h>
+#include "gr.h"
 #include "../rf/gr/gr_font.h"
 #include "../rf/bmpman.h"
 #include "../rf/multi.h"
@@ -27,33 +34,17 @@ struct ParsedFontName
     bool digits_only;
 };
 
-template<typename T = int>
-class TextureAtlasPacker {
-public:
-    void add(int w, int h, T userdata);
-    void pack();
-    [[nodiscard]] std::pair<int, int> get_size() const;
-    [[nodiscard]] std::pair<int, int> get_pos(T userdata) const;
-
-private:
-    struct Item
-    {
-        int w, h, area;
-        T userdata;
-    };
-    int total_pixels_ = 0;
-    std::pair<int, int> atlas_size_;
-    std::vector<Item> items_;
-    std::unordered_map<T, std::pair<int, int>> packed_pos_map_;
-
-    void update_size();
-    bool try_pack();
-};
-
 class GrNewFont
 {
 public:
     GrNewFont(std::string_view name);
+    ~GrNewFont();
+    // Owns an FT_Face and the file buffer it points into, so it cannot be copied.
+    GrNewFont(const GrNewFont&) = delete;
+    GrNewFont& operator=(const GrNewFont&) = delete;
+    GrNewFont(GrNewFont&& other) noexcept;
+    GrNewFont& operator=(GrNewFont&& other) noexcept;
+
     void draw(int x, int y, std::string_view text, rf::gr::Mode state) const;
     void draw_aligned(rf::gr::TextAlignment align, int x, int y, std::string_view text, rf::gr::Mode state) const;
     void get_size(int* w, int* h, std::string_view text) const;
@@ -71,25 +62,92 @@ public:
 private:
     struct GlyphInfo
     {
-        int bm_x;
-        int bm_y;
-        int bm_w;
-        int bm_h;
-        int x;
-        int y;
-        int advance_x;
+        int page = -1;   // index into pages_, -1 when there is nothing to draw
+        int bm_x = 0;
+        int bm_y = 0;
+        int bm_w = 0;
+        int bm_h = 0;
+        int x = 0;
+        int y = 0;
+        int advance_x = 0;
     };
 
+    // Glyphs are rasterized on first use rather than up front. Pre-baking every
+    // character a translation might need costs over 100 MB of atlas at 4K in a
+    // 32 bit process, while a screen of text uses a couple of hundred distinct
+    // characters. Pages are filled with a shelf allocator; a new one is created
+    // when the current ones are full.
+    //
+    // A page keeps its own copy of the pixels. Locking a bitmap WRITE_ONLY hands
+    // back staging memory that is not seeded from the current texture, and
+    // unlocking copies the whole thing back, so a partial write would erase every
+    // glyph already in the page. Glyphs go into pixels_ and the page is uploaded
+    // as a unit, at most once per draw.
+    struct AtlasPage
+    {
+        int bitmap;
+        int next_x;
+        int next_y;
+        int row_h;
+        bool dirty;
+        std::vector<unsigned char> pixels;   // page_side_ * page_side_, FORMAT_8888_ARGB
+    };
+
+    const GlyphInfo& glyph_for(uint32_t code_point) const;
+    GlyphInfo rasterize(uint32_t code_point) const;
+    bool place(int w, int h, int& out_page, int& out_x, int& out_y) const;
+    void flush_pages() const;
+
     std::string name_;
-    int bitmap_;
-    int height_;
-    int baseline_y_;
-    int line_spacing_;
-    std::vector<GlyphInfo> glyphs_;
-    int char_map_[256];
+    // FT_New_Memory_Face does not copy its input, so the file has to outlive the face.
+    std::vector<unsigned char> file_data_;
+    FT_Face face_ = nullptr;
+    bool digits_only_ = false;
+    int height_ = 0;
+    int baseline_y_ = 0;
+    int line_spacing_ = 0;
+    int page_side_ = 256;
+    // Keyed by Unicode code point. Legacy Windows-1252 bytes are cached under
+    // their raw byte value; rasterize() translates them before asking FreeType.
+    mutable std::vector<AtlasPage> pages_;
+    mutable std::unordered_map<uint32_t, GlyphInfo> glyphs_;
 };
 
 constexpr int ttf_font_flag = 0x1000;
+
+// Stock .vf bitmap fonts index glyphs by a single byte, so any non-Latin text
+// drawn with one comes out as per-byte mojibake. Alpine already swaps the four
+// rf::ui globals for TrueType, but some widgets (the weapon priority list and
+// the control binding list among them) hold a separate font handle and still
+// ask for a .vf. Redirect the three general-purpose text fonts to their
+// TrueType equivalents, using the same scale factors menu_init_hook uses, so
+// those widgets get a font that can actually render the text.
+//
+// bigfont.vf / smallfont.vf / biggerfont.vf are deliberately left alone: they
+// hold 32-69 glyphs with a non-standard first_ascii and are special-purpose
+// glyph sets (HUD counters), not general text.
+// The replacement is the same size as the bitmap font it stands in for, not a
+// resolution-scaled one. These are the sizes menu_init_hook already treats as
+// equivalent at scale 1, and they match the cell heights in the .vf headers once
+// leading is taken off. Scaling here instead would blow up every HUD element that
+// is laid out for the small bitmap font when Big HUD is off, and would also make
+// the redirect depend on a scale that is not known yet during start-up -- font
+// ids are handed out once and cached by the caller for good, so the same .vf would
+// resolve to two different fonts and the engine would measure a string with one
+// and draw it with the other.
+static const char* redirect_vf_font(const char* name)
+{
+    if (string_iequals(name, "rfpc-large.vf")) {
+        return "boldfont.ttf:15";
+    }
+    if (string_iequals(name, "rfpc-medium.vf")) {
+        return "regularfont.ttf:9";
+    }
+    if (string_iequals(name, "rfpc-small.vf")) {
+        return "regularfont.ttf:8";
+    }
+    return nullptr;
+}
 
 FT_Library g_freetype_lib = nullptr;
 int g_default_font_id = 0;
@@ -136,240 +194,272 @@ static bool load_file_into_buffer(const char* name, std::vector<unsigned char>& 
     return true;
 }
 
-template<typename T>
-inline void TextureAtlasPacker<T>::add(int w, int h, T userdata)
-{
-    int area = w * h;
-    items_.push_back({w, h, area, userdata});
-    total_pixels_ += area;
-}
+// ============================================================================
+// Support for non-Latin scripts (CJK and others)
+// ----------------------------------------------------------------------------
+// Glyphs used to be indexed by a single byte (char_map_[256]), which can only
+// hold the ~220 Windows-1252 characters, so anything outside that came out as
+// per-byte mojibake. Glyphs are now keyed by Unicode code point and rasterized
+// on demand, so a font covers whatever the text happens to contain.
+// ============================================================================
 
-template<typename T>
-inline void TextureAtlasPacker<T>::pack()
+// Decode one UTF-8 code point at pos and advance pos.
+// On an invalid byte it falls back to returning that single byte. That both
+// guarantees forward progress and keeps legacy Windows-1252 text working:
+// bytes 0x80-0xFF are invalid UTF-8 lead bytes, so they come back unchanged
+// and can still be looked up by their byte value.
+static uint32_t utf8_decode(std::string_view text, size_t& pos)
 {
-    update_size();
-    xlog::trace("Texture atlas usage: {:.2f}", total_pixels_ * 100.0f / (atlas_size_.first * atlas_size_.second));
-    // Sort by area (from largest to smallest)
-    std::sort(items_.begin(), items_.end(), [](Item& a, Item& b) {
-        return a.area > b.area;
-    });
-    // Set positions
-    if (!try_pack()) {
-        atlas_size_ = {2 * atlas_size_.first, 2 * atlas_size_.second};
-        if (!try_pack()) {
-            throw std::runtime_error{"unable to pack texture atlas"};
-        }
+    auto byte_at = [&](size_t i) { return static_cast<unsigned char>(text[i]); };
+    unsigned char lead = byte_at(pos);
+    if (lead < 0x80) {
+        ++pos;
+        return lead;
     }
-}
-
-template<typename T>
-inline bool TextureAtlasPacker<T>::try_pack()
-{
-    // Set positions
-    int cur_x = 0;
-    int cur_y = 0;
-    int current_row_h = 0;
-    for (auto& item : items_) {
-        if (cur_x + item.w > atlas_size_.first) {
-            cur_x = 0;
-            cur_y += current_row_h;
-            current_row_h = 0;
-        }
-        if (cur_y + item.h > atlas_size_.second) {
-            return false;
-        }
-        packed_pos_map_[item.userdata] = std::pair{cur_x, cur_y};
-        cur_x += item.w;
-        current_row_h = std::max(current_row_h, item.h);
+    uint32_t cp;
+    int extra;
+    if ((lead & 0xE0) == 0xC0) { cp = lead & 0x1Fu; extra = 1; }
+    else if ((lead & 0xF0) == 0xE0) { cp = lead & 0x0Fu; extra = 2; }
+    else if ((lead & 0xF8) == 0xF0) { cp = lead & 0x07u; extra = 3; }
+    else { ++pos; return lead; }
+    if (pos + extra >= text.size()) {
+        ++pos;
+        return lead;
     }
-    return true;
-}
-
-template<typename T>
-std::pair<int, int> TextureAtlasPacker<T>::get_size() const
-{
-    return atlas_size_;
-}
-
-template<typename T>
-inline std::pair<int, int> TextureAtlasPacker<T>::get_pos(T userdata) const
-{
-    auto it = packed_pos_map_.find(userdata);
-    if (it == packed_pos_map_.end()) {
-        throw std::runtime_error{"element not found in texture atlas"};
+    for (int i = 1; i <= extra; ++i) {
+        unsigned char cont = byte_at(pos + i);
+        if ((cont & 0xC0) != 0x80) {
+            ++pos;
+            return lead;
+        }
+        cp = (cp << 6) | (cont & 0x3Fu);
     }
-    return it->second;
-}
-
-template<typename T>
-inline void TextureAtlasPacker<T>::update_size()
-{
-    // calculate area + some margin for place that we don't use
-    int total_pixels_adjusted = total_pixels_ * 9 / 8;
-    // find squere root of calculated area (atlas is a squere)
-    auto size_before_rounding = std::sqrt(total_pixels_adjusted);
-    // round to next power of two
-    auto exp = std::ceil(std::log(size_before_rounding) / std::log(2));
-    int size = static_cast<int>(std::pow(2, exp));
-    atlas_size_ = std::pair{size, size};
+    pos += extra + 1;
+    return cp;
 }
 
 GrNewFont::GrNewFont(std::string_view name) :
     name_{name}
 {
     auto [filename, size_x, size_y, digits_only] = parse_font_name(name);
-    std::vector<unsigned char> buffer;
+    digits_only_ = digits_only;
     xlog::trace("Loading font {} size {}", filename, size_y);
-    if (!load_file_into_buffer(filename.c_str(), buffer)) {
+    if (!load_file_into_buffer(filename.c_str(), file_data_)) {
         xlog::error("load_file_into_buffer failed for {}", filename);
         throw std::runtime_error{"failed to load font"};
     }
 
-    FT_Face face;
-    FT_Error error = FT_New_Memory_Face(g_freetype_lib, buffer.data(), buffer.size(), 0, &face);
+    // The face keeps a pointer into file_data_, so both live as long as the font.
+    FT_Error error = FT_New_Memory_Face(g_freetype_lib, file_data_.data(),
+        static_cast<FT_Long>(file_data_.size()), 0, &face_);
     if (error) {
         xlog::error("FT_New_Memory_Face failed: {}", error);
         throw std::runtime_error{"failed to load font"};
     }
 
-    error = FT_Set_Pixel_Sizes(face, size_x, size_y);
+    error = FT_Set_Pixel_Sizes(face_, size_x, size_y);
     if (error) {
+        FT_Done_Face(face_);
+        face_ = nullptr;
         xlog::error("FT_Set_Pixel_Sizes failed: {}", error);
         throw std::runtime_error{"failed to load font"};
     }
 
-    xlog::trace("raw height {} ascender {} descender {}", face->height, face->ascender, face->descender);
-    xlog::trace("scaled height {} ascender {} descender {}", face->size->metrics.height / 64,
-        face->size->metrics.ascender / 64, face->size->metrics.descender / 64);
-    line_spacing_ = face->size->metrics.height / 64;
-    height_ = line_spacing_; //(face->size->metrics.ascender - face->size->metrics.descender) / 64;
-    baseline_y_ = face->size->metrics.ascender / 64;
+    line_spacing_ = face_->size->metrics.height / 64;
+    height_ = line_spacing_;
+    baseline_y_ = face_->size->metrics.ascender / 64;
     xlog::trace("line_spacing {} height {} baseline_y {}", line_spacing_, height_, baseline_y_);
 
-    // Prepare lookup table for translating Windows 1252 characters (encoding used by RF) into Unicode codepoints
-
-    static std::pair<int, int> win_1252_char_ranges[]{
-        {0x20, 0x7E},
-        {0x8C, 0x8C},
-        {0x95, 0x95},
-        {0x99, 0x99},
-        {0x9C, 0x9C},
-        {0x9F, 0x9F},
-        {0xA6, 0xA7},
-        {0xA9, 0xAB},
-        {0xAE, 0xAE},
-        {0xB0, 0xB0},
-        {0xC0, 0xC2},
-        {0xC4, 0xCB},
-        {0xCE, 0xCF},
-        {0xD2, 0xD4},
-        {0xD6, 0xD6},
-        {0xD9, 0xDC},
-        {0xDF, 0xE2},
-        {0xE4, 0xEB},
-        {0xEE, 0xEF},
-        {0xF2, 0xF4},
-        {0xF6, 0xF6},
-        {0xF9, 0xFC},
-    };
-
-    // Prepare character mapping and array of unicode code points
-    std::fill(char_map_, char_map_ + std::size(char_map_), -1);
-    std::vector<int> unicode_code_points;
-    for (auto& range : win_1252_char_ranges) {
-        for (auto c = range.first; c < range.second + 1; ++c) {
-            if (digits_only && !std::isdigit(c)) {
-                continue;
-            }
-            char windows_1252_char = static_cast<char>(c);
-            wchar_t unicode_char = 0;
-            MultiByteToWideChar(1252, 0, &windows_1252_char, 1, &unicode_char, 1);
-            unicode_code_points.push_back(unicode_char);
-            auto char_idx = static_cast<unsigned char>(windows_1252_char);
-            char_map_[char_idx] = unicode_code_points.size() - 1;
-        }
+    // Size a page to hold roughly 250 glyphs of this font: small enough that a
+    // font using a handful of characters does not reserve megabytes, large
+    // enough that ordinary text never needs more than one or two pages.
+    int side = 1;
+    while (side < std::max(1, line_spacing_) * 16) {
+        side *= 2;
     }
+    page_side_ = std::clamp(side, 128, 1024);
+}
 
-    TextureAtlasPacker atlas_packer;
-    std::unordered_set<wchar_t> packed_codepoints;
+GrNewFont::~GrNewFont()
+{
+    if (face_) {
+        FT_Done_Face(face_);
+    }
+}
 
-    for (auto codepoint : unicode_code_points) {
-        error = FT_Load_Char(face, codepoint, FT_LOAD_BITMAP_METRICS_ONLY);
-        if (error) {
-            xlog::error("FT_Load_Char failed: {}", error);
+GrNewFont::GrNewFont(GrNewFont&& other) noexcept :
+    name_{std::move(other.name_)},
+    file_data_{std::move(other.file_data_)},
+    face_{other.face_},
+    digits_only_{other.digits_only_},
+    height_{other.height_},
+    baseline_y_{other.baseline_y_},
+    line_spacing_{other.line_spacing_},
+    page_side_{other.page_side_},
+    pages_{std::move(other.pages_)},
+    glyphs_{std::move(other.glyphs_)}
+{
+    // Moving the vector moves the heap block itself, so the pointer the face
+    // holds into it stays valid.
+    other.face_ = nullptr;
+}
+
+GrNewFont& GrNewFont::operator=(GrNewFont&& other) noexcept
+{
+    if (this != &other) {
+        if (face_) {
+            FT_Done_Face(face_);
+        }
+        name_ = std::move(other.name_);
+        file_data_ = std::move(other.file_data_);
+        face_ = other.face_;
+        digits_only_ = other.digits_only_;
+        height_ = other.height_;
+        baseline_y_ = other.baseline_y_;
+        line_spacing_ = other.line_spacing_;
+        page_side_ = other.page_side_;
+        pages_ = std::move(other.pages_);
+        glyphs_ = std::move(other.glyphs_);
+        other.face_ = nullptr;
+    }
+    return *this;
+}
+
+// Shelf allocation into the existing pages, creating another when they are full.
+// Returns the page index rather than a bitmap handle so the caller can write into
+// that page's pixel buffer.
+bool GrNewFont::place(int w, int h, int& out_page, int& out_x, int& out_y) const
+{
+    constexpr int padding = 1;   // keeps filtering from bleeding between neighbours
+    const int need_w = w + padding;
+    const int need_h = h + padding;
+    if (need_w > page_side_ || need_h > page_side_) {
+        return false;
+    }
+    for (size_t i = 0; i < pages_.size(); ++i) {
+        auto& page = pages_[i];
+        if (page.next_x + need_w > page_side_) {
+            page.next_x = 0;
+            page.next_y += page.row_h;
+            page.row_h = 0;
+        }
+        if (page.next_y + need_h > page_side_) {
             continue;
         }
-        FT_GlyphSlot slot = face->glyph;
-        atlas_packer.add(slot->bitmap.width, slot->bitmap.rows, codepoint);
-        packed_codepoints.insert(codepoint);
+        out_page = static_cast<int>(i);
+        out_x = page.next_x;
+        out_y = page.next_y;
+        page.next_x += need_w;
+        page.row_h = std::max(page.row_h, need_h);
+        return true;
     }
 
-    atlas_packer.pack();
-    auto [atlas_w, atlas_h] = atlas_packer.get_size();
-
-    xlog::trace("Creating font texture atlas {}x{}", atlas_w, atlas_h);
-    bitmap_ = rf::bm::create(rf::bm::FORMAT_8888_ARGB, atlas_w, atlas_h);
-    if (bitmap_ == -1) {
-        xlog::error("bm_create failed for font texture");
-        throw std::runtime_error{"failed to load font"};
+    int bm_handle = rf::bm::create(rf::bm::FORMAT_8888_ARGB, page_side_, page_side_);
+    if (bm_handle == -1) {
+        xlog::error("bm_create failed for font atlas page {}x{}", page_side_, page_side_);
+        return false;
     }
-    rf::gr::LockInfo lock;
-    if (!rf::gr::lock(bitmap_, 0, &lock, rf::gr::LOCK_WRITE_ONLY)) {
-        xlog::error("gr_lock failed for font texture");
-        throw std::runtime_error{"failed to load font"};
-    }
+    rf::gr::tcache_add_ref(bm_handle);
 
-    auto* bitmap_bits = lock.data;
-    glyphs_.reserve(unicode_code_points.size());
+    AtlasPage page;
+    page.bitmap = bm_handle;
+    page.next_x = need_w;
+    page.next_y = 0;
+    page.row_h = need_h;
+    page.dirty = true;
+    // Zero initialised, so anything not covered by a glyph is transparent.
+    page.pixels.assign(static_cast<size_t>(page_side_) * page_side_ * 4, 0);
+    pages_.push_back(std::move(page));
 
-    for (auto codepoint : unicode_code_points) {
-        error = FT_Load_Char(face, codepoint, FT_LOAD_RENDER);
-        if (error) {
-            // char_map_ stores indices into unicode_code_points, so glyphs_ has to stay
-            // index aligned with it. Skipping an entry here would shift every later glyph
-            // by one and push the last char_map_ entries past the end of glyphs_ -- an out
-            // of range operator[] read that does not throw and is not otherwise detectable.
-            // A zero filled glyph draws nothing and advances the pen by nothing.
-            xlog::error("FT_Load_Char failed for codepoint {:#x}: {}", codepoint, error);
-            glyphs_.push_back(GlyphInfo{});
+    out_page = static_cast<int>(pages_.size()) - 1;
+    out_x = 0;
+    out_y = 0;
+    return true;
+}
+
+// Push every page whose pixels changed up to its texture. Called before drawing
+// rather than from rasterize() so a string that introduces twenty new characters
+// costs one upload per page instead of twenty.
+void GrNewFont::flush_pages() const
+{
+    for (auto& page : pages_) {
+        if (!page.dirty) {
             continue;
         }
-        if (!packed_codepoints.contains(codepoint)) {
-            // Metrics failed for this codepoint but the render succeeded, so no atlas slot
-            // was ever sized for it. Emit the same zero filled glyph as above rather than
-            // blitting into space reserved for another glyph.
-            xlog::error("Skipping codepoint {:#x}: no texture atlas slot was reserved", codepoint);
-            glyphs_.push_back(GlyphInfo{});
+        rf::gr::LockInfo lock;
+        if (!rf::gr::lock(page.bitmap, 0, &lock, rf::gr::LOCK_WRITE_ONLY)) {
+            xlog::error("gr_lock failed for font atlas page");
             continue;
         }
-        FT_GlyphSlot slot = face->glyph;
-        FT_Bitmap& bitmap = slot->bitmap;
-        int glyph_bm_w = static_cast<int>(bitmap.width);
-        int glyph_bm_h = static_cast<int>(bitmap.rows);
+        bm_convert_format(lock.data, lock.format, page.pixels.data(), rf::bm::FORMAT_8888_ARGB,
+            page_side_, page_side_, lock.stride_in_bytes, page_side_ * 4);
+        // No mark_texture_dirty here: unlocking already copies the staging surface
+        // to the texture, while marking it dirty would make the next frame reload
+        // the texture from the bitmap's own pixels, which a user bitmap does not have.
+        rf::gr::unlock(&lock);
+        page.dirty = false;
+    }
+}
 
-        auto [glyph_bm_x, glyph_bm_y] = atlas_packer.get_pos(codepoint);
-
-        xlog::trace("glyph {:x} bitmap x {} y {} w {} h {} left {} top {} advance {}", codepoint, glyph_bm_x, glyph_bm_y,
-            glyph_bm_w, glyph_bm_h, slot->bitmap_left, slot->bitmap_top, slot->advance.x >> 6);
-
-        GlyphInfo glyph_info;
-        glyph_info.advance_x = slot->advance.x >> 6;
-        glyph_info.bm_x = glyph_bm_x;
-        glyph_info.bm_y = glyph_bm_y;
-        glyph_info.bm_w = glyph_bm_w;
-        glyph_info.bm_h = glyph_bm_h;
-        glyph_info.x = slot->bitmap_left;
-        glyph_info.y = -slot->bitmap_top;
-
-        int pixel_size = bm_bytes_per_pixel(lock.format);
-        auto* dst_ptr = bitmap_bits + glyph_bm_y * lock.stride_in_bytes + glyph_bm_x * pixel_size;
-        bm_convert_format(dst_ptr, lock.format, bitmap.buffer, rf::bm::FORMAT_8_ALPHA, bitmap.width, bitmap.rows, lock.stride_in_bytes, bitmap.pitch);
-
-        glyphs_.push_back(glyph_info);
+// Render one code point into a page's pixel buffer. A zeroed GlyphInfo (draws
+// nothing, advances nothing) is returned when the character is not available,
+// and that is what gets cached so the failure is not retried every frame.
+GrNewFont::GlyphInfo GrNewFont::rasterize(uint32_t code_point) const
+{
+    GlyphInfo info;
+    if (digits_only_ && (code_point < '0' || code_point > '9')) {
+        return info;
     }
 
-    rf::gr::unlock(&lock);
-    rf::gr::tcache_add_ref(bitmap_);
+    // The decoder hands back bytes 0x80-0xFF unchanged because they are invalid
+    // UTF-8 lead bytes. Stock, German and French tables are Windows-1252, so
+    // translate those to the code point FreeType expects.
+    uint32_t unicode = code_point;
+    if (code_point >= 0x80 && code_point <= 0xFF) {
+        char raw = static_cast<char>(code_point);
+        wchar_t wide = 0;
+        if (MultiByteToWideChar(1252, 0, &raw, 1, &wide, 1) == 1 && wide != 0) {
+            unicode = static_cast<uint32_t>(wide);
+        }
+    }
+
+    if (FT_Load_Char(face_, unicode, FT_LOAD_RENDER) != 0) {
+        return info;
+    }
+    FT_GlyphSlot slot = face_->glyph;
+    FT_Bitmap& bitmap = slot->bitmap;
+    info.advance_x = slot->advance.x >> 6;
+    info.x = slot->bitmap_left;
+    info.y = -slot->bitmap_top;
+    int glyph_w = static_cast<int>(bitmap.width);
+    int glyph_h = static_cast<int>(bitmap.rows);
+    if (glyph_w <= 0 || glyph_h <= 0) {
+        return info;   // whitespace: advances the pen, nothing to blit
+    }
+    if (!place(glyph_w, glyph_h, info.page, info.bm_x, info.bm_y)) {
+        info.page = -1;
+        return info;
+    }
+
+    auto& page = pages_[info.page];
+    const int stride = page_side_ * 4;
+    auto* dst_ptr = page.pixels.data() + static_cast<size_t>(info.bm_y) * stride + info.bm_x * 4;
+    bm_convert_format(dst_ptr, rf::bm::FORMAT_8888_ARGB, bitmap.buffer, rf::bm::FORMAT_8_ALPHA,
+        bitmap.width, bitmap.rows, stride, bitmap.pitch);
+    page.dirty = true;
+
+    info.bm_w = glyph_w;
+    info.bm_h = glyph_h;
+    return info;
+}
+
+const GrNewFont::GlyphInfo& GrNewFont::glyph_for(uint32_t code_point) const
+{
+    auto it = glyphs_.find(code_point);
+    if (it == glyphs_.end()) {
+        it = glyphs_.emplace(code_point, rasterize(code_point)).first;
+    }
+    return it->second;
 }
 
 void GrNewFont::draw(int x, int y, std::string_view text, rf::gr::Mode state) const
@@ -378,24 +468,31 @@ void GrNewFont::draw(int x, int y, std::string_view text, rf::gr::Mode state) co
         draw_aligned(rf::gr::ALIGN_CENTER, rf::gr::screen.clip_width / 2, y, text, state);
         return;
     }
+    // Rasterize everything this string needs first, then upload the pages that
+    // changed, and only then draw. Uploading from inside the drawing loop would
+    // mean one full page upload per new character.
+    size_t scan_pos = 0;
+    while (scan_pos < text.size()) {
+        glyph_for(utf8_decode(text, scan_pos));
+    }
+    flush_pages();
+
     int pen_x = x;
     int pen_y = y + baseline_y_;
-    for (auto ch : text) {
-        if (ch == '\n') {
+    size_t char_pos = 0;
+    while (char_pos < text.size()) {
+        uint32_t cp = utf8_decode(text, char_pos);
+        if (cp == static_cast<uint32_t>('\n')) {
             pen_x = x;
             pen_y += line_spacing_;
+            continue;
         }
-        else {
-            auto glyph_idx = char_map_[static_cast<unsigned char>(ch)];
-            if (glyph_idx != -1) {
-                const auto& glyph_info = glyphs_[glyph_idx];
-                if (glyph_info.bm_w) {
-                    // rf::gr::rect(pen_x + glyph_info.x, pen_y + glyph_info.y, glyph_info.bm_w, glyph_info.bm_h);
-                    rf::gr::bitmap_ex(bitmap_, pen_x + glyph_info.x, pen_y + glyph_info.y, glyph_info.bm_w, glyph_info.bm_h, glyph_info.bm_x, glyph_info.bm_y, state);
-                }
-                pen_x += glyph_info.advance_x;
-            }
+        const auto& glyph_info = glyph_for(cp);
+        if (glyph_info.page != -1 && glyph_info.bm_w) {
+            rf::gr::bitmap_ex(pages_[glyph_info.page].bitmap, pen_x + glyph_info.x, pen_y + glyph_info.y,
+                glyph_info.bm_w, glyph_info.bm_h, glyph_info.bm_x, glyph_info.bm_y, state);
         }
+        pen_x += glyph_info.advance_x;
     }
     rf::gr::current_string_x = pen_x;
     rf::gr::current_string_y = y;
@@ -433,19 +530,16 @@ void GrNewFont::get_size(int* w, int* h, std::string_view text) const
     *w = 0;
     *h = line_spacing_;
     int cur_line_w = 0;
-    for (auto ch : text) {
-        if (ch == '\n') {
+    size_t char_pos = 0;
+    while (char_pos < text.size()) {
+        uint32_t cp = utf8_decode(text, char_pos);
+        if (cp == static_cast<uint32_t>('\n')) {
             *w = std::max(*w, cur_line_w);
             cur_line_w = 0;
             *h += line_spacing_;
+            continue;
         }
-        else {
-            auto glyph_idx = char_map_[static_cast<unsigned char>(ch)];
-            if (glyph_idx != -1) {
-                const auto& glyph_info = glyphs_[glyph_idx];
-                cur_line_w += glyph_info.advance_x;
-            }
-        }
+        cur_line_w += glyph_for(cp).advance_x;
     }
     *w = std::max(*w, cur_line_w);
 }
@@ -483,7 +577,12 @@ FunHook<int(const char*, int)> gr_init_font_hook{
            return -1;
         }
         if (string_ends_with(name, ".vf")) {
-            return gr_init_font_hook.call_target(name, reserved);
+            const char* redirected = redirect_vf_font(name);
+            if (!redirected) {
+                return gr_init_font_hook.call_target(name, reserved);
+            }
+            xlog::info("Redirecting bitmap font {} to {}", name, redirected);
+            name = redirected;
         }
         for (unsigned i = 0; i < g_fonts.size(); ++i) {
             auto& font = g_fonts[i];
@@ -492,8 +591,7 @@ FunHook<int(const char*, int)> gr_init_font_hook{
             }
         }
         try {
-            GrNewFont font{name};
-            g_fonts.push_back(font);
+            g_fonts.emplace_back(name);
             return static_cast<int>((g_fonts.size() - 1) | ttf_font_flag);
         }
         catch (std::exception& e) {
@@ -607,6 +705,23 @@ CodeInjection gr_create_font_increment_number_injection{
     },
 };
 
+// Byte offset where the last character of text starts, using the same rules the
+// renderer decodes with. A backward scan over 0x80-0xBF would be wrong: those are
+// UTF-8 continuation bytes, but they are also perfectly ordinary Windows-1252
+// characters - the bullet at 0x95 and the automated chat prefix at 0xA6 among them -
+// and the decoder hands such bytes back as single characters. Scanning forward means
+// whatever the renderer treats as one character is what gets trimmed.
+size_t gr_last_code_point_offset(std::string_view text)
+{
+    size_t pos = 0;
+    size_t last = 0;
+    while (pos < text.size()) {
+        last = pos;
+        utf8_decode(text, pos);
+    }
+    return last;
+}
+
 int gr_fit_string(
     std::string& text,
     const int max_width,
@@ -624,13 +739,133 @@ int gr_fit_string(
     }
 
     while (text_w + suffix_w > max_width && !text.empty()) {
-        const auto [last_w, last_h] = rf::gr::get_char_size(text.back(), font_id);
-        text_w -= last_w;
-        text.pop_back();
+        // Trim whole code points, otherwise a multi-byte character gets cut in half
+        text.erase(gr_last_code_point_offset(text));
+        const auto [new_w, new_h] = rf::gr::get_string_size(text, font_id);
+        text_w = new_w;
     }
 
     text.append(suffix);
     return text_w + suffix_w;
+};
+
+
+// ---- CJK aware line breaking ----
+// See gr_split_str_hook below. Break opportunities follow the usual CJK rules: a line
+// may break between two ideographs, but never before closing punctuation nor after
+// opening punctuation.
+static bool cjk_breakable(uint32_t cp)
+{
+    return (cp >= 0x2E80 && cp <= 0x9FFF)      // radicals, kana, CJK ideographs
+        || (cp >= 0xF900 && cp <= 0xFAFF)      // compatibility ideographs
+        || (cp >= 0x3000 && cp <= 0x303F)      // CJK punctuation
+        || (cp >= 0xFF00 && cp <= 0xFF60);     // fullwidth forms
+}
+
+static bool cjk_no_break_before(uint32_t cp)
+{
+    switch (cp) {
+    case 0x3001: case 0x3002: case 0xFF0C: case 0xFF0E:
+    case 0xFF1A: case 0xFF1B: case 0xFF01: case 0xFF1F:
+    case 0x300D: case 0x300F: case 0x3011: case 0x300B:
+    case 0xFF09: case 0x2019: case 0x201D:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static bool cjk_no_break_after(uint32_t cp)
+{
+    switch (cp) {
+    case 0x300C: case 0x300E: case 0x3010: case 0x300A:
+    case 0xFF08: case 0x2018: case 0x201C:
+        return true;
+    default:
+        return false;
+    }
+}
+
+// Replacement for the engine's gr_split_str. Fills offset_array/len_array with byte
+// offsets and lengths of each line and returns the line count, same contract as the
+// original. unk_char is ignored: its meaning in the original is unclear and every
+// caller we can see passes 0. A newline always breaks, as it did before.
+FunHook<int(int*, int*, char*, int, int, char, int)> gr_split_str_hook{
+    0x00520810,
+    [](int* len_array, int* offset_array, char* text, int max_w, int max_lines, char unk_char,
+       int font_num) -> int {
+        static_cast<void>(unk_char);
+        if (!text || !len_array || !offset_array || max_lines <= 0 || max_w <= 0) {
+            return 0;
+        }
+        const std::string_view sv{text};
+        int n_lines = 0;
+        size_t line_start = 0;
+        size_t pos = 0;
+        int line_w = 0;
+        size_t break_end = 0;   // where the line would end if we break here
+        size_t break_next = 0;  // where the following line would start
+        uint32_t prev_cp = 0;
+        size_t prev_pos = 0;
+
+        auto emit = [&](size_t end, size_t next) {
+            offset_array[n_lines] = static_cast<int>(line_start);
+            len_array[n_lines] = static_cast<int>(end - line_start);
+            ++n_lines;
+            line_start = next;
+            pos = next;
+            line_w = 0;
+            break_end = 0;
+            break_next = 0;
+            prev_cp = 0;
+            prev_pos = 0;
+        };
+
+        while (pos < sv.size() && n_lines < max_lines) {
+            size_t next = pos;
+            const uint32_t cp = utf8_decode(sv, next);
+
+            if (cp == static_cast<uint32_t>('\n')) {
+                emit(pos, next);
+                continue;
+            }
+
+            // Record a break opportunity for the pair (prev_cp, cp) before placing cp,
+            // so that when cp turns out not to fit we already know where to cut.
+            if (prev_cp == static_cast<uint32_t>(' ')) {
+                break_end = prev_pos;   // the space itself is dropped
+                break_next = pos;
+            }
+            else if (prev_cp && !cjk_no_break_after(prev_cp) && !cjk_no_break_before(cp)
+                     && (cjk_breakable(prev_cp) || cjk_breakable(cp))) {
+                break_end = pos;
+                break_next = pos;
+            }
+
+            const int cw = rf::gr::get_string_size(sv.substr(pos, next - pos), font_num).first;
+            if (line_w + cw > max_w && pos > line_start) {
+                if (break_end > line_start) {
+                    emit(break_end, break_next);
+                }
+                else {
+                    emit(pos, pos);   // one word wider than the whole line: hard cut
+                }
+                continue;
+            }
+
+            line_w += cw;
+            prev_cp = cp;
+            prev_pos = pos;
+            pos = next;
+        }
+
+        if (line_start < sv.size() && n_lines < max_lines) {
+            offset_array[n_lines] = static_cast<int>(line_start);
+            len_array[n_lines] = static_cast<int>(sv.size() - line_start);
+            ++n_lines;
+        }
+        return n_lines;
+    },
 };
 
 void gr_font_apply_patch()
@@ -647,6 +882,7 @@ void gr_font_apply_patch()
     gr_get_font_height_hook.install();
     gr_string_hook.install();
     gr_get_string_size_hook.install();
+    gr_split_str_hook.install();
     init_freetype_lib();
 
     // Do not increament number of loaded fonts before a successful load

--- a/game_patch/hud/hud.cpp
+++ b/game_patch/hud/hud.cpp
@@ -13,6 +13,7 @@
 #include "remote_server_cfg_ui.h"
 #include "../misc/alpine_settings.h"
 #include "../main/main.h"
+#include "../graphics/gr.h"
 #include "../os/console.h"
 #include "../rf/gr/gr_font.h"
 #include "../rf/hud.h"
@@ -304,7 +305,15 @@ std::string hud_fit_string(std::string_view str, int max_w, int* str_w_out, int 
     bool has_ellipsis = false;
     auto [str_w, str_h] = rf::gr::get_string_size(result, font_id);
     while (str_w > max_w) {
-        result = result.substr(0, result.size() - (has_ellipsis ? 4 : 1)) + "...";
+        if (has_ellipsis) {
+            result.erase(result.size() - 3);  // drop the "..." added last round
+        }
+        if (result.empty()) {
+            break;
+        }
+        // Step back one whole code point, never split a multi-byte character
+        result.erase(gr_last_code_point_offset(result));
+        result += "...";
         has_ellipsis = true;
         std::tie(str_w, str_h) = rf::gr::get_string_size(result, font_id);
     }


### PR DESCRIPTION
`GrNewFont` indexed glyphs with `char_map_[256]`, one byte per glyph, so any text
outside Windows-1252 came out as per-byte mojibake and a translation into a
non-Latin script wasn't possible at all. This keys the glyph map by Unicode code
point and decodes UTF-8 in `draw()` and `get_size()`.

Legacy text is unaffected. Bytes `0x80`-`0xFF` are invalid UTF-8 lead bytes, so
the decoder returns them unchanged and they're translated from Windows-1252 when
the glyph is rasterized — the stock English, German and French tables render
exactly as before.

### Glyphs are rasterized on demand

Pre-baking a character set large enough for Chinese costs **124 MB** of atlas at
4K, plus the same again in video memory, in a 32 bit process. Measured across the
seven font instances Alpine creates, against my own translation's 1434 code
points:

| | atlas |
|---|---|
| 1280x720 | 37 MB |
| 1920x1080 | 52 MB |
| 2560x1440 | 64 MB |
| 3840x2160 | 124 MB |

With no extra characters it's 7.6 MB, so essentially all of it is glyphs a given
screen never shows. Each font now fills page sized atlases with a shelf allocator
and creates another when they're full, so the cost tracks what's actually drawn.

A page keeps its own copy of its pixels: locking a bitmap `WRITE_ONLY` hands back
staging memory that isn't seeded from the current texture and unlocking copies the
whole surface back, so writing one glyph in place would erase every glyph already
in the page. Pages upload whole, at most once per string drawn.

### .vf fonts resolve to their TrueType equivalents

Alpine already swaps the four `rf::ui` globals for TrueType, but widgets that hold
their own font handle — the weapon priority list and the control binding list
among them — still ask for a `.vf`, and a bitmap font can't render the text no
matter what the rest of the UI does. The three general purpose text fonts are
redirected; `bigfont.vf`, `smallfont.vf` and `biggerfont.vf` are left alone, as
they hold 32-69 glyphs with a non-standard `first_ascii` and are special purpose
glyph sets for HUD counters rather than general text.

The replacement is the same size as the font it stands in for, so only the glyph
source changes and everything laid out around those fonts keeps its proportions.
Scaling here instead would blow up every HUD element that is sized for the small
bitmap font when Big HUD is off, and it would tie the redirect to a scale that
isn't known yet during start-up — font ids are handed out once and cached by the
caller for good, so the same `.vf` would resolve to two different fonts and the
engine would then measure a string with one and draw it with the other. Both of
those were real, and took a while to track down.

### Line breaking and truncation

`gr_split_str` breaks on whole code points and knows the usual CJK rules: a line
may break between two ideographs, but never before closing punctuation nor after
opening punctuation. Latin space breaking is unchanged. `gr_fit_string` and the
HUD string truncation likewise trim whole code points, so a multi-byte character
is never cut in half.

---

Tested at 3840x2160, Big HUD on and off, stock English and with a Simplified
Chinese translation loaded: menus, HUD, subtitles, message log, line breaking and
truncation.