### PR TITLE
Respect DNS TTL for the multiplayer tracker hostname

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -109,6 +109,7 @@ Version 1.4.0 (Lupin): Not yet released
 - Add dedicated server config field `spawn_loadout_blue` to give the blue team its own spawn loadout, with `spawn_loadout` applying to every player when it is not specified
 - Indicate in the dedicated server config printout whether the spawn loadout is granted by the loadout or by the stock spawn weapons, and list the red and blue team loadouts separately when both are configured
 - Add Alpine Faction 1.4.0 clients to the `sv_restrict_status` common test cases
+- Respect DNS TTL for the multiplayer tracker hostname
 
 [@is-this-c](https://github.com/is-this-c)
 - Rewrite `VArray` to fix crashes due to MinGW
@@ -169,6 +170,7 @@ Version 1.4.0 (Lupin): Not yet released
 - Fix an unrecognized `weapon_name` in a `spawn_loadout` entry being silently ignored, which could leave players spawning with no weapons
 - Fix clients keeping weapons the server did not grant when a spawn loadout replaces the stock spawn weapons, which left unusable weapons in the weapon select menu
 - Fix `infinite_reloads` not filling reserve ammo on weapon pickup
+- Fix `MultiplayerTracker` values longer than 63 characters overflowing an internal game buffer
 
 [@is-this-c](https://github.com/is-this-c)
 - Clear cached server config output after a shuffle of a server's rotation

--- a/game_patch/CMakeLists.txt
+++ b/game_patch/CMakeLists.txt
@@ -160,6 +160,8 @@ set(SRCS
     multi/network.cpp
     multi/network.h
     multi/network_debug.cpp
+    multi/tracker.cpp
+    multi/tracker.h
     multi/saved_info.cpp
     multi/saved_info.h
     multi/level_download.cpp
@@ -365,6 +367,7 @@ target_link_libraries(AlpineFaction
     winmm
     iphlpapi
     ws2_32
+    dnsapi
     freetype
     stb_vorbis
     stb_image

--- a/game_patch/misc/alpine_settings.h
+++ b/game_patch/misc/alpine_settings.h
@@ -337,7 +337,7 @@ struct AlpineGameSettings
     }
 
     std::string multiplayer_tracker = "rfgt.factionfiles.com";
-    static constexpr size_t max_tracker_hostname_length = 200;
+    static constexpr size_t max_tracker_hostname_length = 63;
     void set_multiplayer_tracker(const std::string& tracker_hostname)
     {
         if (!tracker_hostname.empty() && tracker_hostname.length() <= max_tracker_hostname_length)

--- a/game_patch/multi/network.cpp
+++ b/game_patch/multi/network.cpp
@@ -26,6 +26,7 @@
 #include <patch_common/AsmWriter.h>
 #include <patch_common/ShortTypes.h>
 #include "network.h"
+#include "tracker.h"
 #include "multi.h"
 #include "mutators.h"
 #include "alpine_packets.h"
@@ -1304,16 +1305,6 @@ CodeInjection process_glass_kill_packet_check_room_exists_patch{
     },
 };
 
-CallHook<int(void*, int, int, rf::NetAddr&, int)> net_get_tracker_hook{
-    0x00482ED4,
-    [](void* data, int a2, int a3, rf::NetAddr& addr, int super_type) {
-        int res = net_get_tracker_hook.call_target(data, a2, a3, addr, super_type);
-        if (res != -1 && addr != rf::tracker_addr)
-            res = -1;
-        return res;
-    },
-};
-
 std::pair<std::unique_ptr<std::byte[]>, size_t> extend_packet_bytes(const std::byte* data, size_t len, const void* add, size_t add_len)
 {
     auto passthrough = [&](const char* why) {
@@ -2546,18 +2537,6 @@ FunHook<void(int, rf::NetAddr*)> multi_start_hook{
     },
 };
 
-FunHook<void()> tracker_do_broadcast_server_hook{
-    0x00483130,
-    []() {
-        tracker_do_broadcast_server_hook.call_target();
-        if (g_alpine_server_config.upnp_enabled) {
-            // Auto forward server port using UPnP (in background thread)
-            std::thread upnp_thread{try_to_auto_forward_port, rf::net_port};
-            upnp_thread.detach();
-        }
-    },
-};
-
 static std::array<
     std::deque<std::vector<uint8_t>>,
     rf::NET_MAX_REL_SOCKETS
@@ -3232,8 +3211,8 @@ void network_init()
     // Fix crash if room does not exist in glass_kill packet
     process_glass_kill_packet_check_room_exists_patch.install();
 
-    // Make sure tracker packets come from configured tracker
-    net_get_tracker_hook.install();
+    // Tracker packet filtering, UPnP port forwarding, and tracker hostname DNS refresh
+    tracker_do_patch();
 
     // Add Alpine Faction signature to game_info, game_info_req, join_req, join_accept packets
     send_game_info_packet_hook.install();
@@ -3257,9 +3236,6 @@ void network_init()
 
     // Use port 7755 when hosting a server without 'Force port' option
     multi_start_hook.install();
-
-    // Use UPnP for port forwarding if server is not in LAN-only mode
-    tracker_do_broadcast_server_hook.install();
 
     // Allow changing client and server update rate
     client_update_rate_injection.install();

--- a/game_patch/multi/network.h
+++ b/game_patch/multi/network.h
@@ -300,5 +300,6 @@ void handle_sound_msg(std::string_view name);
 void send_queues_rel_clear_packets(int socket_id);
 void send_queues_rel_add_packet(int socket_id, const uint8_t* data, size_t len);
 void network_debug_apply_patches();
+bool try_to_auto_forward_port(int port);
 void clear_rcon_profile_sessions();
 void multi_disconnect_from_server();

--- a/game_patch/multi/tracker.cpp
+++ b/game_patch/multi/tracker.cpp
@@ -60,11 +60,22 @@ static void tracker_dns_resolve_worker(std::string host, uint32_t current_ip)
 {
     uint32_t ip = 0;
     uint32_t ttl_s = 0;
-    bool found = false;
 
     PDNS_RECORDA records = nullptr;
     if (DnsQuery_A(host.c_str(), DNS_TYPE_A, DNS_QUERY_STANDARD, nullptr, &records, nullptr) == ERROR_SUCCESS) {
+        uint32_t first_ip = 0;
+        uint32_t first_ttl_s = 0;
+        uint32_t match_ip = 0;
+        uint32_t match_ttl_s = 0;
+        uint32_t cname_ttl_s = UINT32_MAX;
+
+        // Walk the whole list rather than stopping at a match: the alias and address records can be
+        // returned in any order, so an early exit could miss a CNAME that caps the refresh interval
         for (PDNS_RECORDA rec = records; rec; rec = rec->pNext) {
+            if (rec->wType == DNS_TYPE_CNAME) {
+                cname_ttl_s = std::min<uint32_t>(cname_ttl_s, rec->dwTtl);
+                continue;
+            }
             if (rec->wType != DNS_TYPE_A) {
                 continue;
             }
@@ -73,20 +84,25 @@ static void tracker_dns_resolve_worker(std::string host, uint32_t current_ip)
             if (rec_ip == 0) {
                 continue;
             }
-            if (!found) {
-                ip = rec_ip;
-                ttl_s = rec->dwTtl;
-                found = true;
+            if (first_ip == 0) {
+                first_ip = rec_ip;
+                first_ttl_s = rec->dwTtl;
             }
             // Resolvers rotate multi-A answers, and flapping the tracker address drops in-flight
             // replies (they are validated against it), so stay on the current one while it is offered
-            if (rec_ip == current_ip) {
-                ip = rec_ip;
-                ttl_s = rec->dwTtl;
-                break;
+            if (rec_ip == current_ip && match_ip == 0) {
+                match_ip = rec_ip;
+                match_ttl_s = rec->dwTtl;
             }
         }
         DnsRecordListFree(records, DnsFreeRecordList);
+
+        ip = match_ip != 0 ? match_ip : first_ip;
+        ttl_s = match_ip != 0 ? match_ttl_s : first_ttl_s;
+        // An aliased name expires with the shortest TTL in its chain, not with the address record
+        if (ip != 0) {
+            ttl_s = std::min(ttl_s, cname_ttl_s);
+        }
     }
 
     g_tracker_dns.result_ttl_s.store(ttl_s);

--- a/game_patch/multi/tracker.cpp
+++ b/game_patch/multi/tracker.cpp
@@ -1,0 +1,188 @@
+// The numeric-address check must match the engine's own inet_addr semantics,
+// so silence MSVC's deprecation of it.
+#define _WINSOCK_DEPRECATED_NO_WARNINGS
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <exception>
+#include <string>
+#include <thread>
+#include <winsock2.h>
+#include <windns.h>
+#include <xlog/xlog.h>
+#include <patch_common/CallHook.h>
+#include <patch_common/FunHook.h>
+#include "tracker.h"
+#include "network.h"
+#include "server_internal.h"
+#include "../rf/multi.h"
+
+CallHook<int(void*, int, int, rf::NetAddr&, int)> net_get_tracker_hook{
+    0x00482ED4,
+    [](void* data, int a2, int a3, rf::NetAddr& addr, int super_type) {
+        int res = net_get_tracker_hook.call_target(data, a2, a3, addr, super_type);
+        if (res != -1 && addr != rf::tracker_addr)
+            res = -1;
+        return res;
+    },
+};
+
+FunHook<void()> tracker_do_broadcast_server_hook{
+    0x00483130,
+    []() {
+        tracker_do_broadcast_server_hook.call_target();
+        if (g_alpine_server_config.upnp_enabled) {
+            // Auto forward server port using UPnP (in background thread)
+            std::thread upnp_thread{try_to_auto_forward_port, rf::net_port};
+            upnp_thread.detach();
+        }
+    },
+};
+
+// The stock game resolves the tracker hostname once at startup, so a tracker IP change only takes
+// effect after a restart. Re-resolve it in the background when the DNS record's TTL expires.
+struct TrackerDnsState
+{
+    std::atomic<bool> active{false};        // tracker is initialized and configured with a hostname
+    std::atomic<bool> in_flight{false};     // background query is running
+    std::atomic<bool> result_ready{false};  // query finished, waiting to be applied by the main thread
+    std::atomic<uint32_t> result_ip{0};     // host byte order, 0 means the query failed
+    std::atomic<uint32_t> result_ttl_s{0};
+    std::chrono::steady_clock::time_point next_refresh{}; // main thread only
+    bool failure_warned = false;                          // main thread only
+};
+
+static TrackerDnsState g_tracker_dns;
+
+static void tracker_dns_resolve_worker(std::string host, uint32_t current_ip)
+{
+    uint32_t ip = 0;
+    uint32_t ttl_s = 0;
+    bool found = false;
+
+    PDNS_RECORDA records = nullptr;
+    if (DnsQuery_A(host.c_str(), DNS_TYPE_A, DNS_QUERY_STANDARD, nullptr, &records, nullptr) == ERROR_SUCCESS) {
+        for (PDNS_RECORDA rec = records; rec; rec = rec->pNext) {
+            if (rec->wType != DNS_TYPE_A) {
+                continue;
+            }
+            const uint32_t rec_ip = ntohl(rec->Data.A.IpAddress); // tracker_addr keeps the address in host byte order
+            // Blackhole and blocklist resolvers answer with 0.0.0.0, which collides with the failure sentinel
+            if (rec_ip == 0) {
+                continue;
+            }
+            if (!found) {
+                ip = rec_ip;
+                ttl_s = rec->dwTtl;
+                found = true;
+            }
+            // Resolvers rotate multi-A answers, and flapping the tracker address drops in-flight
+            // replies (they are validated against it), so stay on the current one while it is offered
+            if (rec_ip == current_ip) {
+                ip = rec_ip;
+                ttl_s = rec->dwTtl;
+                break;
+            }
+        }
+        DnsRecordListFree(records, DnsFreeRecordList);
+    }
+
+    g_tracker_dns.result_ttl_s.store(ttl_s);
+    g_tracker_dns.result_ip.store(ip);
+    g_tracker_dns.result_ready.store(true);
+    g_tracker_dns.in_flight.store(false);
+}
+
+FunHook<int()> tracker_init_hook{
+    0x00482AE0,
+    []() {
+        int result = tracker_init_hook.call_target();
+        // The engine initializes only once but its callers do not, so never re-arm and clobber the backoff
+        if (result != 0 && !g_tracker_dns.active.load()) {
+            // A numeric address has no DNS record that can expire, so only hostnames are worth
+            // refreshing. Mirrors the stock game's test at 0x00482C4F.
+            const bool is_numeric = inet_addr(rf::tracker_hostname) != INADDR_NONE;
+            if (!is_numeric) {
+                // The engine already resolved the address but exposes no TTL, so query once right away
+                g_tracker_dns.next_refresh = std::chrono::steady_clock::now();
+                g_tracker_dns.active.store(true);
+            }
+        }
+        return result;
+    },
+};
+
+FunHook<void()> tracker_do_frame_hook{
+    0x00482D90,
+    []() {
+        tracker_do_frame_hook.call_target();
+
+        if (!g_tracker_dns.active.load()) {
+            return;
+        }
+
+        const auto now = std::chrono::steady_clock::now();
+        const char* const host = rf::tracker_hostname;
+
+        // Sample in_flight BEFORE result_ready. The worker stores result_ready = true strictly before
+        // in_flight = false, so in this order an observed in_flight == false guarantees any finished
+        // worker's result is already visible in result_ready. Loading them the other way round lets a
+        // worker that finishes between the two loads look idle, and a second worker gets spawned for
+        // the same refresh.
+        const bool in_flight = g_tracker_dns.in_flight.load();
+
+        if (g_tracker_dns.result_ready.load()) {
+            const uint32_t new_ip = g_tracker_dns.result_ip.load();
+            if (new_ip != 0) {
+                if (new_ip != rf::tracker_addr.ip_addr.inner) {
+                    const rf::IpAddr old_ip = rf::tracker_addr.ip_addr;
+                    rf::tracker_addr.ip_addr.inner = new_ip;
+                    xlog::info("Tracker {} moved from {} to {}", host, old_ip, rf::IpAddr{new_ip});
+                }
+                const uint32_t ttl_s = std::clamp<uint32_t>(g_tracker_dns.result_ttl_s.load(), 60, 86400);
+                g_tracker_dns.next_refresh = now + std::chrono::seconds{ttl_s};
+                g_tracker_dns.failure_warned = false;
+            }
+            else {
+                // A hostname that can never resolve would otherwise warn on every retry forever
+                if (!g_tracker_dns.failure_warned) {
+                    xlog::warn("Failed to re-resolve tracker {}, keeping {}", host, rf::tracker_addr.ip_addr);
+                    g_tracker_dns.failure_warned = true;
+                }
+                else {
+                    xlog::debug("Failed to re-resolve tracker {}, keeping {}", host, rf::tracker_addr.ip_addr);
+                }
+                g_tracker_dns.next_refresh = now + std::chrono::seconds{120};
+            }
+            g_tracker_dns.result_ready.store(false);
+        }
+        else if (!in_flight && now >= g_tracker_dns.next_refresh) {
+            g_tracker_dns.in_flight.store(true);
+            try {
+                std::thread dns_thread{tracker_dns_resolve_worker, std::string{host},
+                    rf::tracker_addr.ip_addr.inner};
+                dns_thread.detach();
+            }
+            catch (const std::exception& e) {
+                g_tracker_dns.in_flight.store(false);
+                xlog::warn("Failed to spawn tracker DNS resolve thread: {}", e.what());
+                g_tracker_dns.next_refresh = now + std::chrono::seconds{120};
+            }
+        }
+    },
+};
+
+void tracker_do_patch()
+{
+    // Make sure tracker packets come from configured tracker
+    net_get_tracker_hook.install();
+
+    // Use UPnP for port forwarding if server is not in LAN-only mode
+    tracker_do_broadcast_server_hook.install();
+
+    // Re-resolve the tracker hostname when its DNS record expires
+    tracker_init_hook.install();
+    tracker_do_frame_hook.install();
+}

--- a/game_patch/multi/tracker.h
+++ b/game_patch/multi/tracker.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void tracker_do_patch();

--- a/game_patch/rf/multi.h
+++ b/game_patch/rf/multi.h
@@ -346,6 +346,7 @@ namespace rf
     static auto& num_multi_characters = addr_as_ref<int>(0x006C9C60);
     static auto& simultaneous_ping = addr_as_ref<uint32_t>(0x00599CD8);
     static auto& tracker_addr = addr_as_ref<NetAddr>(0x006FC550);
+    static auto& tracker_hostname = addr_as_ref<char[64]>(0x0059F4B4);
     static auto& rcon_password = addr_as_ref<char[20]>(0x0064ECD0);
 
     enum ChatSayType {


### PR DESCRIPTION
- Respect DNS TTL for the multiplayer tracker hostname
- Fix `MultiplayerTracker` values longer than 63 characters overflowing an internal game buffer