### PR TITLE
Add multiplayer stats implementation

### DIFF
--- a/common/include/common/config/GameConfig.h
+++ b/common/include/common/config/GameConfig.h
@@ -80,6 +80,7 @@ struct GameConfig
     CfgVar<std::string> alpine_faction_version{""};
     CfgVar<std::string> fflink_token{""};
     CfgVar<std::string> fflink_username{""};
+    CfgVar<std::string> afstats_psk{""};
     CfgVar<bool> suppress_first_launch_window = false;
     CfgVar<bool> suppress_ff_link_prompt = false;
 

--- a/common/src/config/GameConfig.cpp
+++ b/common/src/config/GameConfig.cpp
@@ -165,6 +165,7 @@ bool GameConfig::visit_vars(T&& visitor, bool is_save)
     result &= visitor(alpine_faction_key, "Reduced Speed In Background", reduced_speed_in_background);
     result &= visitor(alpine_faction_key, "FFLink Token", fflink_token);
     result &= visitor(alpine_faction_key, "FFLink Username", fflink_username);
+    result &= visitor(alpine_faction_key, "AF Stats PSK", afstats_psk);
     result &= visitor(alpine_faction_key, "Already Saw First Launch Window", suppress_first_launch_window);
     result &= visitor(alpine_faction_key, "Already Saw FF Link Prompt", suppress_ff_link_prompt);
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,12 @@ Version 1.4.0 (Lupin): Not yet released
   - `Level` and `Match` can now select a game type and any number of mutators (with their options) for the voted level
   - Add a vote panel for calling any vote the server allows, opened during gameplay with the bindable `Call Vote Menu` control (`F4` by default)
   - Vote HUD notification now shows live tally, time remaining, and whether you have already voted
+- Add FactionFiles-supported multiplayer statistics tracking
+  - Dedicated servers with a configured `fflink_gsk` report a gameplay event stream to FactionFiles
+  - Clients joining a stats-enabled server obtain a stats session key from FactionFiles and deliver it to the server, attributing their stats to their linked FactionFiles account (or anonymously to their game installation when unlinked)
+  - Players on legacy clients can still join and play normally, and are tracked per-connection without cross-session identity
+  - `afstats_status` console command shows the local stats session state
+  - `sv_afstats_trace` console command logs outgoing report batches (with session keys redacted) on dedicated servers
 
 ### Minor features, changes, and enhancements
 [@GooberRF](https://github.com/GooberRF)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -184,6 +184,8 @@ Version 1.4.0 (Lupin): Not yet released
 - Fix the game feed rendering on top of the scoreboard
 - Fix textures referenced by custom `.vfx` mesh files not being included when the level editor packs a VPP
 - Fix chat and console showing only a bare player name when a player leaves after timing out waiting for game state
+- Fix an over-long console line overflowing the fixed-size console output buffer
+- Fix level editor crash when a custom mesh or texture subdirectory cannot be registered because the editor's internal path table is full
 
 [@is-this-c](https://github.com/is-this-c)
 - Clear cached server config output after a shuffle of a server's rotation

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,10 +45,10 @@ Version 1.4.0 (Lupin): Not yet released
   - `Level` and `Match` can now select a game type and any number of mutators (with their options) for the voted level
   - Add a vote panel for calling any vote the server allows, opened during gameplay with the bindable `Call Vote Menu` control (`F4` by default)
   - Vote HUD notification now shows live tally, time remaining, and whether you have already voted
-- Add FactionFiles-supported multiplayer statistics tracking
+- Add FactionFiles-integrated multiplayer statistics tracking
   - Dedicated servers with a configured `fflink_gsk` report a gameplay event stream to FactionFiles
   - Clients joining a stats-enabled server obtain a stats session key from FactionFiles and deliver it to the server, attributing their stats to their linked FactionFiles account (or anonymously to their game installation when unlinked)
-  - Players on legacy clients can still join and play normally, and are tracked per-connection without cross-session identity
+  - Players on legacy clients can join and play normally, and are tracked per-connection without cross-session identity
   - `afstats_status` console command shows the local stats session state
   - `sv_afstats_trace` console command logs outgoing report batches (with session keys redacted) on dedicated servers
 

--- a/editor_patch/meshes.cpp
+++ b/editor_patch/meshes.cpp
@@ -86,10 +86,13 @@ static std::vector<std::string> enumerate_mesh_subdirs(const char* root)
 // Register `rel_dir` with the VFS unless it is already registered, recording it for reload.
 static void register_mesh_dir(const std::string& rel_dir)
 {
-    if (!g_registered_mesh_dirs.insert(rel_dir).second) return;
+    if (g_registered_mesh_dirs.count(rel_dir)) return;
 
     int slot = file_add_path(rel_dir.c_str(), MESH_EXTENSIONS, false);
     if (slot >= 0) {
+        // Mark as registered only on success so a dir that failed because the VFS path
+        // table was full is retried on a later call instead of being permanently skipped.
+        g_registered_mesh_dirs.insert(rel_dir);
         g_mesh_path_slots.push_back(slot);
     }
     else {

--- a/editor_patch/meshes.cpp
+++ b/editor_patch/meshes.cpp
@@ -86,13 +86,14 @@ static std::vector<std::string> enumerate_mesh_subdirs(const char* root)
 // Register `rel_dir` with the VFS unless it is already registered, recording it for reload.
 static void register_mesh_dir(const std::string& rel_dir)
 {
-    if (g_registered_mesh_dirs.count(rel_dir)) return;
+    // Record on first sight (whether or not registration then succeeds) so this dir is
+    // skipped on every later reload. This is also what dedups the g_mesh_search_dirs
+    // push at each call site: a dir left out of this set would have its search entry
+    // re-appended on every reload_custom_meshes.
+    if (!g_registered_mesh_dirs.insert(rel_dir).second) return;
 
     int slot = file_add_path(rel_dir.c_str(), MESH_EXTENSIONS, false);
     if (slot >= 0) {
-        // Mark as registered only on success so a dir that failed because the VFS path
-        // table was full is retried on a later call instead of being permanently skipped.
-        g_registered_mesh_dirs.insert(rel_dir);
         g_mesh_path_slots.push_back(slot);
     }
     else {

--- a/editor_patch/textures.cpp
+++ b/editor_patch/textures.cpp
@@ -218,7 +218,15 @@ CodeInjection sidebar_custom_texture_path_injection{
         auto* panel = reinterpret_cast<TextureModePanel*>(static_cast<uintptr_t>(regs.esi));
         auto* cat_array = reinterpret_cast<VArray<TextureCategory*>*>(
             static_cast<char*>(panel->texture_manager) + 0x7C);
-        regs.edx = (*cat_array)[panel->category_index]->path_handle;
+        int path_handle = (*cat_array)[panel->category_index]->path_handle;
+        // A custom subdirectory whose VFS path failed to register (path table full)
+        // has path_handle == -1. This EDX value flows into the search's path-handle
+        // arg (FUN_004c3ec0 -> FUN_004c33d0), whose stock guard is `if (param_1 != 0)`:
+        // a negative handle passes that guard and indexes (&DAT_0156b110)[-3] out of
+        // bounds, then strlen's it -> crash. 0 is the stock "no path" sentinel that
+        // skips the prefix cleanly, so fall back to it (mirrors the handle>=0 guard in
+        // reload_custom_textures) — the category behaves as if it had no custom path.
+        regs.edx = (path_handle >= 0) ? path_handle : 0;
         // Original MOV EDX,[ESI+0x98] is 6 bytes; continue at next instruction
         regs.eip = 0x00445415;
     },
@@ -355,6 +363,10 @@ CodeInjection texture_refresh_all_iterate_custom_injection{
         for (int i = 0; i < cat_array->get_size(); i++) {
             TextureCategory* cat = (*cat_array)[i];
             if (std::strncmp(cat->name.c_str(), "Custom", 6) != 0) continue;
+            // A subdirectory whose VFS path failed to register has path_handle == -1;
+            // texture_browser_scan_path (0x004c3ec0) would index the path table out of
+            // bounds on a negative handle. Skip it (mirrors reload_custom_textures).
+            if (cat->path_handle < 0) continue;
 
             TextureListSentinel temp;
             temp.head = reinterpret_cast<TextureListNode*>(&temp);

--- a/game_patch/CMakeLists.txt
+++ b/game_patch/CMakeLists.txt
@@ -176,6 +176,8 @@ set(SRCS
     multi/faction_files.h
     fflink/afstats_client.cpp
     fflink/afstats_client.h
+    fflink/afstats_events.cpp
+    fflink/afstats_events.h
     fflink/fflink.cpp
     fflink/fflink.h
     fflink/fflink_achievements.cpp

--- a/game_patch/CMakeLists.txt
+++ b/game_patch/CMakeLists.txt
@@ -174,6 +174,8 @@ set(SRCS
     multi/endgame_votes.h
     multi/faction_files.cpp
     multi/faction_files.h
+    fflink/afstats_client.cpp
+    fflink/afstats_client.h
     fflink/fflink.cpp
     fflink/fflink.h
     fflink/fflink_achievements.cpp

--- a/game_patch/fflink/afstats_client.cpp
+++ b/game_patch/fflink/afstats_client.cpp
@@ -14,6 +14,7 @@
 #include <utility>
 
 #include <json.hpp>
+#include <patch_common/FunHook.h>
 #include <xlog/xlog.h>
 
 #include <common/HttpRequest.h>
@@ -242,7 +243,8 @@ ExchangeOutcome do_one_exchange(const std::string& psk, const std::string& fflin
         const std::string response_preview = sanitize_for_log(
             response.size() <= k_log_response_prefix
                 ? std::string_view{response}
-                : std::string_view{response}.substr(0, k_log_response_prefix));
+                : std::string_view{response}.substr(0, k_log_response_prefix),
+            k_log_response_prefix);
         const char* truncated = response.size() > k_log_response_prefix ? "...[truncated]" : "";
         xlog::warn("[afstats] <<< body: {}{}", response_preview, truncated);
     }
@@ -276,6 +278,14 @@ ExchangeOutcome do_one_exchange(const std::string& psk, const std::string& fflin
 
 void maybe_send_pssk()
 {
+    if (!g_state.stats_enabled) {
+        // An exchange the browser entry started can outlive the accept that disowned it,
+        // so delivery is gated on the flag rather than on how the exchange began.
+        if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+            xlog::warn("[afstats] holding PSSK delivery: this server is not stats-enabled");
+        }
+        return;
+    }
     if (g_state.status != Status::done) {
         if constexpr (AFSTATS_VERIFICATION_LOGGING) {
             xlog::warn("[afstats] holding PSSK delivery: exchange status is {}",
@@ -308,10 +318,38 @@ void maybe_send_pssk()
 
 void on_exchange_finished(uint32_t join_id, ExchangeOutcome outcome)
 {
+    // Two effects are process-lifetime, not join-scoped, so they run BEFORE the stale
+    // guard below: an abandoned or superseded join must not throw them away.
+    //   - The 429 mint backoff is per-IP-per-hour on the FF side, so it has to hold
+    //     even if the join it was minted for is already gone.
+    //   - A freshly minted PSK is the player's key regardless of which join fetched it;
+    //     persisting it here (rather than after the guard) is what lets a same-address
+    //     retry reuse it instead of minting again.
+    // PSSK DELIVERY stays join-scoped and remains below the guard.
+    if (outcome.kind == ExchangeOutcome::Kind::mint_rate_limited) {
+        g_mint_backoff_until = std::chrono::steady_clock::now() + k_mint_backoff;
+        xlog::warn("[afstats] mint backoff armed for the next {} minutes", k_mint_backoff.count());
+    }
+    if (outcome.kind == ExchangeOutcome::Kind::success) {
+        // The returned PSK is authoritative; it differs from ours whenever we sent
+        // none, sent one FactionFiles no longer knows, or the player relinked.
+        if (outcome.psk != g_game_config.afstats_psk.value()) {
+            g_game_config.afstats_psk = outcome.psk;
+            g_game_config.save();
+            if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+                xlog::warn("[afstats] new PSK persisted to config");
+            }
+        }
+        else if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+            xlog::warn("[afstats] PSK unchanged, nothing written to config");
+        }
+    }
+
     if (join_id != g_state.join_id) {
         if constexpr (AFSTATS_VERIFICATION_LOGGING) {
             xlog::warn(
-                "[afstats] dropping stale exchange result (started for join_id={}, current join_id={})",
+                "[afstats] dropping stale exchange result (started for join_id={}, current join_id={}); "
+                "PSK/backoff already applied above",
                 join_id, g_state.join_id);
         }
         return; // the join this was started for is gone
@@ -322,32 +360,12 @@ void on_exchange_finished(uint32_t join_id, ExchangeOutcome outcome)
                    kind_to_str(outcome.kind));
     }
 
-    if (outcome.kind == ExchangeOutcome::Kind::mint_rate_limited) {
-        g_mint_backoff_until = std::chrono::steady_clock::now() + k_mint_backoff;
-        xlog::warn("[afstats] mint backoff armed for the next {} minutes", k_mint_backoff.count());
-    }
-
     if (outcome.kind != ExchangeOutcome::Kind::success) {
         xlog::warn("[afstats] no stats session this join: {} ({})", kind_to_str(outcome.kind),
                    outcome.error_detail);
         g_state.status = Status::failed;
         rf::console::print("Stats are unavailable this session ({}).", outcome.error_detail);
         return;
-    }
-
-    // The returned PSK is authoritative; it differs from ours whenever we sent
-    // none, sent one FactionFiles no longer knows, or the player relinked.
-    if (outcome.psk != g_game_config.afstats_psk.value()) {
-        g_game_config.afstats_psk = outcome.psk;
-        g_game_config.save();
-        if constexpr (AFSTATS_VERIFICATION_LOGGING) {
-            xlog::warn("[afstats] new PSK persisted to config");
-        }
-    }
-    else {
-        if constexpr (AFSTATS_VERIFICATION_LOGGING) {
-            xlog::warn("[afstats] PSK unchanged, nothing written to config");
-        }
     }
 
     g_state.status = Status::done;
@@ -498,14 +516,46 @@ ConsoleCommand2 afstats_status_cmd{
     "Show the status of this session's FactionFiles player stats link.",
 };
 
+// multi_set_current_server_addr: the engine records the server it is about to send a
+// join_req to. Every join attempt runs through it exactly once — the server list's
+// join button, the password prompt's callback, and our own -url path — and nothing
+// else calls it, so it is the one signal that a NEW attempt is beginning.
+//
+// This is where an abandoned attempt is dropped. The stock join has no cancel of its
+// own: leaving the connecting screen never reaches multi_stop, so without this a
+// cancel followed by a rejoin to the same address would inherit the abandoned
+// attempt's exchange state and PSSK (and its pssk_sent latch, which would suppress
+// delivery on the new connection entirely).
+//
+// Reset only on a NEW target. A wrong-password retry re-enters this hook with the same
+// address; resetting there would wipe an in-progress or completed exchange and any live
+// PSSK, and force a needless FF mint round-trip on the retry. multi_stop already resets
+// on a genuine disconnect, so a rejoin to the same address after leaving starts clean
+// regardless. g_state.target is cleared by afstats_client_reset(), so the last address
+// is tracked here rather than read back from it.
+std::optional<rf::NetAddr> g_last_attempt_addr;
+
+FunHook<void(const rf::NetAddr&)> multi_set_current_server_addr_hook{
+    0x0044B380,
+    [](const rf::NetAddr& addr) {
+        multi_set_current_server_addr_hook.call_target(addr);
+        if (!g_last_attempt_addr || *g_last_attempt_addr != addr) {
+            g_last_attempt_addr = addr;
+            afstats_client_reset();
+        }
+    },
+};
+
 } // namespace
 
 void afstats_client_on_join_req(const rf::NetAddr& addr, bool stats_enabled)
 {
     xlog::debug("[afstats] join_req to {} (stats_enabled={})", addr, stats_enabled ? "yes" : "no");
 
-    // The stock cancel path leaves multiplayer without a multi_stop, so a join the
-    // player abandoned is only cleared here, when the next one starts elsewhere.
+    // The attempt-start hook above already cleared any abandoned
+    // join, so this only fires if a join_req ever reaches the wire without the engine
+    // recording the target first. Retransmits within one attempt carry the same
+    // address and must not reset.
     if (g_state.target && *g_state.target != addr) {
         if constexpr (AFSTATS_VERIFICATION_LOGGING) {
             xlog::warn("[afstats] target changed from {} to {}; dropping the abandoned join's state",
@@ -529,14 +579,17 @@ void afstats_client_on_join_req(const rf::NetAddr& addr, bool stats_enabled)
 void afstats_client_on_join_accept(bool stats_enabled)
 {
     if constexpr (AFSTATS_VERIFICATION_LOGGING) {
-        xlog::warn("[afstats] join_accept parsed (stats_enabled={}, exchange already started={})",
+        xlog::warn("[afstats] join_accept settled stats_enabled={} (exchange already started={})",
                    stats_enabled ? "yes" : "no", g_state.exchange_started ? "yes" : "no");
     }
 
+    // The accept is the server describing itself, so it settles the flag in both
+    // directions: a browser entry that said "stats enabled" can be stale or simply
+    // belong to a different server that has since taken the address.
+    g_state.stats_enabled = stats_enabled;
     if (!stats_enabled) {
         return;
     }
-    g_state.stats_enabled = true;
     maybe_start_exchange();
 }
 
@@ -576,6 +629,7 @@ void afstats_client_reset()
 void afstats_client_do_patch()
 {
     afstats_status_cmd.register_cmd();
+    multi_set_current_server_addr_hook.install();
 }
 
 } // namespace fflink

--- a/game_patch/fflink/afstats_client.cpp
+++ b/game_patch/fflink/afstats_client.cpp
@@ -1,0 +1,500 @@
+#include "afstats_client.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <format>
+#include <iterator>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <utility>
+
+#include <json.hpp>
+#include <xlog/xlog.h>
+
+#include <common/HttpRequest.h>
+#include <common/version/version.h>
+
+#include "../main/main.h"
+#include "../multi/alpine_packets.h"
+#include "../multi/multi.h"
+#include "../os/console.h"
+#include "../rf/multi.h"
+#include "fflink_utils.h"
+
+namespace fflink {
+
+namespace {
+
+constexpr const char* k_session_url = "https://www.factionfiles.com/pfapi/afstats/v1/playerstatssession.php";
+constexpr const char* k_user_agent = AF_USER_AGENT_SUFFIX("AFStatsPlayer");
+
+// Connect and receive timeouts in ms
+constexpr unsigned long k_connect_timeout_ms = 3000;
+constexpr unsigned long k_receive_timeout_ms = 5000;
+
+// Delays before each retry (seconds). The array size is also the retry count.
+constexpr int k_retry_delays_s[] = {2, 5};
+
+// How long a mint_rate_limited response keeps us from asking for a brand new PSK.
+constexpr auto k_mint_backoff = std::chrono::minutes(15);
+
+enum class Status
+{
+    idle,
+    in_flight,
+    done,
+    failed,
+};
+
+const char* status_to_str(Status s)
+{
+    switch (s) {
+        case Status::idle:      return "not started";
+        case Status::in_flight: return "exchange in progress";
+        case Status::done:      return "ready";
+        case Status::failed:    return "unavailable";
+    }
+    return "unknown";
+}
+
+struct JoinState
+{
+    uint32_t join_id = 0;
+    std::optional<rf::NetAddr> target;
+    bool stats_enabled = false;
+    bool exchange_started = false;
+    Status status = Status::idle;
+    std::string pssk;
+    int user_id = -1;
+    std::string user_name;
+    bool in_game = false;
+    bool pssk_sent = false;
+};
+
+// Owned by the main thread; workers only ever enqueue tasks that touch it.
+JoinState g_state;
+
+// Mirror of g_state.join_id that workers may read, so they can abort between retries.
+std::atomic<uint32_t> g_active_join_id{0};
+
+// Survives joins: the FF-side mint limit is per IP per hour, not per connection.
+std::chrono::steady_clock::time_point g_mint_backoff_until{};
+
+bool g_stale_link_notice_shown = false;
+
+struct ExchangeOutcome
+{
+    enum class Kind {
+        success,
+        client_error,      // 400/405: we built a bad request, retrying can't help
+        mint_rate_limited, // 429: give up for this join and back off minting
+        transient_error,   // 5xx, network, parse: retry
+    };
+    Kind kind = Kind::transient_error;
+    std::string psk;
+    std::string pssk;
+    std::string psk_origin;
+    std::string fflink_status;
+    int user_id = -1;
+    std::string user_name;
+    std::string error_detail; // safe-to-display message
+};
+
+const char* kind_to_str(ExchangeOutcome::Kind kind)
+{
+    switch (kind) {
+        case ExchangeOutcome::Kind::success:           return "success";
+        case ExchangeOutcome::Kind::client_error:      return "client_error";
+        case ExchangeOutcome::Kind::mint_rate_limited: return "mint_rate_limited";
+        case ExchangeOutcome::Kind::transient_error:   return "transient_error";
+    }
+    return "unknown";
+}
+
+ExchangeOutcome do_one_exchange(const std::string& psk, const std::string& fflink_token)
+{
+    ExchangeOutcome out;
+
+    // Absent credentials must be JSON null; an empty string is a 400 on the FF side.
+    const auto as_json = [](const std::string& value) {
+        return value.empty() ? nlohmann::json(nullptr) : nlohmann::json(value);
+    };
+    const std::string body =
+        nlohmann::json{{"psk", as_json(psk)}, {"fflink_token", as_json(fflink_token)}}.dump();
+
+    // Redacted copy for logging — neither key may ever be written to disk. The
+    // placeholder is fixed width so the log does not even carry a key length.
+    const auto redacted = [](const std::string& value) {
+        return value.empty() ? nlohmann::json(nullptr) : nlohmann::json("<redacted>");
+    };
+    const std::string body_for_log =
+        nlohmann::json{{"psk", redacted(psk)}, {"fflink_token", redacted(fflink_token)}}.dump();
+    xlog::warn("[afstats] >>> POST {}", k_session_url);
+    xlog::warn("[afstats] >>> User-Agent: {}", k_user_agent);
+    xlog::warn("[afstats] >>> Content-Type: application/json");
+    xlog::warn("[afstats] >>> Content-Length: {}", body.size());
+    xlog::warn("[afstats] >>> body ({} bytes): {}", body.size(), body_for_log);
+
+    std::string response;
+    int status_code = 0;
+
+    try {
+        HttpSession session(k_user_agent);
+        session.set_connect_timeout(k_connect_timeout_ms);
+        session.set_receive_timeout(k_receive_timeout_ms);
+
+        HttpRequest req(k_session_url, "POST", session);
+        req.set_content_type("application/json");
+        status_code = req.send_no_check(body);
+
+        char buf[1024];
+        std::ostringstream stream;
+        while (size_t n = req.read(buf, sizeof(buf))) {
+            stream.write(buf, n);
+        }
+        response = stream.str();
+    }
+    catch (const std::exception& e) {
+        out.kind = ExchangeOutcome::Kind::transient_error;
+        out.error_detail = std::string{"network error: "} + e.what();
+        xlog::warn("[afstats] <<< {} (classified transient)", out.error_detail);
+        return out;
+    }
+
+    xlog::warn("[afstats] <<< HTTP {} from {} ({} byte body)", status_code, k_session_url, response.size());
+
+    constexpr size_t k_log_response_prefix = 256;
+    auto log_body_preview = [&]() {
+        const std::string response_preview = sanitize_for_log(
+            response.size() <= k_log_response_prefix
+                ? std::string_view{response}
+                : std::string_view{response}.substr(0, k_log_response_prefix));
+        const char* truncated = response.size() > k_log_response_prefix ? "...[truncated]" : "";
+        xlog::warn("[afstats] <<< body: {}{}", response_preview, truncated);
+    };
+
+    if (status_code == 200) {
+        try {
+            auto j = nlohmann::json::parse(response);
+            auto psk_out = j.at("psk").get<std::string>();
+            auto pssk_out = j.at("pssk").get<std::string>();
+            if (!is_valid_stats_key_format(psk_out)) {
+                throw std::runtime_error("psk has invalid format");
+            }
+            if (!is_valid_stats_key_format(pssk_out)) {
+                throw std::runtime_error("pssk has invalid format");
+            }
+            out.kind = ExchangeOutcome::Kind::success;
+            out.psk = std::move(psk_out);
+            out.pssk = std::move(pssk_out);
+            if (j.contains("psk_origin") && j["psk_origin"].is_string()) {
+                out.psk_origin = sanitize_for_log(j["psk_origin"].get<std::string>());
+            }
+            if (j.contains("fflink_status") && j["fflink_status"].is_string()) {
+                out.fflink_status = sanitize_for_log(j["fflink_status"].get<std::string>());
+            }
+            if (j.contains("user_id") && j["user_id"].is_number_integer()) {
+                out.user_id = j["user_id"].get<int>();
+            }
+            if (j.contains("user_name") && j["user_name"].is_string()) {
+                out.user_name = sanitize_for_log(j["user_name"].get<std::string>());
+            }
+            xlog::warn("[afstats] <<< parsed OK (classified success)");
+            return out;
+        }
+        catch (const nlohmann::json::parse_error& e) {
+            // Never log the body or e.what() here: a parse error quotes the input it
+            // choked on, and on a 200 that input is key material.
+            xlog::warn("[afstats] HTTP 200 but the body failed to parse (error {} at byte {}); "
+                       "body length={} bytes",
+                       e.id, e.byte, response.size());
+            out.kind = ExchangeOutcome::Kind::transient_error;
+            out.error_detail = "malformed JSON response";
+            return out;
+        }
+        catch (const std::exception& e) {
+            // Missing/mistyped fields and our own format checks. These describe the
+            // shape of the response, never its contents.
+            xlog::warn("[afstats] HTTP 200 but validation failed: {}; body length={} bytes", e.what(),
+                       response.size());
+            out.kind = ExchangeOutcome::Kind::transient_error;
+            out.error_detail = std::string{"invalid response: "} + e.what();
+            return out;
+        }
+    }
+
+    log_body_preview();
+
+    std::string error_code = "unspecified";
+    try {
+        auto j = nlohmann::json::parse(response);
+        if (j.contains("error") && j["error"].is_string()) {
+            error_code = sanitize_for_log(j["error"].get<std::string>());
+        }
+    }
+    catch (const std::exception&) {
+        // Body wasn't JSON; leave error_code as default.
+    }
+
+    out.error_detail = std::format("HTTP {} ({})", status_code, error_code);
+    if (status_code == 429) {
+        out.kind = ExchangeOutcome::Kind::mint_rate_limited;
+    }
+    else if (status_code == 400 || status_code == 405) {
+        out.kind = ExchangeOutcome::Kind::client_error;
+    }
+    else {
+        out.kind = ExchangeOutcome::Kind::transient_error;
+    }
+    xlog::warn("[afstats] <<< {} classified as {}", out.error_detail, kind_to_str(out.kind));
+    return out;
+}
+
+void maybe_send_pssk()
+{
+    if (g_state.status != Status::done) {
+        xlog::warn("[afstats] holding PSSK delivery: exchange status is {}", status_to_str(g_state.status));
+        return;
+    }
+    if (!g_state.in_game) {
+        xlog::warn("[afstats] holding PSSK delivery: not in the game yet");
+        return;
+    }
+    if (g_state.pssk_sent) {
+        xlog::warn("[afstats] holding PSSK delivery: already sent for this join");
+        return;
+    }
+    // VERIFICATION PHASE ONLY: logs the session key verbatim, by explicit request.
+    xlog::warn("[afstats] delivering PSSK {} to server", g_state.pssk);
+    af_send_stats_pssk(g_state.pssk);
+    g_state.pssk_sent = true;
+    xlog::warn("[afstats] PSSK sent (join_id={})", g_state.join_id);
+}
+
+void on_exchange_finished(uint32_t join_id, ExchangeOutcome outcome)
+{
+    if (join_id != g_state.join_id) {
+        xlog::warn("[afstats] dropping stale exchange result (started for join_id={}, current join_id={})",
+                   join_id, g_state.join_id);
+        return; // the join this was started for is gone
+    }
+
+    xlog::warn("[afstats] exchange finished for join_id={} with outcome {}", join_id,
+               kind_to_str(outcome.kind));
+
+    if (outcome.kind == ExchangeOutcome::Kind::mint_rate_limited) {
+        g_mint_backoff_until = std::chrono::steady_clock::now() + k_mint_backoff;
+        xlog::warn("[afstats] mint backoff armed for the next {} minutes", k_mint_backoff.count());
+    }
+
+    if (outcome.kind != ExchangeOutcome::Kind::success) {
+        xlog::warn("[afstats] no stats session this join: {} ({})", kind_to_str(outcome.kind),
+                   outcome.error_detail);
+        g_state.status = Status::failed;
+        rf::console::print("Stats are unavailable this session ({}).", outcome.error_detail);
+        return;
+    }
+
+    // The returned PSK is authoritative; it differs from ours whenever we sent
+    // none, sent one FactionFiles no longer knows, or the player relinked.
+    if (outcome.psk != g_game_config.afstats_psk.value()) {
+        g_game_config.afstats_psk = outcome.psk;
+        g_game_config.save();
+        xlog::warn("[afstats] new PSK persisted to config");
+    }
+    else {
+        xlog::warn("[afstats] PSK unchanged, nothing written to config");
+    }
+
+    g_state.status = Status::done;
+    g_state.pssk = std::move(outcome.pssk);
+    g_state.user_id = outcome.user_id;
+    g_state.user_name = std::move(outcome.user_name);
+
+    // VERIFICATION PHASE ONLY: logs the session key verbatim, by explicit request.
+    xlog::warn("[afstats] obtained PSSK {}", g_state.pssk);
+    xlog::warn("[afstats] session ready (psk_origin={}, fflink_status={}, user_id={}, user_name={})",
+               outcome.psk_origin.empty() ? "<absent>" : outcome.psk_origin,
+               outcome.fflink_status.empty() ? "<absent>" : outcome.fflink_status, g_state.user_id,
+               g_state.user_name.empty() ? "anonymous" : g_state.user_name);
+
+    if (outcome.fflink_status == "unknown" && !g_stale_link_notice_shown) {
+        g_stale_link_notice_shown = true;
+        xlog::warn("[afstats] fflink token is stale; showing the re-link notice once this session");
+        rf::console::print("Your FactionFiles link has expired. Re-link from the launcher.");
+    }
+
+    maybe_send_pssk();
+}
+
+void exchange_worker_impl(uint32_t join_id, const std::string& psk, const std::string& fflink_token)
+{
+    constexpr int max_attempts = static_cast<int>(std::size(k_retry_delays_s)) + 1;
+
+    for (int attempt = 0;; ++attempt) {
+        const uint32_t active = g_active_join_id.load(std::memory_order_acquire);
+        if (active != join_id) {
+            xlog::warn("[afstats] worker aborting: join_id={} is stale (active join_id={})", join_id,
+                       active);
+            return;
+        }
+
+        xlog::warn("[afstats] exchange attempt {}/{} for join_id={}", attempt + 1, max_attempts, join_id);
+
+        // Always the same PSK: retrying with null would abandon the player's key.
+        ExchangeOutcome outcome = do_one_exchange(psk, fflink_token);
+
+        const bool can_retry = outcome.kind == ExchangeOutcome::Kind::transient_error
+            && attempt < static_cast<int>(std::size(k_retry_delays_s));
+        if (!can_retry) {
+            xlog::warn("[afstats] no further attempts ({}), handing result to the main thread",
+                       kind_to_str(outcome.kind));
+            enqueue_main_thread_task([join_id, outcome = std::move(outcome)]() mutable {
+                on_exchange_finished(join_id, std::move(outcome));
+            });
+            return;
+        }
+
+        const int delay_s = k_retry_delays_s[attempt];
+        xlog::warn("[afstats] attempt {} failed ({}); retrying in {}s", attempt + 1, outcome.error_detail,
+                   delay_s);
+        std::this_thread::sleep_for(std::chrono::seconds(delay_s));
+    }
+}
+
+void exchange_worker(uint32_t join_id, std::string psk, std::string fflink_token)
+{
+    // Catch-all wrapper and safe escape for worker thread
+    try {
+        exchange_worker_impl(join_id, psk, fflink_token);
+    }
+    catch (const std::exception& e) {
+        xlog::warn("[afstats] stats session worker terminated unexpectedly: {}", e.what());
+    }
+    catch (...) {
+        xlog::warn("[afstats] stats session worker terminated with unknown exception");
+    }
+}
+
+void maybe_start_exchange()
+{
+    if (g_state.exchange_started) {
+        xlog::warn("[afstats] skipping exchange: already started for join_id={}", g_state.join_id);
+        return; // join_req resends and the join_accept trigger both land here
+    }
+    if (client_bot_launch_enabled()) {
+        xlog::warn("[afstats] skipping exchange: this client is a launch bot");
+        return; // client bots must never mint PSKs
+    }
+
+    std::string psk = g_game_config.afstats_psk.value();
+    if (!psk.empty() && !is_valid_stats_key_format(psk)) {
+        xlog::warn("[afstats] stored PSK is malformed; cleared it and asking FactionFiles for a new one");
+        psk.clear();
+    }
+    // The mint limit only applies to new keys, so a client holding one is never blocked.
+    const auto now = std::chrono::steady_clock::now();
+    if (psk.empty() && now < g_mint_backoff_until) {
+        const auto remaining_s =
+            std::chrono::duration_cast<std::chrono::seconds>(g_mint_backoff_until - now).count();
+        xlog::warn("[afstats] skipping exchange: mint backoff active for another {}s and no stored PSK",
+                   remaining_s);
+        return;
+    }
+
+    g_state.exchange_started = true;
+    g_state.status = Status::in_flight;
+
+    const bool have_token = !g_game_config.fflink_token.value().empty();
+    xlog::warn("[afstats] starting exchange (join_id={}, stored PSK: {}, fflink token: {})",
+               g_state.join_id, psk.empty() ? "no" : "yes", have_token ? "yes" : "no");
+
+    try {
+        std::thread(exchange_worker, g_state.join_id, std::move(psk),
+                    g_game_config.fflink_token.value())
+            .detach();
+    }
+    catch (const std::exception& e) {
+        xlog::warn("[afstats] failed to spawn stats session thread: {}", e.what());
+        g_state.status = Status::failed;
+    }
+}
+
+ConsoleCommand2 afstats_status_cmd{
+    "afstats_status",
+    []() {
+        rf::console::print("Stats-enabled server: {}", g_state.stats_enabled ? "yes" : "no");
+        rf::console::print("  Stats session: {}{}", status_to_str(g_state.status),
+            g_state.pssk_sent ? " (delivered to server)" : "");
+        // The PSK remembers the account it was linked to, so attribution can hold
+        // even when the token we sent was stale.
+        rf::console::print("  Signed in as: {}", g_state.user_id < 0
+            ? std::string{"anonymous"}
+            : (g_state.user_name.empty() ? std::to_string(g_state.user_id) : g_state.user_name));
+    },
+    "Show the status of this session's FactionFiles player stats link.",
+};
+
+} // namespace
+
+void afstats_on_join_req(const rf::NetAddr& addr, bool stats_enabled)
+{
+    xlog::warn("[afstats] join_req to {} (stats_enabled={})", addr, stats_enabled ? "yes" : "no");
+
+    // The stock cancel path leaves multiplayer without a multi_stop, so a join the
+    // player abandoned is only cleared here, when the next one starts elsewhere.
+    if (g_state.target && *g_state.target != addr) {
+        xlog::warn("[afstats] target changed from {} to {}; dropping the abandoned join's state",
+                   *g_state.target, addr);
+        afstats_reset();
+    }
+    g_state.target = addr;
+
+    if (!stats_enabled) {
+        xlog::warn("[afstats] browser entry says this server is not stats-enabled; no exchange from join_req");
+        return;
+    }
+    g_state.stats_enabled = true;
+    maybe_start_exchange();
+}
+
+void afstats_on_join_accept(bool stats_enabled)
+{
+    xlog::warn("[afstats] join_accept parsed (stats_enabled={}, exchange already started={})",
+               stats_enabled ? "yes" : "no", g_state.exchange_started ? "yes" : "no");
+
+    if (!stats_enabled) {
+        return;
+    }
+    g_state.stats_enabled = true;
+    maybe_start_exchange();
+}
+
+void afstats_on_entered_game()
+{
+    g_state.in_game = true;
+    xlog::warn("[afstats] entered the game (join_id={}, exchange status={})", g_state.join_id,
+               status_to_str(g_state.status));
+    maybe_send_pssk();
+}
+
+void afstats_reset()
+{
+    const uint32_t next_join_id = g_state.join_id + 1;
+    xlog::warn("[afstats] resetting join state (join_id {} -> {})", g_state.join_id, next_join_id);
+    g_state = JoinState{};
+    g_state.join_id = next_join_id;
+    g_active_join_id.store(next_join_id, std::memory_order_release);
+}
+
+void afstats_do_patch()
+{
+    afstats_status_cmd.register_cmd();
+}
+
+} // namespace fflink

--- a/game_patch/fflink/afstats_client.cpp
+++ b/game_patch/fflink/afstats_client.cpp
@@ -37,6 +37,9 @@ constexpr const char* k_user_agent = AF_USER_AGENT_SUFFIX("AFStatsPlayer");
 constexpr unsigned long k_connect_timeout_ms = 3000;
 constexpr unsigned long k_receive_timeout_ms = 5000;
 
+// Harden against a broken response from FF being unbounded.
+constexpr size_t k_max_response_bytes = 256 * 1024;
+
 // Delays before each retry (seconds). The array size is also the retry count.
 constexpr int k_retry_delays_s[] = {2, 5};
 
@@ -127,18 +130,20 @@ ExchangeOutcome do_one_exchange(const std::string& psk, const std::string& fflin
     const std::string body =
         nlohmann::json{{"psk", as_json(psk)}, {"fflink_token", as_json(fflink_token)}}.dump();
 
-    // Redacted copy for logging — neither key may ever be written to disk. The
-    // placeholder is fixed width so the log does not even carry a key length.
-    const auto redacted = [](const std::string& value) {
-        return value.empty() ? nlohmann::json(nullptr) : nlohmann::json("<redacted>");
-    };
-    const std::string body_for_log =
-        nlohmann::json{{"psk", redacted(psk)}, {"fflink_token", redacted(fflink_token)}}.dump();
-    xlog::warn("[afstats] >>> POST {}", k_session_url);
-    xlog::warn("[afstats] >>> User-Agent: {}", k_user_agent);
-    xlog::warn("[afstats] >>> Content-Type: application/json");
-    xlog::warn("[afstats] >>> Content-Length: {}", body.size());
-    xlog::warn("[afstats] >>> body ({} bytes): {}", body.size(), body_for_log);
+    if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+        // Redacted copy for logging — neither key may ever be written to disk. The
+        // placeholder is fixed width so the log does not even carry a key length.
+        const auto redacted = [](const std::string& value) {
+            return value.empty() ? nlohmann::json(nullptr) : nlohmann::json("<redacted>");
+        };
+        const std::string body_for_log =
+            nlohmann::json{{"psk", redacted(psk)}, {"fflink_token", redacted(fflink_token)}}.dump();
+        xlog::warn("[afstats] >>> POST {}", k_session_url);
+        xlog::warn("[afstats] >>> User-Agent: {}", k_user_agent);
+        xlog::warn("[afstats] >>> Content-Type: application/json");
+        xlog::warn("[afstats] >>> Content-Length: {}", body.size());
+        xlog::warn("[afstats] >>> body ({} bytes): {}", body.size(), body_for_log);
+    }
 
     std::string response;
     int status_code = 0;
@@ -154,7 +159,14 @@ ExchangeOutcome do_one_exchange(const std::string& psk, const std::string& fflin
 
         char buf[1024];
         std::ostringstream stream;
+        size_t total = 0;
         while (size_t n = req.read(buf, sizeof(buf))) {
+            total += n;
+            if (total > k_max_response_bytes) {
+                // A broken or hostile endpoint must not stream unbounded data into
+                // memory; classify as transient.
+                throw std::runtime_error("response exceeded size cap");
+            }
             stream.write(buf, n);
         }
         response = stream.str();
@@ -162,21 +174,16 @@ ExchangeOutcome do_one_exchange(const std::string& psk, const std::string& fflin
     catch (const std::exception& e) {
         out.kind = ExchangeOutcome::Kind::transient_error;
         out.error_detail = std::string{"network error: "} + e.what();
-        xlog::warn("[afstats] <<< {} (classified transient)", out.error_detail);
+        if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+            xlog::warn("[afstats] <<< {} (classified transient)", out.error_detail);
+        }
         return out;
     }
 
-    xlog::warn("[afstats] <<< HTTP {} from {} ({} byte body)", status_code, k_session_url, response.size());
-
-    constexpr size_t k_log_response_prefix = 256;
-    auto log_body_preview = [&]() {
-        const std::string response_preview = sanitize_for_log(
-            response.size() <= k_log_response_prefix
-                ? std::string_view{response}
-                : std::string_view{response}.substr(0, k_log_response_prefix));
-        const char* truncated = response.size() > k_log_response_prefix ? "...[truncated]" : "";
-        xlog::warn("[afstats] <<< body: {}{}", response_preview, truncated);
-    };
+    if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+        xlog::warn("[afstats] <<< HTTP {} from {} ({} byte body)", status_code, k_session_url,
+                   response.size());
+    }
 
     if (status_code == 200) {
         try {
@@ -204,7 +211,9 @@ ExchangeOutcome do_one_exchange(const std::string& psk, const std::string& fflin
             if (j.contains("user_name") && j["user_name"].is_string()) {
                 out.user_name = sanitize_for_log(j["user_name"].get<std::string>());
             }
-            xlog::warn("[afstats] <<< parsed OK (classified success)");
+            if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+                xlog::warn("[afstats] <<< parsed OK (classified success)");
+            }
             return out;
         }
         catch (const nlohmann::json::parse_error& e) {
@@ -228,7 +237,15 @@ ExchangeOutcome do_one_exchange(const std::string& psk, const std::string& fflin
         }
     }
 
-    log_body_preview();
+    if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+        constexpr size_t k_log_response_prefix = 256;
+        const std::string response_preview = sanitize_for_log(
+            response.size() <= k_log_response_prefix
+                ? std::string_view{response}
+                : std::string_view{response}.substr(0, k_log_response_prefix));
+        const char* truncated = response.size() > k_log_response_prefix ? "...[truncated]" : "";
+        xlog::warn("[afstats] <<< body: {}{}", response_preview, truncated);
+    }
 
     std::string error_code = "unspecified";
     try {
@@ -251,41 +268,59 @@ ExchangeOutcome do_one_exchange(const std::string& psk, const std::string& fflin
     else {
         out.kind = ExchangeOutcome::Kind::transient_error;
     }
-    xlog::warn("[afstats] <<< {} classified as {}", out.error_detail, kind_to_str(out.kind));
+    if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+        xlog::warn("[afstats] <<< {} classified as {}", out.error_detail, kind_to_str(out.kind));
+    }
     return out;
 }
 
 void maybe_send_pssk()
 {
     if (g_state.status != Status::done) {
-        xlog::warn("[afstats] holding PSSK delivery: exchange status is {}", status_to_str(g_state.status));
+        if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+            xlog::warn("[afstats] holding PSSK delivery: exchange status is {}",
+                       status_to_str(g_state.status));
+        }
         return;
     }
     if (!g_state.in_game) {
-        xlog::warn("[afstats] holding PSSK delivery: not in the game yet");
+        if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+            xlog::warn("[afstats] holding PSSK delivery: not in the game yet");
+        }
         return;
     }
     if (g_state.pssk_sent) {
-        xlog::warn("[afstats] holding PSSK delivery: already sent for this join");
+        if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+            xlog::warn("[afstats] holding PSSK delivery: already sent for this join");
+        }
         return;
     }
-    // VERIFICATION PHASE ONLY: logs the session key verbatim, by explicit request.
-    xlog::warn("[afstats] delivering PSSK {} to server", g_state.pssk);
+    if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+        // VERIFICATION PHASE ONLY: logs the session key verbatim, by explicit request.
+        xlog::warn("[afstats] delivering PSSK {} to server", g_state.pssk);
+    }
     af_send_stats_pssk(g_state.pssk);
     g_state.pssk_sent = true;
-    xlog::warn("[afstats] PSSK sent (join_id={})", g_state.join_id);
+    if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+        xlog::warn("[afstats] PSSK sent (join_id={})", g_state.join_id);
+    }
 }
 
 void on_exchange_finished(uint32_t join_id, ExchangeOutcome outcome)
 {
     if (join_id != g_state.join_id) {
-        xlog::warn("[afstats] dropping stale exchange result (started for join_id={}, current join_id={})",
-                   join_id, g_state.join_id);
+        if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+            xlog::warn(
+                "[afstats] dropping stale exchange result (started for join_id={}, current join_id={})",
+                join_id, g_state.join_id);
+        }
         return; // the join this was started for is gone
     }
 
-    xlog::warn("[afstats] exchange finished for join_id={} with outcome {}", join_id,
-               kind_to_str(outcome.kind));
+    if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+        xlog::warn("[afstats] exchange finished for join_id={} with outcome {}", join_id,
+                   kind_to_str(outcome.kind));
+    }
 
     if (outcome.kind == ExchangeOutcome::Kind::mint_rate_limited) {
         g_mint_backoff_until = std::chrono::steady_clock::now() + k_mint_backoff;
@@ -305,10 +340,14 @@ void on_exchange_finished(uint32_t join_id, ExchangeOutcome outcome)
     if (outcome.psk != g_game_config.afstats_psk.value()) {
         g_game_config.afstats_psk = outcome.psk;
         g_game_config.save();
-        xlog::warn("[afstats] new PSK persisted to config");
+        if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+            xlog::warn("[afstats] new PSK persisted to config");
+        }
     }
     else {
-        xlog::warn("[afstats] PSK unchanged, nothing written to config");
+        if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+            xlog::warn("[afstats] PSK unchanged, nothing written to config");
+        }
     }
 
     g_state.status = Status::done;
@@ -316,12 +355,14 @@ void on_exchange_finished(uint32_t join_id, ExchangeOutcome outcome)
     g_state.user_id = outcome.user_id;
     g_state.user_name = std::move(outcome.user_name);
 
-    // VERIFICATION PHASE ONLY: logs the session key verbatim, by explicit request.
-    xlog::warn("[afstats] obtained PSSK {}", g_state.pssk);
-    xlog::warn("[afstats] session ready (psk_origin={}, fflink_status={}, user_id={}, user_name={})",
-               outcome.psk_origin.empty() ? "<absent>" : outcome.psk_origin,
-               outcome.fflink_status.empty() ? "<absent>" : outcome.fflink_status, g_state.user_id,
-               g_state.user_name.empty() ? "anonymous" : g_state.user_name);
+    if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+        // VERIFICATION PHASE ONLY: logs the session key verbatim, by explicit request.
+        xlog::warn("[afstats] obtained PSSK {}", g_state.pssk);
+        xlog::warn("[afstats] session ready (psk_origin={}, fflink_status={}, user_id={}, user_name={})",
+                   outcome.psk_origin.empty() ? "<absent>" : outcome.psk_origin,
+                   outcome.fflink_status.empty() ? "<absent>" : outcome.fflink_status, g_state.user_id,
+                   g_state.user_name.empty() ? "anonymous" : g_state.user_name);
+    }
 
     if (outcome.fflink_status == "unknown" && !g_stale_link_notice_shown) {
         g_stale_link_notice_shown = true;
@@ -339,12 +380,17 @@ void exchange_worker_impl(uint32_t join_id, const std::string& psk, const std::s
     for (int attempt = 0;; ++attempt) {
         const uint32_t active = g_active_join_id.load(std::memory_order_acquire);
         if (active != join_id) {
-            xlog::warn("[afstats] worker aborting: join_id={} is stale (active join_id={})", join_id,
-                       active);
+            if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+                xlog::warn("[afstats] worker aborting: join_id={} is stale (active join_id={})", join_id,
+                           active);
+            }
             return;
         }
 
-        xlog::warn("[afstats] exchange attempt {}/{} for join_id={}", attempt + 1, max_attempts, join_id);
+        if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+            xlog::warn("[afstats] exchange attempt {}/{} for join_id={}", attempt + 1, max_attempts,
+                       join_id);
+        }
 
         // Always the same PSK: retrying with null would abandon the player's key.
         ExchangeOutcome outcome = do_one_exchange(psk, fflink_token);
@@ -352,8 +398,10 @@ void exchange_worker_impl(uint32_t join_id, const std::string& psk, const std::s
         const bool can_retry = outcome.kind == ExchangeOutcome::Kind::transient_error
             && attempt < static_cast<int>(std::size(k_retry_delays_s));
         if (!can_retry) {
-            xlog::warn("[afstats] no further attempts ({}), handing result to the main thread",
-                       kind_to_str(outcome.kind));
+            if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+                xlog::warn("[afstats] no further attempts ({}), handing result to the main thread",
+                           kind_to_str(outcome.kind));
+            }
             enqueue_main_thread_task([join_id, outcome = std::move(outcome)]() mutable {
                 on_exchange_finished(join_id, std::move(outcome));
             });
@@ -361,8 +409,10 @@ void exchange_worker_impl(uint32_t join_id, const std::string& psk, const std::s
         }
 
         const int delay_s = k_retry_delays_s[attempt];
-        xlog::warn("[afstats] attempt {} failed ({}); retrying in {}s", attempt + 1, outcome.error_detail,
-                   delay_s);
+        if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+            xlog::warn("[afstats] attempt {} failed ({}); retrying in {}s", attempt + 1,
+                       outcome.error_detail, delay_s);
+        }
         std::this_thread::sleep_for(std::chrono::seconds(delay_s));
     }
 }
@@ -384,11 +434,15 @@ void exchange_worker(uint32_t join_id, std::string psk, std::string fflink_token
 void maybe_start_exchange()
 {
     if (g_state.exchange_started) {
-        xlog::warn("[afstats] skipping exchange: already started for join_id={}", g_state.join_id);
+        if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+            xlog::warn("[afstats] skipping exchange: already started for join_id={}", g_state.join_id);
+        }
         return; // join_req resends and the join_accept trigger both land here
     }
     if (client_bot_launch_enabled()) {
-        xlog::warn("[afstats] skipping exchange: this client is a launch bot");
+        if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+            xlog::warn("[afstats] skipping exchange: this client is a launch bot");
+        }
         return; // client bots must never mint PSKs
     }
 
@@ -400,19 +454,23 @@ void maybe_start_exchange()
     // The mint limit only applies to new keys, so a client holding one is never blocked.
     const auto now = std::chrono::steady_clock::now();
     if (psk.empty() && now < g_mint_backoff_until) {
-        const auto remaining_s =
-            std::chrono::duration_cast<std::chrono::seconds>(g_mint_backoff_until - now).count();
-        xlog::warn("[afstats] skipping exchange: mint backoff active for another {}s and no stored PSK",
-                   remaining_s);
+        if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+            const auto remaining_s =
+                std::chrono::duration_cast<std::chrono::seconds>(g_mint_backoff_until - now).count();
+            xlog::warn("[afstats] skipping exchange: mint backoff active for another {}s and no stored PSK",
+                       remaining_s);
+        }
         return;
     }
 
     g_state.exchange_started = true;
     g_state.status = Status::in_flight;
 
-    const bool have_token = !g_game_config.fflink_token.value().empty();
-    xlog::warn("[afstats] starting exchange (join_id={}, stored PSK: {}, fflink token: {})",
-               g_state.join_id, psk.empty() ? "no" : "yes", have_token ? "yes" : "no");
+    if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+        const bool have_token = !g_game_config.fflink_token.value().empty();
+        xlog::warn("[afstats] starting exchange (join_id={}, stored PSK: {}, fflink token: {})",
+                   g_state.join_id, psk.empty() ? "no" : "yes", have_token ? "yes" : "no");
+    }
 
     try {
         std::thread(exchange_worker, g_state.join_id, std::move(psk),
@@ -442,31 +500,38 @@ ConsoleCommand2 afstats_status_cmd{
 
 } // namespace
 
-void afstats_on_join_req(const rf::NetAddr& addr, bool stats_enabled)
+void afstats_client_on_join_req(const rf::NetAddr& addr, bool stats_enabled)
 {
-    xlog::warn("[afstats] join_req to {} (stats_enabled={})", addr, stats_enabled ? "yes" : "no");
+    xlog::debug("[afstats] join_req to {} (stats_enabled={})", addr, stats_enabled ? "yes" : "no");
 
     // The stock cancel path leaves multiplayer without a multi_stop, so a join the
     // player abandoned is only cleared here, when the next one starts elsewhere.
     if (g_state.target && *g_state.target != addr) {
-        xlog::warn("[afstats] target changed from {} to {}; dropping the abandoned join's state",
-                   *g_state.target, addr);
-        afstats_reset();
+        if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+            xlog::warn("[afstats] target changed from {} to {}; dropping the abandoned join's state",
+                       *g_state.target, addr);
+        }
+        afstats_client_reset();
     }
     g_state.target = addr;
 
     if (!stats_enabled) {
-        xlog::warn("[afstats] browser entry says this server is not stats-enabled; no exchange from join_req");
+        if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+            xlog::warn(
+                "[afstats] browser entry says this server is not stats-enabled; no exchange from join_req");
+        }
         return;
     }
     g_state.stats_enabled = true;
     maybe_start_exchange();
 }
 
-void afstats_on_join_accept(bool stats_enabled)
+void afstats_client_on_join_accept(bool stats_enabled)
 {
-    xlog::warn("[afstats] join_accept parsed (stats_enabled={}, exchange already started={})",
-               stats_enabled ? "yes" : "no", g_state.exchange_started ? "yes" : "no");
+    if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+        xlog::warn("[afstats] join_accept parsed (stats_enabled={}, exchange already started={})",
+                   stats_enabled ? "yes" : "no", g_state.exchange_started ? "yes" : "no");
+    }
 
     if (!stats_enabled) {
         return;
@@ -475,24 +540,40 @@ void afstats_on_join_accept(bool stats_enabled)
     maybe_start_exchange();
 }
 
-void afstats_on_entered_game()
+void afstats_client_on_entered_game()
 {
     g_state.in_game = true;
-    xlog::warn("[afstats] entered the game (join_id={}, exchange status={})", g_state.join_id,
-               status_to_str(g_state.status));
+    if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+        xlog::warn("[afstats] entered the game (join_id={}, exchange status={})", g_state.join_id,
+                   status_to_str(g_state.status));
+    }
     maybe_send_pssk();
 }
 
-void afstats_reset()
+// Overwrites a key's bytes before the string is cleared/freed, so a live PSSK does
+// not linger in the freed allocation. volatile keeps the writes from being elided.
+void secure_wipe(std::string& s)
+{
+    volatile char* p = const_cast<volatile char*>(s.data());
+    for (size_t i = 0; i < s.size(); ++i) {
+        p[i] = '\0';
+    }
+    s.clear();
+}
+
+void afstats_client_reset()
 {
     const uint32_t next_join_id = g_state.join_id + 1;
-    xlog::warn("[afstats] resetting join state (join_id {} -> {})", g_state.join_id, next_join_id);
+    if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+        xlog::warn("[afstats] resetting join state (join_id {} -> {})", g_state.join_id, next_join_id);
+    }
+    secure_wipe(g_state.pssk); // scrub the PSSK before the state is dropped
     g_state = JoinState{};
     g_state.join_id = next_join_id;
     g_active_join_id.store(next_join_id, std::memory_order_release);
 }
 
-void afstats_do_patch()
+void afstats_client_do_patch()
 {
     afstats_status_cmd.register_cmd();
 }

--- a/game_patch/fflink/afstats_client.h
+++ b/game_patch/fflink/afstats_client.h
@@ -12,14 +12,17 @@ namespace rf
 
 namespace fflink {
 
-// A join_req is going out to `addr`. Anything tracked for a different server is
-// dropped first, so a join the player cancelled can never hand its key to the next
-// one. `stats_enabled` comes from the target's server browser entry and starts the
-// PSK -> PSSK exchange; join_req resends do not start it twice.
+// A join_req is going out to `addr`. State from an abandoned attempt is already gone
+// by this point (the attempt-start hook clears it), so a join the player cancelled can
+// never hand its key to the next one. `stats_enabled` comes from the target's server
+// browser entry and starts the PSK -> PSSK exchange; join_req resends do not start it
+// twice.
 void afstats_client_on_join_req(const rf::NetAddr& addr, bool stats_enabled);
 
-// The join_accept has been parsed. This is where a direct connect - which has no
-// browser entry when its join_req goes out - learns the server is stats-enabled.
+// The server accepted the join and said whether it reports stats: true from the AF
+// join_accept extension, false when there is no extension to read. This is where a
+// direct connect - which has no browser entry when its join_req goes out - learns the
+// server is stats-enabled, and where a stale browser entry claiming so is corrected.
 void afstats_client_on_join_accept(bool stats_enabled);
 
 // The client has entered the game and the reliable channel is up, so a PSSK that is

--- a/game_patch/fflink/afstats_client.h
+++ b/game_patch/fflink/afstats_client.h
@@ -1,5 +1,10 @@
 #pragma once
 
+// Set to false for release builds. Gates the stats verification logging across
+// the afstats client, the server-side event sender, and the packet handlers.
+// Note that PSSKs do appear in logs when this is true.
+#define AFSTATS_VERIFICATION_LOGGING false
+
 namespace rf
 {
     struct NetAddr;
@@ -11,21 +16,21 @@ namespace fflink {
 // dropped first, so a join the player cancelled can never hand its key to the next
 // one. `stats_enabled` comes from the target's server browser entry and starts the
 // PSK -> PSSK exchange; join_req resends do not start it twice.
-void afstats_on_join_req(const rf::NetAddr& addr, bool stats_enabled);
+void afstats_client_on_join_req(const rf::NetAddr& addr, bool stats_enabled);
 
 // The join_accept has been parsed. This is where a direct connect - which has no
 // browser entry when its join_req goes out - learns the server is stats-enabled.
-void afstats_on_join_accept(bool stats_enabled);
+void afstats_client_on_join_accept(bool stats_enabled);
 
 // The client has entered the game and the reliable channel is up, so a PSSK that is
 // already in hand can be delivered now.
-void afstats_on_entered_game();
+void afstats_client_on_entered_game();
 
 // Leaving multiplayer: invalidate anything still in flight and drop the PSSK.
-void afstats_reset();
+void afstats_client_reset();
 
 // Register console commands and any other one-time setup for the client stats
 // subsystem. Called from fflink::do_patch().
-void afstats_do_patch();
+void afstats_client_do_patch();
 
 } // namespace fflink

--- a/game_patch/fflink/afstats_client.h
+++ b/game_patch/fflink/afstats_client.h
@@ -1,0 +1,31 @@
+#pragma once
+
+namespace rf
+{
+    struct NetAddr;
+}
+
+namespace fflink {
+
+// A join_req is going out to `addr`. Anything tracked for a different server is
+// dropped first, so a join the player cancelled can never hand its key to the next
+// one. `stats_enabled` comes from the target's server browser entry and starts the
+// PSK -> PSSK exchange; join_req resends do not start it twice.
+void afstats_on_join_req(const rf::NetAddr& addr, bool stats_enabled);
+
+// The join_accept has been parsed. This is where a direct connect - which has no
+// browser entry when its join_req goes out - learns the server is stats-enabled.
+void afstats_on_join_accept(bool stats_enabled);
+
+// The client has entered the game and the reliable channel is up, so a PSSK that is
+// already in hand can be delivered now.
+void afstats_on_entered_game();
+
+// Leaving multiplayer: invalidate anything still in flight and drop the PSSK.
+void afstats_reset();
+
+// Register console commands and any other one-time setup for the client stats
+// subsystem. Called from fflink::do_patch().
+void afstats_do_patch();
+
+} // namespace fflink

--- a/game_patch/fflink/afstats_events.cpp
+++ b/game_patch/fflink/afstats_events.cpp
@@ -70,6 +70,14 @@ constexpr size_t k_max_response_bytes = 256 * 1024;
 
 constexpr auto k_pulse_interval = std::chrono::seconds(5);
 constexpr auto k_rate_limit_backoff = std::chrono::seconds(30);
+
+// Minimum spacing between successive event POSTs, enforced even while draining a backlog
+// at ack rate. Without it, a client packet flood grows the queue fast enough that every
+// ack immediately re-arms the pulse, turning post->ack->post into a POST (and TLS
+// handshake) storm at RTT frequency. With a 500 ms floor and 500 events per batch even a
+// full 20k backlog still drains in tens of seconds, but the outbound rate stays capped
+// well below RTT. A round_end flush is not client-floodable and deliberately bypasses this.
+constexpr auto k_min_post_interval = std::chrono::milliseconds(500);
 constexpr int64_t k_ping_sample_interval_ms = 10000;
 
 constexpr unsigned long k_connect_timeout_ms = 3000;
@@ -547,6 +555,9 @@ PendingGap g_pending_gap;
 
 bool g_send_in_flight = false;
 std::chrono::steady_clock::time_point g_next_pulse{};
+// When the last event POST was handed to the worker. Floors how soon the ack-driven
+// fast-drain may re-arm the pulse (see k_min_post_interval).
+std::chrono::steady_clock::time_point g_last_post_at{};
 std::chrono::steady_clock::duration g_pulse_interval = k_pulse_interval;
 bool g_paused_401 = false;
 std::string g_paused_gssk;
@@ -1585,6 +1596,7 @@ void dispatch(PendingBatch& batch, const std::string& gssk)
     }
     g_worker_cv.notify_one();
     g_send_in_flight = true;
+    g_last_post_at = std::chrono::steady_clock::now();
 }
 
 void build_batch_from_queue()
@@ -1701,9 +1713,11 @@ void on_send_result(SendResult result)
         g_pending.pop_front();
         ++g_batches_acked;
         g_pulse_interval = k_pulse_interval;
-        // Drain a backlog at ack rate rather than one batch per pulse.
+        // Drain a backlog faster than one batch per pulse, but never post more often than
+        // the floor: floor the re-arm to k_min_post_interval after the last POST so a
+        // client flood can't reflect into a POST/handshake storm at RTT frequency.
         if (!g_pending.empty() || g_queue.size() >= k_max_events_per_batch) {
-            g_next_pulse = std::chrono::steady_clock::now();
+            g_next_pulse = std::max(std::chrono::steady_clock::now(), g_last_post_at + k_min_post_interval);
         }
         return;
     }
@@ -1794,6 +1808,13 @@ void reset_module_state()
     g_session_started = false;
     g_session_id.clear();
     g_reannouncing = false;
+
+    // Diagnostics describe one session's stream, so they go with it: otherwise the
+    // status console reports the previous session's totals against a fresh session id.
+    g_last_response = "none yet";
+    g_events_emitted = 0;
+    g_events_dropped = 0;
+    g_batches_acked = 0;
 
     // Per-player identity belongs to the session that minted it. Leaving keys behind
     // would strand everyone still connected: on_player_join refuses to mint over an
@@ -2248,14 +2269,37 @@ void on_player_leave(rf::Player* player)
     player->afstats_key.clear();
 }
 
-void on_player_rename(rf::Player* player, const char* name)
+void on_player_rename(rf::Player* player, const char* name, std::string_view prev_name)
 {
     if (!player || !ensure_session() || player->afstats_key.empty()) {
         return;
     }
+    const std::string new_name = sanitize_string(name ? name : "", k_max_name_len);
+
+    // Only the edge matters. A client can resend its current name, and the roster
+    // already carries whatever the player holds, so an unchanged name is not a stream
+    // event. Compare the sanitized forms so a change confined to bytes the wire never
+    // shows is also a no-op. This intentionally does not touch the rate floor below.
+    if (new_name == sanitize_string(prev_name, k_max_name_len)) {
+        return;
+    }
+
+    // Floor the emission rate so a rename flood cannot become an event flood. The stock
+    // handler already applied and rebroadcast the name; only the stats event is gated,
+    // and the next roster still reports the live name regardless. uptime_ms() resets when
+    // a new session starts, so a stored value ahead of `now` is treated as out of the
+    // window and allowed through rather than wrongly suppressed.
+    const int64_t now = static_cast<int64_t>(uptime_ms());
+    constexpr int64_t k_rename_floor_ms = 1000;
+    if (player->last_rename_ms && now >= *player->last_rename_ms
+        && now - *player->last_rename_ms < k_rename_floor_ms) {
+        return;
+    }
+    player->last_rename_ms = now;
+
     EvPlayerRename ev;
     ev.player = player->afstats_key;
-    ev.name = sanitize_string(name ? name : "", k_max_name_len);
+    ev.name = new_name;
     if constexpr (AFSTATS_VERIFICATION_LOGGING) {
         // Redacted: the key is incidental here, the name change is the subject.
         xlog::warn("[afstats-ev] rename {} -> '{}'", key_suffix(ev.player), ev.name);
@@ -2572,6 +2616,17 @@ void on_match_start(int team_size, const std::vector<rf::Player*>& participants)
     if (!ensure_session()) {
         return;
     }
+    // A prior match that never saw its end still holds the shared latch: an external
+    // level change or admin map mid-match closes the round path but not the match path,
+    // leaving g_match_open set. Close it as canceled before opening the new one so the
+    // stream never carries two match_start without an end between them. This is done here
+    // rather than in on_round_start on purpose: a ready-up match spans multiple rounds
+    // (start_match restarts the level, firing on_round_start while the match is live), so
+    // closing on round_start would wrongly cancel a live ready-up match. on_match_start
+    // fires once per match for both producers, so it is the safe single close point.
+    if (g_match_open) {
+        on_match_end(MatchResult::canceled, team_none, nullptr);
+    }
     EvMatchStart ev;
     ev.team_size = static_cast<uint32_t>(std::max(team_size, 0));
     for (rf::Player* player : participants) {
@@ -2752,14 +2807,40 @@ void do_frame_impl()
         return;
     }
 
+    const auto now = std::chrono::steady_clock::now();
+    const bool pulse_due = now >= g_next_pulse;
+
+    // A revoked or malformed GSK never yields a GSSK, so stop the stream cleanly
+    // instead of caching forever. Checked here rather than only on the paused-401
+    // path below because a session starts on the first event, which can land while
+    // the key exchange is still pending: if that exchange then hard-rejects, nothing
+    // is ever posted, no 401 ever comes back, and the pause path is unreachable while
+    // the queue and the per-frame sampling run on. A genuinely new GSSK later restarts
+    // a fresh session through ensure_session().
+    // Only on the pulse: snapshot_state() is a mutex plus a copy.
+    if (pulse_due) {
+        const auto status = fflink::snapshot_state().status;
+        if (status == fflink::SessionStatus::rejected_by_server
+            || status == fflink::SessionStatus::bad_gsk_format) {
+            // The GSSK is contractually rejected (a 4xx, or a malformed configured GSK),
+            // so nothing more can be transmitted: an open round, an open match, and the
+            // whole queue terminate silently by necessity. Unlike the shutdown flush path
+            // above, no closing round_end / match_end is emitted, because there is no
+            // session left to carry it — this is the spec's orphaned-session behavior, not
+            // a dropped event we could recover. reset_module_state() clears g_match_open
+            // (and g_round_open) so a genuinely new GSSK later starts a clean session.
+            xlog::warn("[afstats-ev] session key permanently rejected; stopping the event stream");
+            reset_module_state();
+            return;
+        }
+    }
+
     for (rf::Player& player : SinglyLinkedList{rf::player_list}) {
         if (!player.is_browser && !player.afstats_key.empty()) {
             sample_player_state(&player);
         }
     }
 
-    const auto now = std::chrono::steady_clock::now();
-    const bool pulse_due = now >= g_next_pulse;
     if (pulse_due) {
         g_next_pulse = now + g_pulse_interval;
         // Move the damage/accuracy accumulators into the live queue every pulse,
@@ -2770,18 +2851,9 @@ void do_frame_impl()
 
     if (g_paused_401) {
         // Only re-check the session key on the pulse, not every frame, so a long
-        // pause is not a per-frame get_gssk() mutex + string copy.
+        // pause is not a per-frame get_gssk() mutex + string copy. A permanent
+        // rejection has already been handled above.
         if (!pulse_due) {
-            return;
-        }
-        // A revoked or malformed GSK never yields a new GSSK, so stop the stream
-        // cleanly instead of caching forever. A genuinely new GSSK later restarts a
-        // fresh session through ensure_session().
-        const auto status = fflink::snapshot_state().status;
-        if (status == fflink::SessionStatus::rejected_by_server
-            || status == fflink::SessionStatus::bad_gsk_format) {
-            xlog::warn("[afstats-ev] session key permanently rejected; stopping the event stream");
-            reset_module_state();
             return;
         }
         const std::string gssk = fflink::get_gssk();
@@ -2813,6 +2885,12 @@ void on_shutdown_impl()
     if (g_round_open) {
         note_round_end_type(RoundEndType::server_shutdown);
         emit_round_end(RoundEndType::server_shutdown);
+    }
+
+    // The shutdown flush below can still transmit, so close an open match rather than
+    // dropping it silently. Its match_end is queued here and goes out with the flush.
+    if (g_match_open) {
+        on_match_end(MatchResult::canceled, team_none, nullptr);
     }
 
     // Tell the worker to stop; the final attempt runs inline so its timeouts, not a

--- a/game_patch/fflink/afstats_events.cpp
+++ b/game_patch/fflink/afstats_events.cpp
@@ -328,6 +328,22 @@ struct EvMatchEnd
     std::string winner_player; // empty = null
 };
 
+struct EvSubroundStart
+{
+    uint32_t index = 0;
+    uint8_t match_state = 0;
+    std::vector<std::string> participants;
+};
+
+struct EvSubroundEnd
+{
+    uint32_t index = 0;
+    uint8_t result = 0;
+    uint8_t winner_team = team_none;
+    std::string winner_player; // empty = null
+    uint64_t duration_ms = 0;
+};
+
 struct EvVoteCalled
 {
     uint8_t vote_type = 0;
@@ -381,8 +397,8 @@ using EventPayload =
     std::variant<EvServerHello, EvGap, EvPlayerJoin, EvPlayerRemediate, EvPlayerRename, EvPlayerLeave,
                  EvRoundStart, EvRoundEnd, EvKill, EvSpawn, EvDamage, EvAccuracy, EvStatus,
                  EvItemPickup, EvFlagEvent, EvPointEvent, EvBagmanEvent, EvGgLevelup, EvMatchStart,
-                 EvMatchEnd, EvVoteCalled, EvVoteEnded, EvGeomod, EvClutterDestroyed,
-                 EvDetailBrushDestroyed>;
+                 EvMatchEnd, EvSubroundStart, EvSubroundEnd, EvVoteCalled, EvVoteEnded, EvGeomod,
+                 EvClutterDestroyed, EvDetailBrushDestroyed>;
 
 struct Event
 {
@@ -422,6 +438,11 @@ bool g_any_round_started = false;
 // A cancel and the limbo that follows it both reach the match-end path; this makes
 // the second one a no-op.
 bool g_match_open = false;
+// Subround (Pit duel / Wipeout round) latch. index is 1-based and restarts each game;
+// the open flag makes subround_start/subround_end strictly alternate.
+uint32_t g_subround_index = 0;
+bool g_subround_open = false;
+int64_t g_subround_start_ms = 0;
 std::optional<RoundEndType> g_pending_end_type;
 
 std::deque<Event> g_queue;
@@ -1253,6 +1274,21 @@ nlohmann::json event_to_json(const Event& e)
                 j["winner_player"] =
                     p.winner_player.empty() ? nlohmann::json(nullptr) : nlohmann::json(p.winner_player);
             }
+            else if constexpr (std::is_same_v<T, EvSubroundStart>) {
+                j["type"] = "subround_start";
+                j["index"] = p.index;
+                j["match_state"] = p.match_state;
+                j["participants"] = p.participants;
+            }
+            else if constexpr (std::is_same_v<T, EvSubroundEnd>) {
+                j["type"] = "subround_end";
+                j["index"] = p.index;
+                j["result"] = p.result;
+                j["winner_team"] = p.winner_team;
+                j["winner_player"] =
+                    p.winner_player.empty() ? nlohmann::json(nullptr) : nlohmann::json(p.winner_player);
+                j["duration_ms"] = p.duration_ms;
+            }
             else if constexpr (std::is_same_v<T, EvVoteCalled>) {
                 j["type"] = "vote_called";
                 j["vote_type"] = p.vote_type;
@@ -1800,6 +1836,8 @@ void reset_module_state()
     g_round_open = false;
     g_any_round_started = false;
     g_match_open = false;
+    g_subround_index = 0;
+    g_subround_open = false;
     g_pending_end_type.reset();
     g_send_in_flight = false;
     g_paused_401 = false;
@@ -2074,6 +2112,12 @@ void emit_round_end(RoundEndType end_type)
     // Aggregates belong to the round that is closing, not the one that follows.
     flush_accumulators();
 
+    // A subround still open when the game ends emits its subround_end first, so the
+    // stream closes the nested unit before the round that contained it.
+    if (g_subround_open) {
+        on_subround_end(SubroundResult::canceled, team_none, nullptr);
+    }
+
     const auto game_type = rf::multi_get_game_type();
 
     EvRoundEnd ev;
@@ -2323,6 +2367,10 @@ void on_round_start()
     g_any_round_started = true;
     g_round_open = true;
     g_pending_end_type.reset();
+    // A new game restarts subround numbering. Any subround still open was closed by the
+    // emit_round_end above; drop the latch regardless so the count starts clean.
+    g_subround_index = 0;
+    g_subround_open = false;
 
     for (rf::Player& player : SinglyLinkedList{rf::player_list}) {
         if (!player.is_browser) {
@@ -2616,14 +2664,14 @@ void on_match_start(int team_size, const std::vector<rf::Player*>& participants)
     if (!ensure_session()) {
         return;
     }
-    // A prior match that never saw its end still holds the shared latch: an external
-    // level change or admin map mid-match closes the round path but not the match path,
-    // leaving g_match_open set. Close it as canceled before opening the new one so the
-    // stream never carries two match_start without an end between them. This is done here
-    // rather than in on_round_start on purpose: a ready-up match spans multiple rounds
-    // (start_match restarts the level, firing on_round_start while the match is live), so
-    // closing on round_start would wrongly cancel a live ready-up match. on_match_start
-    // fires once per match for both producers, so it is the safe single close point.
+    // A prior match that never saw its end still holds the latch: an external level
+    // change or admin map mid-match closes the round path but not the match path, leaving
+    // g_match_open set. Close it as canceled before opening the new one so the stream
+    // never carries two match_start without an end between them. This is done here rather
+    // than in on_round_start on purpose: a ready-up match (now the sole match_* producer)
+    // spans multiple rounds -- start_match restarts the level, firing on_round_start while
+    // the match is live -- so closing on round_start would wrongly cancel a live match.
+    // on_match_start fires once per match, so it is the safe single close point.
     if (g_match_open) {
         on_match_end(MatchResult::canceled, team_none, nullptr);
     }
@@ -2670,6 +2718,60 @@ void on_match_end_derived(MatchResult result)
     rf::Player* winner_player = nullptr;
     derive_winner(winner_team, winner_player);
     on_match_end(result, winner_team, winner_player);
+}
+
+void on_subround_start(const std::vector<rf::Player*>& participants)
+{
+    if (!ensure_session()) {
+        return;
+    }
+    // A prior subround that never saw its end still holds the latch (a level change
+    // between subrounds, an abandoned pairing). Close it as canceled before opening the
+    // new one so the stream never carries two subround_start without an end between them.
+    if (g_subround_open) {
+        on_subround_end(SubroundResult::canceled, team_none, nullptr);
+    }
+    ++g_subround_index;
+    g_subround_start_ms = static_cast<int64_t>(uptime_ms());
+    g_subround_open = true;
+
+    EvSubroundStart ev;
+    ev.index = g_subround_index;
+    // Reuse the same source round_start stamps, so a subround's state matches its game.
+    ev.match_state = af_match_state_for_stats();
+    for (rf::Player* player : participants) {
+        if (player && !player->afstats_key.empty()) {
+            ev.participants.push_back(player->afstats_key);
+        }
+    }
+    if (g_trace) {
+        xlog::warn("[afstats-ev] subround_start {} with {} participants", ev.index,
+                   ev.participants.size());
+    }
+    push_event(std::move(ev));
+}
+
+void on_subround_end(SubroundResult result, uint8_t winner_team, rf::Player* winner_player)
+{
+    if (!ensure_session() || !g_subround_open) {
+        return; // no open subround: an end with no start (abandoned pairing) stays silent
+    }
+    g_subround_open = false;
+
+    EvSubroundEnd ev;
+    ev.index = g_subround_index;
+    ev.result = static_cast<uint8_t>(result);
+    ev.winner_team = winner_team;
+    if (winner_player && !winner_player->afstats_key.empty()) {
+        ev.winner_player = winner_player->afstats_key;
+    }
+    const int64_t now = static_cast<int64_t>(uptime_ms());
+    ev.duration_ms = static_cast<uint64_t>(std::max<int64_t>(0, now - g_subround_start_ms));
+    if (g_trace) {
+        xlog::warn("[afstats-ev] subround_end {} result {} winner_team {}", ev.index, ev.result,
+                   ev.winner_team);
+    }
+    push_event(std::move(ev));
 }
 
 void on_vote_called(uint8_t vote_type, rf::Player* initiator, rf::Player* target, const char* detail)
@@ -2885,6 +2987,12 @@ void on_shutdown_impl()
     if (g_round_open) {
         note_round_end_type(RoundEndType::server_shutdown);
         emit_round_end(RoundEndType::server_shutdown);
+    }
+
+    // The shutdown flush below can still transmit, so close an open subround rather than
+    // dropping it silently (emit_round_end already closed it when a round was open).
+    if (g_subround_open) {
+        on_subround_end(SubroundResult::canceled, team_none, nullptr);
     }
 
     // The shutdown flush below can still transmit, so close an open match rather than

--- a/game_patch/fflink/afstats_events.cpp
+++ b/game_patch/fflink/afstats_events.cpp
@@ -1,0 +1,2918 @@
+#include "afstats_events.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdlib>
+#include <ctime>
+#include <deque>
+#include <format>
+#include <iterator>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <random>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include <json.hpp>
+#include <xlog/xlog.h>
+
+#include <common/HttpRequest.h>
+#include <common/utils/list-utils.h>
+#include <common/utils/os-utils.h>
+#include <common/version/version.h>
+
+#include "../misc/player.h"
+#include "../multi/alpine_packets.h"
+#include "../multi/bagman.h"
+#include "../multi/gametype.h"
+#include "../multi/multi.h"
+#include "../multi/salvage.h"
+#include "../multi/server_internal.h"
+#include "../multi/wipeout.h"
+#include "../os/console.h"
+#include "../rf/clutter.h"
+#include "../rf/level.h"
+#include "../rf/multi.h"
+#include "../rf/os/os.h"
+#include "../rf/player/player.h"
+#include "afstats_client.h" // AFSTATS_VERIFICATION_LOGGING
+#include "fflink_session.h"
+#include "fflink_utils.h"
+
+namespace afstats {
+
+namespace {
+
+constexpr const char* k_events_url = "https://link.factionfiles.com/afstats/v1/events.php";
+constexpr const char* k_user_agent = AF_USER_AGENT_SUFFIX("AFStatsEvents");
+
+constexpr int k_envelope_version = 1;
+
+// Hard caps FactionFiles enforces. Staying under them client-side means
+// the 413 split path only ever fires on a contract mismatch.
+constexpr size_t k_max_events_per_batch = 500;
+constexpr size_t k_max_queued_events = 20000;
+
+// The ack body is a few dozen bytes; cap the read so a broken or hostile endpoint
+// can't stream unbounded data into worker memory.
+constexpr size_t k_max_response_bytes = 256 * 1024;
+
+constexpr auto k_pulse_interval = std::chrono::seconds(5);
+constexpr auto k_rate_limit_backoff = std::chrono::seconds(30);
+constexpr int64_t k_ping_sample_interval_ms = 10000;
+
+constexpr unsigned long k_connect_timeout_ms = 3000;
+constexpr unsigned long k_receive_timeout_ms = 5000;
+
+// The shutdown path gets its own short timeouts so one unreachable host cannot hold
+// the process open past the ~2s shutdown wall: a single unreachable attempt stays
+// under the deadline, and the flush breaks on the first failure.
+constexpr unsigned long k_shutdown_connect_timeout_ms = 500;
+constexpr unsigned long k_shutdown_receive_timeout_ms = 1000;
+
+constexpr size_t k_max_name_len = 32;
+constexpr size_t k_max_string_len = 64;
+
+// -------------------------------------------------------------------------
+// Event records. Gameplay hooks fill these in; JSON is only ever built when a
+// batch is serialized for transmission.
+// -------------------------------------------------------------------------
+
+struct Vec3
+{
+    float x = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+};
+
+// Never true, but dependent on T so it only fires when a std::visit branch is actually
+// instantiated. Backs the final-else static_assert that fails the build if an event
+// payload alternative is added without a serialization branch.
+template <typename>
+inline constexpr bool always_false_v = false;
+
+// Roster/player `flags` bitfield.
+constexpr uint8_t k_player_flag_bot = 1;
+constexpr uint8_t k_player_flag_spectating = 2;
+constexpr uint8_t k_player_flag_idle = 4;
+
+// `platform` registry.
+constexpr uint8_t k_platform_windows = 0;
+constexpr uint8_t k_platform_wine = 1;
+
+// `kind` registry for player_join.
+constexpr uint8_t k_join_kind_human = 0;
+constexpr uint8_t k_join_kind_bot = 1;
+
+// A roster entry plus the summary block round_end and player_leave
+// append to it. `has_summary` selects which of the two shapes is serialized.
+struct RosterEntry
+{
+    std::string player;
+    std::string name;
+    uint8_t team = team_none;
+    uint8_t flags = 0;
+    int handicap = 0;
+
+    bool has_summary = false;
+    int score = 0;
+    uint32_t kills = 0;
+    uint32_t deaths = 0;
+    uint32_t assists = 0;
+    uint32_t caps = 0;
+    uint32_t shots_fired = 0;
+    uint32_t shots_hit = 0;
+    float damage_dealt = 0.0f;
+    float damage_taken = 0.0f;
+    uint32_t highest_streak = 0;
+    int64_t time_played_ms = 0;
+    int64_t time_spectating_ms = 0;
+    int64_t time_idle_ms = 0;
+    int avg_ping = 0;
+};
+
+using SettingValue = std::variant<bool, int64_t, double, std::string>;
+
+struct MutatorRecord
+{
+    std::string name;
+    std::vector<std::pair<std::string, SettingValue>> settings;
+};
+
+struct EvServerHello
+{
+    std::string server_name;
+    uint16_t port = 0;
+    std::string af_version;
+    uint8_t platform = k_platform_windows;
+    uint8_t max_players = 0;
+};
+
+struct EvGap
+{
+    uint64_t dropped = 0;
+    uint64_t first_seq = 0;
+    uint64_t last_seq = 0;
+};
+
+struct EvPlayerJoin
+{
+    std::string upssk;
+    std::string name;
+    uint8_t kind = k_join_kind_human;
+    std::string client;
+};
+
+struct EvPlayerRemediate
+{
+    std::string upssk;
+    std::string pssk;
+};
+
+struct EvPlayerRename
+{
+    std::string player;
+    std::string name;
+};
+
+struct EvPlayerLeave
+{
+    uint8_t reason = 0;
+    RosterEntry stats;
+};
+
+struct EvRoundStart
+{
+    std::string tc_mod;
+    std::string level_file;
+    std::string level_name;
+    uint8_t gametype = 0;
+    uint32_t time_limit_s = 0;
+    int64_t win_condition = 0;
+    bool overtime_enabled = false;
+    uint32_t af_flags = 0;
+    uint8_t rf_flags = 0;
+    uint32_t gi_flags = 0;
+    uint8_t match_state = 0;
+    std::vector<MutatorRecord> mutators;
+    std::vector<std::pair<std::string, SettingValue>> gametype_settings;
+    std::vector<RosterEntry> roster;
+};
+
+struct EvRoundEnd
+{
+    uint8_t end_type = 0;
+    uint64_t duration_ms = 0;
+    bool overtime = false;
+    int red_score = 0;
+    int blue_score = 0;
+    std::vector<RosterEntry> players;
+};
+
+struct EvKill
+{
+    std::string victim;
+    std::string killer; // empty = world/environment death
+    int weapon = -1;      // negative = unknown, reported as null
+    uint8_t damage_type = 0;
+    uint8_t flags = 0; // af_kill_info_flags, verbatim
+    std::vector<std::string> assists;
+    Vec3 victim_pos;
+    bool has_killer_pos = false;
+    Vec3 killer_pos;
+};
+
+struct EvSpawn
+{
+    std::string player;
+    Vec3 pos;
+};
+
+struct EvDamage
+{
+    std::string attacker; // empty = environmental
+    std::string victim;
+    int weapon = -1;
+    uint8_t damage_type = 0;
+    float amount = 0.0f;
+    uint32_t hits = 0;
+};
+
+struct EvAccuracy
+{
+    std::string player;
+    int weapon = -1;
+    uint32_t fired = 0;
+    uint32_t hit = 0;
+    uint32_t hit_head = 0;
+};
+
+struct EvStatus
+{
+    std::string player;
+    uint8_t kind = 0;
+    bool has_value = false;
+    int value = 0;
+};
+
+struct EvItemPickup
+{
+    std::string player;
+    int item = -1;
+    Vec3 pos;
+    uint32_t respawn_ms = 0;
+};
+
+struct EvFlagEvent
+{
+    uint8_t kind = 0;
+    uint8_t team = team_none;
+    std::string player; // empty = null (timeout / reset)
+    Vec3 pos;
+};
+
+struct EvPointEvent
+{
+    uint8_t hill = 0;
+    uint8_t kind = 0;
+    uint8_t owner = team_none;
+    std::vector<std::string> players;
+    bool locked = false;
+};
+
+struct EvBagmanEvent
+{
+    uint8_t kind = 0;
+    std::string player; // empty = null
+    bool has_from = false;
+    uint8_t from = 0;
+    Vec3 pos;
+};
+
+struct EvGgLevelup
+{
+    std::string player;
+    uint32_t level = 0;
+    int weapon = -1;
+};
+
+struct EvMatchStart
+{
+    uint32_t team_size = 0;
+    std::vector<std::string> participants;
+};
+
+struct EvMatchEnd
+{
+    uint8_t result = 0;
+    uint8_t winner_team = team_none;
+    std::string winner_player; // empty = null
+};
+
+struct EvVoteCalled
+{
+    uint8_t vote_type = 0;
+    std::string initiator;
+    std::string target; // empty = null
+    std::string detail;
+};
+
+struct EvVoteEnded
+{
+    uint8_t vote_type = 0;
+    uint8_t result = 0;
+    uint32_t yes = 0;
+    uint32_t no = 0;
+    uint32_t eligible = 0;
+};
+
+struct EvGeomod
+{
+    Vec3 pos;
+    float scale = 0.0f;
+    bool rf2_style = false;
+    std::string player; // empty = null (unresolved shooter)
+    int weapon = -1;    // negative = null; paired with player (null when player is)
+};
+
+struct EvClutterDestroyed
+{
+    bool has_clutter_type = false;
+    uint32_t clutter_type = 0; // clutter.tbl info_index; absent for an alpine mesh
+    bool has_uid = false;
+    int uid = 0;
+    std::string player; // empty = null (world / environmental)
+    int weapon = -1;    // negative = null; paired with player
+    uint8_t damage_type = 0;
+    Vec3 pos;
+};
+
+struct EvDetailBrushDestroyed
+{
+    uint8_t material = 0; // rf::DetailMaterial registry
+    bool has_room_uid = false;
+    int room_uid = 0;
+    std::string player; // empty = null (world / environmental)
+    int weapon = -1;    // negative = null; paired with player
+    uint8_t damage_type = 0;
+    Vec3 pos;
+};
+
+using EventPayload =
+    std::variant<EvServerHello, EvGap, EvPlayerJoin, EvPlayerRemediate, EvPlayerRename, EvPlayerLeave,
+                 EvRoundStart, EvRoundEnd, EvKill, EvSpawn, EvDamage, EvAccuracy, EvStatus,
+                 EvItemPickup, EvFlagEvent, EvPointEvent, EvBagmanEvent, EvGgLevelup, EvMatchStart,
+                 EvMatchEnd, EvVoteCalled, EvVoteEnded, EvGeomod, EvClutterDestroyed,
+                 EvDetailBrushDestroyed>;
+
+struct Event
+{
+    uint64_t seq = 0;
+    uint64_t t = 0;
+    uint32_t round = 0;
+    EventPayload payload;
+};
+
+struct PendingBatch
+{
+    uint32_t batch = 0;
+    uint64_t first_seq = 0;
+    uint64_t last_seq = 0;
+    uint64_t frozen_at_ms = 0; // uptime when the events were drained out of the queue
+    int attempts = 0;
+    std::vector<Event> events;
+};
+
+// -------------------------------------------------------------------------
+// Module state. Everything below is main-thread-owned unless noted.
+// -------------------------------------------------------------------------
+
+bool g_session_started = false;
+// Re-entrancy guard for the post-hello identity re-announce.
+bool g_reannouncing = false;
+std::string g_session_id;
+// Bumped every time a session starts. A frozen batch carries the generation it was
+// built under; a completion from a previous session's worker is ignored instead of
+// being applied to the new session's state.
+uint32_t g_session_generation = 0;
+uint64_t g_next_seq = 1;
+uint32_t g_next_batch = 1;
+uint32_t g_round = 1;
+bool g_round_open = false;
+bool g_any_round_started = false;
+// A cancel and the limbo that follows it both reach the match-end path; this makes
+// the second one a no-op.
+bool g_match_open = false;
+std::optional<RoundEndType> g_pending_end_type;
+
+std::deque<Event> g_queue;
+std::deque<PendingBatch> g_pending;
+
+// Windowed aggregates. Per-hit volume would dominate the stream, so
+// these accumulate beside the queue and only materialize at batch build time.
+using DamageKey = std::tuple<std::string, std::string, int, uint8_t>; // attacker, victim, weapon, dt
+using AccuracyKey = std::pair<std::string, int>;                      // player, weapon
+
+struct DamageAccum
+{
+    float amount = 0.0f;
+    uint32_t hits = 0;
+};
+
+struct AccuracyAccum
+{
+    uint32_t fired = 0;
+    uint32_t hit = 0;
+    uint32_t hit_head = 0;
+};
+
+// Non-owning lookup keys. on_damage and on_weapon_fired run on every damage
+// application and every trigger pull, and stats keys are 30-32 chars -- past the small
+// string buffer -- so materializing the owning key just to index the map cost two heap
+// allocations per damage tick even when the entry already existed. The maps use a
+// transparent comparator so the hot path can look up with these instead and only build
+// the owning key when a genuinely new bucket is created.
+struct DamageKeyView
+{
+    std::string_view attacker;
+    std::string_view victim;
+    int weapon = -1;
+    uint8_t damage_type = 0;
+};
+
+struct AccuracyKeyView
+{
+    std::string_view player;
+    int weapon = -1;
+};
+
+// Written out elementwise rather than leaning on heterogeneous tuple/pair comparison,
+// which is not portable between the MSVC and MinGW builds.
+struct DamageKeyLess
+{
+    using is_transparent = void;
+
+    static DamageKeyView view(const DamageKey& k)
+    {
+        return DamageKeyView{std::get<0>(k), std::get<1>(k), std::get<2>(k), std::get<3>(k)};
+    }
+    static bool less(const DamageKeyView& a, const DamageKeyView& b)
+    {
+        if (a.attacker != b.attacker) {
+            return a.attacker < b.attacker;
+        }
+        if (a.victim != b.victim) {
+            return a.victim < b.victim;
+        }
+        if (a.weapon != b.weapon) {
+            return a.weapon < b.weapon;
+        }
+        return a.damage_type < b.damage_type;
+    }
+    bool operator()(const DamageKey& a, const DamageKey& b) const { return less(view(a), view(b)); }
+    bool operator()(const DamageKey& a, const DamageKeyView& b) const { return less(view(a), b); }
+    bool operator()(const DamageKeyView& a, const DamageKey& b) const { return less(a, view(b)); }
+};
+
+struct AccuracyKeyLess
+{
+    using is_transparent = void;
+
+    static AccuracyKeyView view(const AccuracyKey& k)
+    {
+        return AccuracyKeyView{k.first, k.second};
+    }
+    static bool less(const AccuracyKeyView& a, const AccuracyKeyView& b)
+    {
+        if (a.player != b.player) {
+            return a.player < b.player;
+        }
+        return a.weapon < b.weapon;
+    }
+    bool operator()(const AccuracyKey& a, const AccuracyKey& b) const { return less(view(a), view(b)); }
+    bool operator()(const AccuracyKey& a, const AccuracyKeyView& b) const { return less(view(a), b); }
+    bool operator()(const AccuracyKeyView& a, const AccuracyKey& b) const { return less(a, view(b)); }
+};
+
+std::map<DamageKey, DamageAccum, DamageKeyLess> g_damage_accum;
+std::map<AccuracyKey, AccuracyAccum, AccuracyKeyLess> g_accuracy_accum;
+
+// Finds the bucket for a lookup view, creating it (and only then paying for the owning
+// key) if it does not exist yet.
+DamageAccum& damage_bucket(const DamageKeyView& k)
+{
+    const auto it = g_damage_accum.find(k);
+    if (it != g_damage_accum.end()) {
+        return it->second;
+    }
+    return g_damage_accum
+        .emplace(DamageKey{std::string{k.attacker}, std::string{k.victim}, k.weapon, k.damage_type},
+                 DamageAccum{})
+        .first->second;
+}
+
+AccuracyAccum& accuracy_bucket(const AccuracyKeyView& k)
+{
+    const auto it = g_accuracy_accum.find(k);
+    if (it != g_accuracy_accum.end()) {
+        return it->second;
+    }
+    return g_accuracy_accum.emplace(AccuracyKey{std::string{k.player}, k.weapon}, AccuracyAccum{})
+        .first->second;
+}
+
+// A single in-progress overflow episode. Instead of pushing one EvGap per evicted
+// event, evictions fold into this and materialize as at most one gap event per batch
+// build. Cleared at materialize time so a later, disjoint loss becomes its own gap
+// rather than merging into one span.
+struct PendingGap
+{
+    bool active = false;
+    uint64_t dropped = 0;
+    uint64_t first_seq = 0;
+    uint64_t last_seq = 0;
+};
+PendingGap g_pending_gap;
+
+bool g_send_in_flight = false;
+std::chrono::steady_clock::time_point g_next_pulse{};
+std::chrono::steady_clock::duration g_pulse_interval = k_pulse_interval;
+bool g_paused_401 = false;
+std::string g_paused_gssk;
+std::string g_last_response = "none yet";
+std::chrono::steady_clock::time_point g_last_permanent_status_warn{};
+bool g_trace = false;
+
+uint64_t g_events_emitted = 0;
+uint64_t g_events_dropped = 0;
+uint64_t g_batches_acked = 0;
+
+std::chrono::steady_clock::time_point g_process_start = std::chrono::steady_clock::now();
+
+// Worker thread plumbing. One persistent thread with a single job slot; outcomes
+// come back through fflink::enqueue_main_thread_task.
+struct SendJob
+{
+    std::string body;
+    uint32_t batch = 0;
+    uint32_t generation = 0;
+};
+
+struct SendResult
+{
+    uint32_t batch = 0;
+    uint32_t generation = 0;
+    int status = 0;
+    int retry_after_s = 0;
+    bool network_error = false;
+    // A 200 only counts as an ack when the body is valid JSON with ok==true; the
+    // acknowledged batch number is then in ack_batch. Any other 200
+    // (non-JSON, empty, ok!=true, wrong batch) is a transient failure, not a drop.
+    bool ack_ok = false;
+    uint32_t ack_batch = 0;
+    std::string detail;
+};
+
+std::mutex g_worker_mutex;
+std::condition_variable g_worker_cv;
+std::optional<SendJob> g_worker_job;
+bool g_worker_stop = false;
+bool g_worker_started = false;
+// Identifies the one worker that is currently the live one. Bumped every time a worker
+// is spawned, so a predecessor still blocked inside a post retires as soon as it loops
+// back instead of lingering as a second consumer of the job slot.
+uint32_t g_worker_generation = 0;
+
+// -------------------------------------------------------------------------
+// Small helpers
+// -------------------------------------------------------------------------
+
+uint64_t uptime_ms()
+{
+    const auto delta = std::chrono::steady_clock::now() - g_process_start;
+    return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(delta).count());
+}
+
+std::string random_chars(const char* alphabet, size_t alphabet_size, size_t count)
+{
+    // std::random_device is the OS CSPRNG here; a few dozen draws per join is nowhere
+    // near hot enough to justify seeding a cheaper engine from it. It is opened once
+    // rather than per call because its constructor is the part that can fail.
+    //
+    // libstdc++ THROWS from that constructor when the target has no entropy source, and
+    // the shipped Linux/Wine build is MinGW/libstdc++, so a throw here would escape
+    // through mint_upssk into the join packet handler. These values are opaque
+    // identifiers rather than secrets, so a degraded seed is an acceptable trade against
+    // taking the server down; the firewall at the module boundary is the backstop, this
+    // removes the throw at the source.
+    static std::optional<std::random_device> rd;
+    static const bool rd_ready = [] {
+        try {
+            rd.emplace();
+        }
+        catch (const std::exception& e) {
+            xlog::error("[afstats-ev] no OS entropy source ({}); stats identifiers fall back to a "
+                        "time-seeded engine",
+                        e.what());
+        }
+        catch (...) {
+            xlog::error("[afstats-ev] no OS entropy source; stats identifiers fall back to a "
+                        "time-seeded engine");
+        }
+        return rd.has_value();
+    }();
+    static std::mt19937 fallback{[] {
+        const auto steady =
+            static_cast<uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count());
+        const auto wall = static_cast<uint64_t>(std::time(nullptr));
+        // The module is in an ASLR'd DLL, so a static's address adds per-process entropy.
+        const auto addr = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(&rd));
+        return static_cast<std::mt19937::result_type>(steady ^ (wall << 17) ^ addr);
+    }()};
+
+    std::uniform_int_distribution<size_t> dist(0, alphabet_size - 1);
+    std::string out;
+    out.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+        out.push_back(alphabet[rd_ready ? dist(*rd) : dist(fallback)]);
+    }
+    return out;
+}
+
+std::string mint_session_id()
+{
+    return random_chars("0123456789abcdef", 16, 16);
+}
+
+std::string mint_upssk()
+{
+    // "u-" plus 30 alphanumerics, structurally disjoint from the PSSK
+    // alphabet so any key self-identifies as tracked or untracked.
+    return "u-" + random_chars("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", 62, 30);
+}
+
+std::string sanitize_string(std::string_view in, size_t max_len)
+{
+    // Guarantees valid UTF-8 output: every codepoint that reaches JSON is a whole,
+    // well-formed sequence, so json::dump() can never throw on this string (the
+    // build enables nlohmann exceptions and a throw here would unwind into the stock
+    // game loop). max_len is a byte cap; truncation stops on a sequence boundary so a
+    // codepoint is never bisected. C0 controls and DEL are stripped as before.
+    std::string out;
+    out.reserve(std::min(in.size(), max_len));
+    const size_t n = in.size();
+    size_t i = 0;
+    while (i < n) {
+        const unsigned char c0 = static_cast<unsigned char>(in[i]);
+        size_t seq_len = 0;
+        uint32_t cp = 0;
+        if (c0 < 0x80) {
+            seq_len = 1;
+            cp = c0;
+        }
+        else if ((c0 & 0xE0) == 0xC0) {
+            seq_len = 2;
+            cp = c0 & 0x1Fu;
+        }
+        else if ((c0 & 0xF0) == 0xE0) {
+            seq_len = 3;
+            cp = c0 & 0x0Fu;
+        }
+        else if ((c0 & 0xF8) == 0xF0) {
+            seq_len = 4;
+            cp = c0 & 0x07u;
+        }
+
+        bool valid = seq_len != 0 && i + seq_len <= n;
+        for (size_t k = 1; valid && k < seq_len; ++k) {
+            const unsigned char cc = static_cast<unsigned char>(in[i + k]);
+            if ((cc & 0xC0) != 0x80) {
+                valid = false;
+                break;
+            }
+            cp = (cp << 6) | (cc & 0x3Fu);
+        }
+        if (valid) {
+            // Reject overlong encodings, UTF-16 surrogates, and out-of-range values.
+            static constexpr uint32_t min_cp[5] = {0, 0x0, 0x80, 0x800, 0x10000};
+            if (cp < min_cp[seq_len] || (cp >= 0xD800 && cp <= 0xDFFF) || cp > 0x10FFFF) {
+                valid = false;
+            }
+        }
+
+        if (!valid) {
+            // Replace exactly one bad byte and resync; never emit a partial sequence.
+            if (out.size() + 1 > max_len) {
+                break;
+            }
+            out.push_back('?');
+            ++i;
+            continue;
+        }
+        if (seq_len == 1 && (cp < 0x20 || cp == 0x7F)) {
+            ++i;
+            continue;
+        }
+        if (out.size() + seq_len > max_len) {
+            break;
+        }
+        out.append(in.substr(i, seq_len));
+        i += seq_len;
+    }
+    return out;
+}
+
+// A stats key reduced to a form that identifies it in a log without being usable: the
+// last four characters and nothing else. Used wherever a key is incidental to a
+// lifecycle log rather than being the subject of the verification-phase handshake
+// logging, so an operator pasting a server log never leaks a live PSSK.
+std::string key_suffix(std::string_view key)
+{
+    if (key.empty()) {
+        return "(none)";
+    }
+    if (key.size() <= 4) {
+        return "***";
+    }
+    return "***" + std::string{key.substr(key.size() - 4)};
+}
+
+double round_coord(float v)
+{
+    // Positions are rounded to one decimal on the wire. Going through double keeps
+    // the shortest-round-trip JSON representation at one decimal too.
+    return std::round(static_cast<double>(v) * 10.0) / 10.0;
+}
+
+bool emitting_enabled()
+{
+    return rf::is_multi && rf::is_server && fflink::afstats_server_enabled();
+}
+
+uint8_t platform_id()
+{
+    static const bool is_wine = get_wine_version().has_value();
+    return is_wine ? k_platform_wine : k_platform_windows;
+}
+
+std::string client_string(const rf::Player* player)
+{
+    const auto& v = player->version_info;
+    switch (v.software) {
+        case ClientSoftware::AlpineFaction:
+            return std::format("af {}.{}.{}", v.major, v.minor, v.patch);
+        case ClientSoftware::DashFaction:
+            return std::format("df {}.{}", v.major, v.minor);
+        case ClientSoftware::PureFaction:
+            return std::format("pf {}.{}", v.major, v.minor);
+        case ClientSoftware::Browser:
+            return "browser";
+        default:
+            return "legacy";
+    }
+}
+
+uint8_t team_id(const rf::Player* player)
+{
+    if (!multi_is_team_game_type()) {
+        return team_none;
+    }
+    return player->team == rf::TEAM_BLUE ? team_blue : team_red;
+}
+
+// -------------------------------------------------------------------------
+// Queue and round counters
+// -------------------------------------------------------------------------
+
+// Folds a loss into the current overflow episode. No queue event and at most one
+// log line per episode; the gap event is materialized later.
+void accumulate_gap(uint64_t dropped, uint64_t first_seq, uint64_t last_seq)
+{
+    if (!g_pending_gap.active) {
+        g_pending_gap.active = true;
+        g_pending_gap.dropped = dropped;
+        g_pending_gap.first_seq = first_seq;
+        g_pending_gap.last_seq = last_seq;
+        xlog::warn("[afstats-ev] queue full; dropping events (episode start, seq {}-{})", first_seq,
+                   last_seq);
+        return;
+    }
+    g_pending_gap.dropped += dropped;
+    g_pending_gap.first_seq = std::min(g_pending_gap.first_seq, first_seq);
+    g_pending_gap.last_seq = std::max(g_pending_gap.last_seq, last_seq);
+}
+
+void push_event(EventPayload payload)
+{
+    Event e;
+    e.seq = g_next_seq++;
+    e.t = uptime_ms();
+    e.round = g_round;
+    e.payload = std::move(payload);
+    g_queue.push_back(std::move(e));
+    ++g_events_emitted;
+
+    if (g_queue.size() <= k_max_queued_events) {
+        return;
+    }
+    // Bound memory by dropping the oldest events, leaving the queue holding
+    // exactly the documented cap. Evicting to a reserved slot below the cap instead
+    // would drop two events per push once full, so the queue would oscillate around
+    // cap-1 and never actually hold the advertised 20000. materialize_pending_gap
+    // appends its marker directly rather than through here, so it can carry the queue
+    // one event past the cap for the moment between the fold and the batch cut -- that
+    // is bounded at +1 and drains on the same call.
+    const size_t to_drop = g_queue.size() - k_max_queued_events;
+    const uint64_t first = g_queue.front().seq;
+    uint64_t last = first;
+    for (size_t i = 0; i < to_drop; ++i) {
+        last = g_queue.front().seq;
+        g_queue.pop_front();
+    }
+    g_events_dropped += to_drop;
+    accumulate_gap(to_drop, first, last);
+}
+
+// Turns the current overflow episode into a single gap event and clears it, so a
+// later disjoint loss starts a fresh episode. Minted at the tail with a fresh seq:
+// FF reads the loss from the range fields, not the event's position.
+void materialize_pending_gap()
+{
+    if (!g_pending_gap.active) {
+        return;
+    }
+    EvGap gap;
+    gap.dropped = g_pending_gap.dropped;
+    gap.first_seq = g_pending_gap.first_seq;
+    gap.last_seq = g_pending_gap.last_seq;
+    xlog::warn("[afstats-ev] gap materialized: {} events lost, seq {}-{}", gap.dropped, gap.first_seq,
+               gap.last_seq);
+    g_pending_gap = PendingGap{};
+
+    Event e;
+    e.seq = g_next_seq++;
+    e.t = uptime_ms();
+    e.round = g_round;
+    e.payload = std::move(gap);
+    g_queue.push_back(std::move(e));
+}
+
+// Materializes the windowed aggregates into events. Runs immediately before a
+// batch is cut and before a round closes, so an aggregate never lands under the
+// round number of the round after the one it happened in.
+void flush_accumulators()
+{
+    // extract() yields a node whose key() is mutable, so the captured-at-damage-time
+    // key strings move out instead of being copied, with no allocation per
+    // entry and no writing through a const map key.
+    while (!g_damage_accum.empty()) {
+        auto node = g_damage_accum.extract(g_damage_accum.begin());
+        auto& key = node.key();
+        EvDamage ev;
+        ev.attacker = std::move(std::get<0>(key));
+        ev.victim = std::move(std::get<1>(key));
+        ev.weapon = std::get<2>(key);
+        ev.damage_type = std::get<3>(key);
+        ev.amount = node.mapped().amount;
+        ev.hits = node.mapped().hits;
+        push_event(std::move(ev));
+    }
+
+    while (!g_accuracy_accum.empty()) {
+        auto node = g_accuracy_accum.extract(g_accuracy_accum.begin());
+        EvAccuracy ev;
+        ev.player = std::move(node.key().first);
+        ev.weapon = node.key().second;
+        ev.fired = node.mapped().fired;
+        ev.hit = node.mapped().hit;
+        ev.hit_head = node.mapped().hit_head;
+        push_event(std::move(ev));
+    }
+}
+
+void reset_round_counters(rf::Player* player)
+{
+    const int64_t now = static_cast<int64_t>(uptime_ms());
+    player->afstats_round = AfstatsRoundCounters{};
+    player->afstats_round.present_since_ms = now;
+    player->afstats_round.last_sample_ms = now;
+    player->afstats_round.last_ping_sample_ms = now;
+}
+
+// Advances the time accumulators by sampling the player's current state, and
+// edge-detects idle. Called on the sender pulse and again whenever a summary is
+// about to be serialized, so the coarse totals need no per-transition hook. Idle
+// is sampled rather than hooked because the engine stores no idle flag: it is a
+// predicate that flips when an inactivity timer expires, with nothing to hook.
+void sample_player_state(rf::Player* player)
+{
+    if (player->is_browser) {
+        return;
+    }
+    const int64_t now = static_cast<int64_t>(uptime_ms());
+    auto& c = player->afstats_round;
+    const bool idle = player_is_idle(player);
+    const int64_t delta = now - c.last_sample_ms;
+    if (delta > 0) {
+        c.last_sample_ms = now;
+        // time_played_ms is total connected time; time_spectating_ms is a subset of
+        // it, not a separate bucket; this is definitional, FF nets them if it wants.
+        c.time_played_ms += delta;
+        if (player->is_spectator) {
+            c.time_spectating_ms += delta;
+        }
+        if (idle) {
+            c.time_idle_ms += delta;
+        }
+    }
+    if (idle != c.was_idle) {
+        c.was_idle = idle;
+        on_status(player, idle ? StatusKind::idle_start : StatusKind::idle_stop);
+    }
+    if (now - c.last_ping_sample_ms >= k_ping_sample_interval_ms && player->net_data) {
+        c.ping_sum += player->net_data->ping;
+        ++c.ping_samples;
+        c.last_ping_sample_ms = now;
+    }
+}
+
+RosterEntry build_roster_entry(rf::Player* player, bool with_summary)
+{
+    RosterEntry e;
+    e.player = player->afstats_key;
+    e.name = sanitize_string(player->name.c_str(), k_max_name_len);
+    e.team = team_id(player);
+    if (player->is_bot) {
+        e.flags |= k_player_flag_bot;
+    }
+    if (player->is_spectator) {
+        e.flags |= k_player_flag_spectating;
+    }
+    if (player_is_idle(player)) {
+        e.flags |= k_player_flag_idle;
+    }
+    e.handicap = player->damage_handicap;
+    if (!with_summary) {
+        return e;
+    }
+
+    sample_player_state(player);
+    const auto& c = player->afstats_round;
+    e.has_summary = true;
+    // Score and caps are the engine's own per-level numbers; duplicating them into
+    // the round counters would just give them a second chance to disagree.
+    if (player->stats) {
+        e.score = player->stats->score;
+        e.caps = static_cast<uint32_t>(std::max<int>(player->stats->caps, 0));
+    }
+    e.kills = c.kills;
+    e.deaths = c.deaths;
+    e.assists = c.assists;
+    e.shots_fired = c.shots_fired;
+    e.shots_hit = c.shots_hit;
+    e.damage_dealt = c.damage_dealt;
+    e.damage_taken = c.damage_taken;
+    e.highest_streak = c.highest_streak;
+    e.time_played_ms = c.time_played_ms;
+    e.time_spectating_ms = c.time_spectating_ms;
+    e.time_idle_ms = c.time_idle_ms;
+    // 0 until the first ~10s ping sample lands, so short-lived connections report 0
+    // rather than a spuriously precise value; this is definitional, not a defect.
+    e.avg_ping = c.ping_samples > 0 ? static_cast<int>(c.ping_sum / c.ping_samples) : 0;
+    return e;
+}
+
+std::vector<RosterEntry> build_roster(bool with_summary)
+{
+    std::vector<RosterEntry> roster;
+    for (rf::Player& player : SinglyLinkedList{rf::player_list}) {
+        if (player.is_browser || player.afstats_key.empty()) {
+            continue;
+        }
+        roster.push_back(build_roster_entry(&player, with_summary));
+    }
+    return roster;
+}
+
+// -------------------------------------------------------------------------
+// JSON serialization (batch time only)
+// -------------------------------------------------------------------------
+
+nlohmann::json setting_to_json(const SettingValue& value)
+{
+    return std::visit(
+        [](const auto& v) -> nlohmann::json {
+            return nlohmann::json(v);
+        },
+        value);
+}
+
+nlohmann::json pos_to_json(const Vec3& p)
+{
+    return nlohmann::json::array({round_coord(p.x), round_coord(p.y), round_coord(p.z)});
+}
+
+nlohmann::json roster_entry_to_json(const RosterEntry& e)
+{
+    nlohmann::json j{
+        {"player", e.player},
+        {"name", e.name},
+        {"team", e.team},
+        {"flags", e.flags},
+        {"handicap", e.handicap},
+    };
+    if (!e.has_summary) {
+        return j;
+    }
+    j["score"] = e.score;
+    j["kills"] = e.kills;
+    j["deaths"] = e.deaths;
+    j["assists"] = e.assists;
+    j["caps"] = e.caps;
+    j["shots_fired"] = e.shots_fired;
+    j["shots_hit"] = e.shots_hit;
+    j["damage_dealt"] = e.damage_dealt;
+    j["damage_taken"] = e.damage_taken;
+    j["highest_streak"] = e.highest_streak;
+    j["time_played_ms"] = e.time_played_ms;
+    j["time_spectating_ms"] = e.time_spectating_ms;
+    j["time_idle_ms"] = e.time_idle_ms;
+    j["avg_ping"] = e.avg_ping;
+    return j;
+}
+
+nlohmann::json event_to_json(const Event& e)
+{
+    nlohmann::json j{
+        {"seq", e.seq},
+        {"t", e.t},
+        {"round", e.round},
+    };
+
+    std::visit(
+        [&j](const auto& p) {
+            using T = std::decay_t<decltype(p)>;
+            if constexpr (std::is_same_v<T, EvServerHello>) {
+                j["type"] = "server_hello";
+                j["server_name"] = p.server_name;
+                j["port"] = p.port;
+                j["af_version"] = p.af_version;
+                j["platform"] = p.platform;
+                j["max_players"] = p.max_players;
+            }
+            else if constexpr (std::is_same_v<T, EvGap>) {
+                j["type"] = "gap";
+                j["dropped"] = p.dropped;
+                j["first_seq"] = p.first_seq;
+                j["last_seq"] = p.last_seq;
+            }
+            else if constexpr (std::is_same_v<T, EvPlayerJoin>) {
+                j["type"] = "player_join";
+                j["upssk"] = p.upssk;
+                j["name"] = p.name;
+                j["kind"] = p.kind;
+                j["client"] = p.client;
+            }
+            else if constexpr (std::is_same_v<T, EvPlayerRemediate>) {
+                j["type"] = "player_remediate";
+                j["upssk"] = p.upssk;
+                j["pssk"] = p.pssk;
+            }
+            else if constexpr (std::is_same_v<T, EvPlayerRename>) {
+                j["type"] = "player_rename";
+                j["player"] = p.player;
+                j["name"] = p.name;
+            }
+            else if constexpr (std::is_same_v<T, EvPlayerLeave>) {
+                j["type"] = "player_leave";
+                j["player"] = p.stats.player;
+                j["reason"] = p.reason;
+                j["stats"] = roster_entry_to_json(p.stats);
+            }
+            else if constexpr (std::is_same_v<T, EvRoundStart>) {
+                j["type"] = "round_start";
+                j["tc_mod"] = p.tc_mod;
+                j["level_file"] = p.level_file;
+                j["level_name"] = p.level_name;
+                j["gametype"] = p.gametype;
+                j["time_limit_s"] = p.time_limit_s;
+                j["win_condition"] = p.win_condition;
+                j["overtime_enabled"] = p.overtime_enabled;
+                j["af_flags"] = p.af_flags;
+                j["rf_flags"] = p.rf_flags;
+                j["gi_flags"] = p.gi_flags;
+                j["match_state"] = p.match_state;
+
+                auto mutators = nlohmann::json::array();
+                for (const auto& m : p.mutators) {
+                    auto settings = nlohmann::json::object();
+                    for (const auto& [key, value] : m.settings) {
+                        settings[key] = setting_to_json(value);
+                    }
+                    nlohmann::json entry;
+                    entry["name"] = m.name;
+                    entry["settings"] = std::move(settings);
+                    mutators.push_back(std::move(entry));
+                }
+                j["mutators"] = std::move(mutators);
+
+                auto gametype_settings = nlohmann::json::object();
+                for (const auto& [key, value] : p.gametype_settings) {
+                    gametype_settings[key] = setting_to_json(value);
+                }
+                j["gametype_settings"] = std::move(gametype_settings);
+
+                auto roster = nlohmann::json::array();
+                for (const auto& entry : p.roster) {
+                    roster.push_back(roster_entry_to_json(entry));
+                }
+                j["roster"] = std::move(roster);
+            }
+            else if constexpr (std::is_same_v<T, EvRoundEnd>) {
+                j["type"] = "round_end";
+                j["end_type"] = p.end_type;
+                j["duration_ms"] = p.duration_ms;
+                j["overtime"] = p.overtime;
+                j["red_score"] = p.red_score;
+                j["blue_score"] = p.blue_score;
+                auto players = nlohmann::json::array();
+                for (const auto& entry : p.players) {
+                    players.push_back(roster_entry_to_json(entry));
+                }
+                j["players"] = std::move(players);
+            }
+            else if constexpr (std::is_same_v<T, EvKill>) {
+                j["type"] = "kill";
+                j["victim"] = p.victim;
+                j["killer"] = p.killer.empty() ? nlohmann::json(nullptr) : nlohmann::json(p.killer);
+                j["weapon"] = p.weapon < 0 ? nlohmann::json(nullptr) : nlohmann::json(p.weapon);
+                j["damage_type"] = p.damage_type;
+                j["flags"] = p.flags;
+                j["assists"] = p.assists;
+                j["victim_pos"] = pos_to_json(p.victim_pos);
+                j["killer_pos"] = p.has_killer_pos ? pos_to_json(p.killer_pos) : nlohmann::json(nullptr);
+            }
+            else if constexpr (std::is_same_v<T, EvSpawn>) {
+                j["type"] = "spawn";
+                j["player"] = p.player;
+                j["pos"] = pos_to_json(p.pos);
+            }
+            else if constexpr (std::is_same_v<T, EvDamage>) {
+                j["type"] = "damage";
+                j["attacker"] = p.attacker.empty() ? nlohmann::json(nullptr) : nlohmann::json(p.attacker);
+                j["victim"] = p.victim;
+                j["weapon"] = p.weapon < 0 ? nlohmann::json(nullptr) : nlohmann::json(p.weapon);
+                j["damage_type"] = p.damage_type;
+                j["amount"] = p.amount;
+                j["hits"] = p.hits;
+            }
+            else if constexpr (std::is_same_v<T, EvAccuracy>) {
+                j["type"] = "accuracy";
+                j["player"] = p.player;
+                j["weapon"] = p.weapon;
+                j["fired"] = p.fired;
+                j["hit"] = p.hit;
+                j["hit_head"] = p.hit_head;
+            }
+            else if constexpr (std::is_same_v<T, EvStatus>) {
+                j["type"] = "status";
+                j["player"] = p.player;
+                j["kind"] = p.kind;
+                if (p.has_value) {
+                    j["value"] = p.value;
+                }
+            }
+            else if constexpr (std::is_same_v<T, EvItemPickup>) {
+                j["type"] = "item_pickup";
+                j["player"] = p.player;
+                j["item"] = p.item;
+                j["pos"] = pos_to_json(p.pos);
+                j["respawn_ms"] = p.respawn_ms;
+            }
+            else if constexpr (std::is_same_v<T, EvFlagEvent>) {
+                j["type"] = "flag_event";
+                j["kind"] = p.kind;
+                j["team"] = p.team;
+                j["player"] = p.player.empty() ? nlohmann::json(nullptr) : nlohmann::json(p.player);
+                j["pos"] = pos_to_json(p.pos);
+            }
+            else if constexpr (std::is_same_v<T, EvPointEvent>) {
+                j["type"] = "point_event";
+                j["hill"] = p.hill;
+                j["kind"] = p.kind;
+                j["owner"] = p.owner;
+                j["players"] = p.players;
+                j["locked"] = p.locked;
+            }
+            else if constexpr (std::is_same_v<T, EvBagmanEvent>) {
+                j["type"] = "bagman_event";
+                j["kind"] = p.kind;
+                j["player"] = p.player.empty() ? nlohmann::json(nullptr) : nlohmann::json(p.player);
+                if (p.has_from) {
+                    j["from"] = p.from;
+                }
+                j["pos"] = pos_to_json(p.pos);
+            }
+            else if constexpr (std::is_same_v<T, EvGgLevelup>) {
+                j["type"] = "gg_levelup";
+                j["player"] = p.player;
+                j["level"] = p.level;
+                j["weapon"] = p.weapon < 0 ? nlohmann::json(nullptr) : nlohmann::json(p.weapon);
+            }
+            else if constexpr (std::is_same_v<T, EvMatchStart>) {
+                j["type"] = "match_start";
+                j["team_size"] = p.team_size;
+                j["participants"] = p.participants;
+            }
+            else if constexpr (std::is_same_v<T, EvMatchEnd>) {
+                j["type"] = "match_end";
+                j["result"] = p.result;
+                j["winner_team"] = p.winner_team;
+                j["winner_player"] =
+                    p.winner_player.empty() ? nlohmann::json(nullptr) : nlohmann::json(p.winner_player);
+            }
+            else if constexpr (std::is_same_v<T, EvVoteCalled>) {
+                j["type"] = "vote_called";
+                j["vote_type"] = p.vote_type;
+                j["initiator"] = p.initiator;
+                j["target"] = p.target.empty() ? nlohmann::json(nullptr) : nlohmann::json(p.target);
+                j["detail"] = p.detail;
+            }
+            else if constexpr (std::is_same_v<T, EvVoteEnded>) {
+                j["type"] = "vote_ended";
+                j["vote_type"] = p.vote_type;
+                j["result"] = p.result;
+                j["yes"] = p.yes;
+                j["no"] = p.no;
+                j["eligible"] = p.eligible;
+            }
+            else if constexpr (std::is_same_v<T, EvGeomod>) {
+                j["type"] = "geomod";
+                j["pos"] = pos_to_json(p.pos);
+                j["scale"] = p.scale;
+                j["rf2_style"] = p.rf2_style;
+                j["player"] = p.player.empty() ? nlohmann::json(nullptr) : nlohmann::json(p.player);
+                j["weapon"] = p.weapon < 0 ? nlohmann::json(nullptr) : nlohmann::json(p.weapon);
+            }
+            else if constexpr (std::is_same_v<T, EvClutterDestroyed>) {
+                j["type"] = "clutter_destroyed";
+                j["clutter_type"] =
+                    p.has_clutter_type ? nlohmann::json(p.clutter_type) : nlohmann::json(nullptr);
+                j["uid"] = p.has_uid ? nlohmann::json(p.uid) : nlohmann::json(nullptr);
+                j["player"] = p.player.empty() ? nlohmann::json(nullptr) : nlohmann::json(p.player);
+                j["weapon"] = p.weapon < 0 ? nlohmann::json(nullptr) : nlohmann::json(p.weapon);
+                j["damage_type"] = p.damage_type;
+                j["pos"] = pos_to_json(p.pos);
+            }
+            else if constexpr (std::is_same_v<T, EvDetailBrushDestroyed>) {
+                j["type"] = "detail_brush_destroyed";
+                j["material"] = p.material;
+                j["room_uid"] = p.has_room_uid ? nlohmann::json(p.room_uid) : nlohmann::json(nullptr);
+                j["player"] = p.player.empty() ? nlohmann::json(nullptr) : nlohmann::json(p.player);
+                j["weapon"] = p.weapon < 0 ? nlohmann::json(nullptr) : nlohmann::json(p.weapon);
+                j["damage_type"] = p.damage_type;
+                j["pos"] = pos_to_json(p.pos);
+            }
+            else {
+                // Every variant alternative must have a branch above; a new event without
+                // one would otherwise ship a typeless event silently. Fail the build.
+                static_assert(always_false_v<T>, "unhandled event payload in event_to_json");
+            }
+        },
+        e.payload);
+
+    return j;
+}
+
+nlohmann::json build_envelope_json(const PendingBatch& batch, const std::string& gssk)
+{
+    nlohmann::json j{
+        {"v", k_envelope_version},
+        {"gssk", gssk},
+        {"session", g_session_id},
+        {"batch", batch.batch},
+        {"sent_at", static_cast<uint64_t>(std::time(nullptr))},
+        {"uptime_ms", uptime_ms()},
+    };
+    auto events = nlohmann::json::array();
+    for (const Event& e : batch.events) {
+        events.push_back(event_to_json(e));
+    }
+    j["events"] = std::move(events);
+    return j;
+}
+
+std::string build_envelope(const PendingBatch& batch, const std::string& gssk)
+{
+    // error_handler_t::replace is defense in depth: sanitize_string already
+    // guarantees valid UTF-8, but a stray bad byte must degrade to U+FFFD rather
+    // than throw out of the serializer.
+    return build_envelope_json(batch, gssk)
+        .dump(-1, ' ', false, nlohmann::json::error_handler_t::replace);
+}
+
+// Masks the GSSK and every stats-key field so the trace log can carry a batch's
+// shape without leaking credentials. Names and non-key fields are kept.
+void redact_credentials(nlohmann::json& node)
+{
+    // Fields whose value is a single key string.
+    static constexpr std::string_view key_fields[] = {
+        "gssk",   "player",   "victim", "killer",       "attacker",
+        "initiator", "target", "upssk", "pssk",         "winner_player"};
+    // Fields whose value is an array of key strings (round_end.players is an array of
+    // roster objects instead, so it is handled by the recursion below, not here).
+    static constexpr std::string_view key_list_fields[] = {"assists", "participants"};
+
+    if (node.is_object()) {
+        for (auto it = node.begin(); it != node.end(); ++it) {
+            const std::string& k = it.key();
+            nlohmann::json& v = it.value();
+            if (std::find(std::begin(key_fields), std::end(key_fields), k) != std::end(key_fields)
+                && v.is_string()) {
+                v = "***";
+            }
+            else if (k == "players" && v.is_array()) {
+                // point_event.players is a key list; round_end.players is roster objects.
+                for (auto& e : v) {
+                    if (e.is_string()) {
+                        e = "***";
+                    }
+                    else {
+                        redact_credentials(e);
+                    }
+                }
+            }
+            else if (std::find(std::begin(key_list_fields), std::end(key_list_fields), k)
+                         != std::end(key_list_fields)
+                     && v.is_array()) {
+                for (auto& e : v) {
+                    if (e.is_string()) {
+                        e = "***";
+                    }
+                }
+            }
+            else {
+                redact_credentials(v);
+            }
+        }
+    }
+    else if (node.is_array()) {
+        for (auto& e : node) {
+            redact_credentials(e);
+        }
+    }
+}
+
+// -------------------------------------------------------------------------
+// Sender
+// -------------------------------------------------------------------------
+
+SendResult do_one_post(const SendJob& job, unsigned long connect_timeout_ms, unsigned long receive_timeout_ms)
+{
+    SendResult out;
+    out.batch = job.batch;
+    out.generation = job.generation;
+
+    std::string response;
+    try {
+        HttpSession session(k_user_agent);
+        session.set_connect_timeout(connect_timeout_ms);
+        session.set_receive_timeout(receive_timeout_ms);
+
+        HttpRequest req(k_events_url, "POST", session);
+        req.set_content_type("application/json");
+        out.status = req.send_no_check(job.body);
+
+        try {
+            if (auto retry_after = req.get_header("Retry-After")) {
+                // Clamp so a hostile/garbled header can't wedge the batch behind an
+                // absurd backoff (spec allows honoring Retry-After; cap at 1 hour).
+                out.retry_after_s = std::clamp(std::atoi(retry_after->c_str()), 0, 3600);
+            }
+        }
+        catch (const std::exception&) {
+            // get_header uses a fixed 1024-byte buffer and throws on a longer header;
+            // an oversized Retry-After must not abort the whole response read.
+        }
+
+        char buf[1024];
+        std::ostringstream stream;
+        size_t total = 0;
+        while (size_t n = req.read(buf, sizeof(buf))) {
+            total += n;
+            if (total > k_max_response_bytes) {
+                // A compromised/broken endpoint must not stream unbounded data into
+                // worker memory; treat an over-cap body as a transient failure.
+                out.network_error = true;
+                out.detail = std::format("response exceeded {} byte cap", k_max_response_bytes);
+                return out;
+            }
+            stream.write(buf, n);
+        }
+        response = stream.str();
+    }
+    catch (const std::exception& e) {
+        out.network_error = true;
+        out.detail = std::string{"network error: "} + e.what();
+        return out;
+    }
+
+    // One parse of the body: a 200 must carry {ok:true, batch:N} to be an ack, and a
+    // non-200 may carry an {error:...} code for diagnostics. A non-JSON
+    // or empty body leaves ack_ok false, so an any-200-is-ack drop can't happen.
+    std::string error_code;
+    try {
+        auto j = nlohmann::json::parse(response);
+        if (out.status == 200) {
+            if (j.contains("ok") && j["ok"].is_boolean() && j["ok"].get<bool>()
+                && j.contains("batch") && j["batch"].is_number_integer()) {
+                const auto acked = j["batch"].get<int64_t>();
+                if (acked >= 0) {
+                    out.ack_ok = true;
+                    out.ack_batch = static_cast<uint32_t>(acked);
+                }
+            }
+        }
+        else if (j.contains("error") && j["error"].is_string()) {
+            error_code = fflink::sanitize_for_log(j["error"].get<std::string>());
+        }
+    }
+    catch (const std::exception&) {
+        // Body wasn't JSON; the status code alone drives the state machine.
+    }
+
+    out.detail = error_code.empty() ? std::format("HTTP {}", out.status)
+                                    : std::format("HTTP {} ({})", out.status, error_code);
+    return out;
+}
+
+void on_send_result(SendResult result);
+
+void worker_main(uint32_t my_generation)
+{
+    for (;;) {
+        SendJob job;
+        {
+            std::unique_lock lock(g_worker_mutex);
+            g_worker_cv.wait(lock, [my_generation] {
+                return g_worker_stop || g_worker_generation != my_generation
+                    || g_worker_job.has_value();
+            });
+            // Retire on either signal. Checking the generation as well as the stop flag
+            // is what makes shutdown sound: a worker blocked in a post outlives the
+            // shutdown window, and by the time it gets here the next session may already
+            // have cleared g_worker_stop -- but it can never be the current generation
+            // again, so exactly one worker survives.
+            if (g_worker_stop || g_worker_generation != my_generation) {
+                return;
+            }
+            job = std::move(*g_worker_job);
+            g_worker_job.reset();
+        }
+
+        SendResult result;
+        try {
+            result = do_one_post(job, k_connect_timeout_ms, k_receive_timeout_ms);
+        }
+        catch (const std::exception& e) {
+            result.batch = job.batch;
+            result.generation = job.generation;
+            result.network_error = true;
+            result.detail = std::string{"sender thread error: "} + e.what();
+        }
+        catch (...) {
+            result.batch = job.batch;
+            result.generation = job.generation;
+            result.network_error = true;
+            result.detail = "sender thread error: unknown exception";
+        }
+
+        fflink::enqueue_main_thread_task([result = std::move(result)]() mutable {
+            on_send_result(std::move(result));
+        });
+    }
+}
+
+bool ensure_worker_started()
+{
+    if (g_worker_started) {
+        return true;
+    }
+    uint32_t my_generation = 0;
+    {
+        std::lock_guard lock(g_worker_mutex);
+        // Claiming a new generation supersedes any predecessor still finishing a post
+        // from the previous session; clearing the stop flag here (rather than at the end
+        // of shutdown) means that predecessor had the whole gap to observe it.
+        my_generation = ++g_worker_generation;
+        g_worker_stop = false;
+        g_worker_job.reset();
+    }
+    g_worker_cv.notify_all(); // retire a predecessor parked on the CV
+    try {
+        std::thread(worker_main, my_generation).detach();
+        g_worker_started = true;
+    }
+    catch (const std::exception& e) {
+        xlog::warn("[afstats-ev] failed to start the sender thread: {}", e.what());
+    }
+    return g_worker_started;
+}
+
+void dispatch(PendingBatch& batch, const std::string& gssk)
+{
+    if (!ensure_worker_started()) {
+        return;
+    }
+
+    // body carries the real GSSK for transmission; the trace log below uses a
+    // separately redacted copy, so the key never reaches the log.
+    std::string body = build_envelope(batch, gssk);
+    ++batch.attempts;
+
+    if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+        if (batch.attempts == 1) {
+            xlog::warn("[afstats-ev] batch {} built: {} events (seq {}-{}), {} bytes", batch.batch,
+                       batch.events.size(), batch.first_seq, batch.last_seq, body.size());
+        }
+        else {
+            // What is waiting behind this batch and will go out in the next one. Each
+            // accumulator entry materializes into exactly one event at the next flush,
+            // so this is a count rather than an estimate.
+            const size_t queued_behind =
+                g_queue.size() + g_damage_accum.size() + g_accuracy_accum.size();
+
+            // Backlog growth over the retry window, from the monotonic event clock. The
+            // denominator has to run to now rather than to the newest queued event, or a
+            // queue that stopped growing would keep reporting the rate it grew at.
+            const uint64_t now_ms = uptime_ms();
+            const uint64_t since_freeze_ms =
+                now_ms > batch.frozen_at_ms ? now_ms - batch.frozen_at_ms : 0;
+            std::string rate;
+            if (queued_behind >= 2 && since_freeze_ms >= 1000) {
+                rate = std::format(" (~{:.1f}/s)",
+                                   static_cast<double>(queued_behind) * 1000.0
+                                       / static_cast<double>(since_freeze_ms));
+            }
+
+            xlog::warn("[afstats-ev] retrying batch {} ({} events, {} bytes, attempt {}); "
+                       "{} events queued awaiting ack{}",
+                       batch.batch, batch.events.size(), body.size(), batch.attempts, queued_behind,
+                       rate);
+        }
+    }
+    if (g_trace) {
+        nlohmann::json redacted = build_envelope_json(batch, gssk);
+        redact_credentials(redacted);
+        xlog::warn("[afstats-ev] trace batch {}: {}", batch.batch,
+                   redacted.dump(-1, ' ', false, nlohmann::json::error_handler_t::replace));
+    }
+
+    {
+        std::lock_guard lock(g_worker_mutex);
+        g_worker_job = SendJob{std::move(body), batch.batch, g_session_generation};
+    }
+    g_worker_cv.notify_one();
+    g_send_in_flight = true;
+}
+
+void build_batch_from_queue()
+{
+    flush_accumulators();
+    // Fold any overflow episode into a single gap event before the batch is cut, so
+    // it goes out with (not after) the events that survived the loss.
+    materialize_pending_gap();
+    if (g_queue.empty()) {
+        return;
+    }
+    PendingBatch batch;
+    batch.batch = g_next_batch++;
+    const size_t count = std::min(g_queue.size(), k_max_events_per_batch);
+    batch.events.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+        batch.events.push_back(std::move(g_queue.front()));
+        g_queue.pop_front();
+    }
+    batch.first_seq = batch.events.front().seq;
+    batch.last_seq = batch.events.back().seq;
+    batch.frozen_at_ms = uptime_ms();
+    g_pending.push_back(std::move(batch));
+}
+
+void pump()
+{
+    if (g_pending.empty()) {
+        build_batch_from_queue();
+    }
+    if (g_pending.empty()) {
+        return;
+    }
+    const std::string gssk = fflink::get_gssk();
+    if (gssk.empty()) {
+        // No session key yet: the queue keeps filling and nothing goes out.
+        return;
+    }
+    dispatch(g_pending.front(), gssk);
+}
+
+void drop_front_batch_with_gap(const char* why)
+{
+    PendingBatch batch = std::move(g_pending.front());
+    g_pending.pop_front();
+    xlog::warn("[afstats-ev] dropping batch {} without retry ({}); {} events lost", batch.batch, why,
+               batch.events.size());
+    accumulate_gap(batch.events.size(), batch.first_seq, batch.last_seq);
+}
+
+void split_front_batch()
+{
+    PendingBatch& front = g_pending.front();
+    if (front.events.size() < 2) {
+        drop_front_batch_with_gap("413 on a single-event batch, nothing left to split");
+        return;
+    }
+
+    const size_t half = front.events.size() / 2;
+    PendingBatch tail;
+    tail.batch = g_next_batch++;
+    tail.frozen_at_ms = front.frozen_at_ms; // both halves were frozen together
+    tail.events.assign(std::make_move_iterator(front.events.begin() + half),
+                       std::make_move_iterator(front.events.end()));
+    front.events.erase(front.events.begin() + half, front.events.end());
+
+    front.last_seq = front.events.back().seq;
+    front.attempts = 0;
+    tail.first_seq = tail.events.front().seq;
+    tail.last_seq = tail.events.back().seq;
+
+    xlog::warn("[afstats-ev] batch {} was too large; split into batch {} ({} events) and batch {} ({} events)",
+               front.batch, front.batch, front.events.size(), tail.batch, tail.events.size());
+    g_pending.insert(g_pending.begin() + 1, std::move(tail));
+}
+
+void on_send_result(SendResult result)
+{
+    // A completion from a previous session's worker: the module was
+    // reset out from under it, so it must not touch the new session's in-flight state.
+    if (!g_session_started || result.generation != g_session_generation) {
+        return;
+    }
+
+    g_send_in_flight = false;
+
+    if (g_pending.empty() || g_pending.front().batch != result.batch) {
+        xlog::warn("[afstats-ev] discarding a result for batch {} that is no longer in flight", result.batch);
+        return;
+    }
+
+    g_last_response = result.detail;
+
+    if (result.network_error) {
+        xlog::warn("[afstats-ev] batch {} failed: {}; retrying on the next pulse", result.batch,
+                   result.detail);
+        return;
+    }
+
+    if (result.status == 200) {
+        // Only a well-formed ack for THIS batch discards it. A 200 with a
+        // non-JSON/empty body, ok!=true, or a mismatched batch number is transient:
+        // retry the identical batch, never silently drop it.
+        if (!result.ack_ok || result.ack_batch != g_pending.front().batch) {
+            xlog::warn("[afstats-ev] batch {} got a 200 that was not a valid ack ({}); retrying "
+                       "on the next pulse",
+                       result.batch, result.detail);
+            return;
+        }
+        if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+            const PendingBatch& front = g_pending.front();
+            xlog::warn("[afstats-ev] batch {} acked ({} events)", front.batch, front.events.size());
+        }
+        g_pending.pop_front();
+        ++g_batches_acked;
+        g_pulse_interval = k_pulse_interval;
+        // Drain a backlog at ack rate rather than one batch per pulse.
+        if (!g_pending.empty() || g_queue.size() >= k_max_events_per_batch) {
+            g_next_pulse = std::chrono::steady_clock::now();
+        }
+        return;
+    }
+
+    switch (result.status) {
+        case 400:
+            // Poison pill: a batch FactionFiles can never accept must not wedge the
+            // stream forever.
+            drop_front_batch_with_gap(result.detail.c_str());
+            break;
+        case 401:
+            g_paused_401 = true;
+            g_paused_gssk = fflink::get_gssk();
+            xlog::warn("[afstats-ev] batch {} rejected ({}); pausing the stream and re-running the "
+                       "session key exchange",
+                       result.batch, result.detail);
+            fflink::start_session_exchange();
+            break;
+        case 413:
+            split_front_batch();
+            break;
+        case 429: {
+            g_pulse_interval = result.retry_after_s > 0 ? std::chrono::seconds(result.retry_after_s)
+                                                        : k_rate_limit_backoff;
+            const auto backoff_s =
+                std::chrono::duration_cast<std::chrono::seconds>(g_pulse_interval).count();
+            xlog::warn("[afstats-ev] rate limited ({}); backing off to a {}s pulse", result.detail,
+                       backoff_s);
+            g_next_pulse = std::chrono::steady_clock::now() + g_pulse_interval;
+            break;
+        }
+        default:
+            xlog::warn("[afstats-ev] batch {} rejected ({}); retrying on the next pulse", result.batch,
+                       result.detail);
+            // Spec keeps retrying unknown codes, but 404/405/501 read as a misrouted
+            // or disabled endpoint rather than a blip; surface that, throttled, so it
+            // is diagnosable without spamming the log every pulse.
+            if (result.status == 404 || result.status == 405 || result.status == 501) {
+                const auto now = std::chrono::steady_clock::now();
+                if (now - g_last_permanent_status_warn >= std::chrono::seconds(60)) {
+                    g_last_permanent_status_warn = now;
+                    xlog::warn("[afstats-ev] endpoint returned {} repeatedly; the events URL may be "
+                               "misrouted or disabled",
+                               result.status);
+                }
+            }
+            break;
+    }
+}
+
+// -------------------------------------------------------------------------
+// Session
+// -------------------------------------------------------------------------
+
+void emit_server_hello()
+{
+    EvServerHello hello;
+    hello.server_name = sanitize_string(rf::netgame.name.c_str(), k_max_name_len * 2);
+    hello.port = rf::net_port;
+    hello.af_version = VERSION_STR;
+    hello.platform = platform_id();
+    hello.max_players =
+        static_cast<uint8_t>(std::clamp(rf::netgame.max_players, 0, 32));
+    push_event(std::move(hello));
+}
+
+// Returns the module to a clean slate so a second session in the same process (a
+// listen-server re-host, or a resume after a permanent 401) starts fresh. Does not
+// touch the worker thread; the worker is managed separately by on_shutdown.
+void reset_module_state()
+{
+    g_queue.clear();
+    g_pending.clear();
+    g_damage_accum.clear();
+    g_accuracy_accum.clear();
+    g_pending_gap = PendingGap{};
+    g_next_seq = 1;
+    g_next_batch = 1;
+    g_round = 1;
+    g_round_open = false;
+    g_any_round_started = false;
+    g_match_open = false;
+    g_pending_end_type.reset();
+    g_send_in_flight = false;
+    g_paused_401 = false;
+    g_paused_gssk.clear();
+    g_pulse_interval = k_pulse_interval;
+    g_session_started = false;
+    g_session_id.clear();
+    g_reannouncing = false;
+
+    // Per-player identity belongs to the session that minted it. Leaving keys behind
+    // would strand everyone still connected: on_player_join refuses to mint over an
+    // existing key, so a recovered session would carry rosters, kills and damage keyed
+    // to identities it never announced. Clearing them here makes the next session
+    // re-mint and re-announce (see reannounce_connected_players).
+    //
+    // afstats_pssk is deliberately kept: the client sends it once per join and will not
+    // resend, so dropping it would permanently downgrade a tracked player to untracked.
+    // The re-announce re-applies it through on_pssk_received instead.
+    for (rf::Player& player : SinglyLinkedList{rf::player_list}) {
+        player.afstats_key.clear();
+        player.afstats_round = AfstatsRoundCounters{};
+        player.afstats_leave_reason = -1;
+    }
+}
+
+// Re-establishes identity for everyone already connected when a session starts. Normally
+// a no-op (players are announced as they join); it does the work after a mid-session
+// teardown, where every key was cleared and nothing else would ever re-mint one.
+void reannounce_connected_players()
+{
+    // on_player_join -> on_status -> ensure_session can re-enter this. The
+    // g_session_started short-circuit in ensure_session already prevents it, but the
+    // guard keeps that from being a load-bearing detail of an unrelated function.
+    if (g_reannouncing) {
+        return;
+    }
+    g_reannouncing = true;
+    for (rf::Player& player : SinglyLinkedList{rf::player_list}) {
+        if (player.is_browser || !player.afstats_key.empty()) {
+            continue;
+        }
+        on_player_join(&player);
+        // Re-apply a PSSK this connection already delivered, so a player who was tracked
+        // before the teardown is tracked again rather than being stuck on the fresh UPSSK.
+        if (player.afstats_pssk) {
+            on_pssk_received(&player);
+        }
+    }
+    g_reannouncing = false;
+}
+
+// Starts the session lazily on the first event, so `server_hello` is always seq 1
+// and always carries a populated netgame.
+bool ensure_session()
+{
+    if (g_session_started) {
+        return true;
+    }
+    if (!emitting_enabled()) {
+        return false;
+    }
+    g_session_started = true;
+    ++g_session_generation;
+    g_session_id = mint_session_id();
+    g_process_start = std::chrono::steady_clock::now();
+    g_next_pulse = std::chrono::steady_clock::now() + k_pulse_interval;
+    if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+        xlog::warn("[afstats-ev] session {} started", g_session_id);
+    }
+    emit_server_hello();
+    reannounce_connected_players();
+    return true;
+}
+
+// -------------------------------------------------------------------------
+// round_start / round_end content
+// -------------------------------------------------------------------------
+
+std::vector<MutatorRecord> build_mutators()
+{
+    std::vector<MutatorRecord> out;
+    for (const MutatorDeclaration& decl : g_alpine_server_config_active_rules.mutators.declarations) {
+        MutatorRecord record;
+        // Mutator names, option keys, and string values are operator-authored config,
+        // so they go through sanitize_string like every other external string.
+        record.name = sanitize_string(decl.name, k_max_string_len);
+        for (const auto& [key, value] : decl.options) {
+            std::string clean_key = sanitize_string(key, k_max_string_len);
+            std::visit(
+                [&record, &clean_key](const auto& v) {
+                    using T = std::decay_t<decltype(v)>;
+                    if constexpr (std::is_same_v<T, bool>) {
+                        record.settings.emplace_back(clean_key, SettingValue{v});
+                    }
+                    else if constexpr (std::is_same_v<T, int32_t>) {
+                        record.settings.emplace_back(clean_key, SettingValue{static_cast<int64_t>(v)});
+                    }
+                    else if constexpr (std::is_same_v<T, float>) {
+                        record.settings.emplace_back(clean_key, SettingValue{static_cast<double>(v)});
+                    }
+                    else {
+                        record.settings.emplace_back(clean_key,
+                                                     SettingValue{sanitize_string(v, k_max_string_len)});
+                    }
+                },
+                value);
+        }
+        out.push_back(std::move(record));
+    }
+    return out;
+}
+
+std::vector<std::pair<std::string, SettingValue>> build_gametype_settings(rf::NetGameType type)
+{
+    const auto& rules = g_alpine_server_config_active_rules;
+    std::vector<std::pair<std::string, SettingValue>> out;
+    const auto add = [&out](const char* key, int64_t value) {
+        out.emplace_back(key, SettingValue{value});
+    };
+
+    switch (type) {
+        case rf::NG_TYPE_BAG:
+        case rf::NG_TYPE_TBAG:
+            add("score_tick_ms", bagman_get_score_tick_ms());
+            add("bag_return_time_ms", rules.bagman.bag_return_time_ms);
+            add("bag_spawn_delay_ms", rules.bagman.bag_spawn_delay_ms);
+            break;
+        case rf::NG_TYPE_SAL:
+            add("flag_spawn_delay_ms", rules.salvage.flag_spawn_delay_ms);
+            add("flag_capture_respawn_delay_ms", rules.salvage.flag_capture_respawn_delay_ms);
+            add("flag_return_time_ms", rules.salvage.flag_return_time_ms);
+            break;
+        case rf::NG_TYPE_CTF:
+            add("flag_return_time_ms", rules.ctf_flag_return_time_ms);
+            break;
+        case rf::NG_TYPE_KOTH:
+        case rf::NG_TYPE_DC:
+        case rf::NG_TYPE_REV:
+        case rf::NG_TYPE_ESC:
+            add("grow_rate", g_koth_info.rules.grow_rate);
+            add("drain_empty_rate", g_koth_info.rules.drain_empty_rate);
+            add("drain_defended_rate", g_koth_info.rules.drain_defended_rate);
+            add("ms_per_point", g_koth_info.rules.ms_per_point);
+            break;
+        case rf::NG_TYPE_PIT:
+        case rf::NG_TYPE_WO:
+            add("max_rounds", rules.rounds.max_rounds);
+            add("round_time_s", rules.rounds.round_time);
+            add("post_round_time_s", rules.rounds.post_round_time);
+            add("intermission_time_s", rules.rounds.intermission_time);
+            break;
+        default:
+            break;
+    }
+    return out;
+}
+
+uint8_t build_rf_flags()
+{
+    // Recomputed rather than read back from build_af_server_info_packet, which is
+    // not idempotent.
+    uint8_t flags = 0;
+    if (rf::netgame.flags & rf::NG_FLAG_WEAPON_STAY) {
+        flags |= rf_server_info_flags::RFSIF_WEAPON_STAY;
+    }
+    if (rf::netgame.flags & rf::NG_FLAG_FORCE_RESPAWN) {
+        flags |= rf_server_info_flags::RFSIF_FORCE_RESPAWN;
+    }
+    if (rf::netgame.flags & rf::NG_FLAG_TEAM_DAMAGE) {
+        flags |= rf_server_info_flags::RFSIF_TEAM_DAMAGE;
+    }
+    if (rf::netgame.flags & rf::NG_FLAG_FALL_DAMAGE) {
+        flags |= rf_server_info_flags::RFSIF_FALL_DAMAGE;
+    }
+    if (rf::netgame.flags & rf::NG_FLAG_BALANCE_TEAMS) {
+        flags |= rf_server_info_flags::RFSIF_BALANCE_TEAMS;
+    }
+    return flags;
+}
+
+void team_scores(rf::NetGameType type, int& red, int& blue)
+{
+    red = 0;
+    blue = 0;
+    switch (type) {
+        case rf::NG_TYPE_CTF:
+            red = rf::multi_ctf_get_red_team_score();
+            blue = rf::multi_ctf_get_blue_team_score();
+            break;
+        case rf::NG_TYPE_TEAMDM:
+            red = rf::multi_tdm_get_red_team_score();
+            blue = rf::multi_tdm_get_blue_team_score();
+            break;
+        case rf::NG_TYPE_KOTH:
+        case rf::NG_TYPE_DC:
+        case rf::NG_TYPE_REV:
+        case rf::NG_TYPE_ESC:
+            red = multi_koth_get_red_team_score();
+            blue = multi_koth_get_blue_team_score();
+            break;
+        case rf::NG_TYPE_SAL:
+            red = salvage_get_red_team_score();
+            blue = salvage_get_blue_team_score();
+            break;
+        case rf::NG_TYPE_BAG:
+        case rf::NG_TYPE_TBAG:
+            red = bagman_get_red_team_score();
+            blue = bagman_get_blue_team_score();
+            break;
+        case rf::NG_TYPE_WO:
+            red = wipeout_get_red_team_score();
+            blue = wipeout_get_blue_team_score();
+            break;
+        default:
+            break;
+    }
+}
+
+// The match system stores no winner, so it is derived the same way the endgame HUD
+// does: team scores in team types, top score otherwise. A tie reports no winner.
+void derive_winner(uint8_t& winner_team, rf::Player*& winner_player)
+{
+    winner_team = team_none;
+    winner_player = nullptr;
+
+    const auto game_type = rf::multi_get_game_type();
+    if (multi_is_team_game_type()) {
+        int red = 0;
+        int blue = 0;
+        team_scores(game_type, red, blue);
+        if (red > blue) {
+            winner_team = team_red;
+        }
+        else if (blue > red) {
+            winner_team = team_blue;
+        }
+        return;
+    }
+
+    int best = 0;
+    bool have_best = false;
+    bool tied = false;
+    for (rf::Player& player : SinglyLinkedList{rf::player_list}) {
+        if (player.is_browser || !player.stats || player.afstats_key.empty()) {
+            continue;
+        }
+        const int score = player.stats->score;
+        if (!have_best || score > best) {
+            best = score;
+            winner_player = &player;
+            have_best = true;
+            tied = false;
+        }
+        else if (score == best) {
+            tied = true;
+        }
+    }
+    if (tied) {
+        winner_player = nullptr;
+    }
+}
+
+void emit_round_end(RoundEndType end_type)
+{
+    // Aggregates belong to the round that is closing, not the one that follows.
+    flush_accumulators();
+
+    const auto game_type = rf::multi_get_game_type();
+
+    EvRoundEnd ev;
+    ev.end_type = static_cast<uint8_t>(end_type);
+    ev.duration_ms = static_cast<uint64_t>(std::max(rf::level.time, 0.0f) * 1000.0f);
+    ev.overtime = g_is_overtime;
+    team_scores(game_type, ev.red_score, ev.blue_score);
+    ev.players = build_roster(true);
+
+    if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+        xlog::warn("[afstats-ev] round {} ended ({}, {} ms, {} players)", g_round, ev.end_type,
+                   ev.duration_ms, ev.players.size());
+    }
+    push_event(std::move(ev));
+
+    g_round_open = false;
+    g_pending_end_type.reset();
+
+    // Build immediately at round end so the website can show finished
+    // rounds promptly instead of waiting out the pulse.
+    g_next_pulse = std::chrono::steady_clock::now();
+}
+
+// -------------------------------------------------------------------------
+// Console commands
+// -------------------------------------------------------------------------
+
+ConsoleCommand2 sv_afstats_events_status_cmd{
+    "sv_afstats_events_status",
+    []() {
+        if (!g_session_started) {
+            rf::console::print("AF stats event stream: not started ({})",
+                               fflink::afstats_server_enabled() ? "no events yet" : "stats not enabled");
+            return;
+        }
+        rf::console::print("AF stats event stream: session {}", g_session_id);
+        rf::console::print("  Round: {} ({})", g_round, g_round_open ? "open" : "closed");
+        rf::console::print("  Events emitted: {} (dropped {})", g_events_emitted, g_events_dropped);
+        rf::console::print("  Queue depth: {} / {}", g_queue.size(), k_max_queued_events);
+        rf::console::print("  Batches acked: {} (next batch number {})", g_batches_acked, g_next_batch);
+        if (g_pending.empty()) {
+            rf::console::print("  In flight: none");
+        }
+        else {
+            const auto& front = g_pending.front();
+            rf::console::print("  In flight: batch {} ({} events, {} attempts){}", front.batch,
+                               front.events.size(), front.attempts,
+                               g_pending.size() > 1
+                                   ? std::format(", {} more queued", g_pending.size() - 1)
+                                   : std::string{});
+        }
+        rf::console::print("  Last response: {}", g_last_response);
+        if (g_paused_401) {
+            rf::console::print("  Paused: waiting for a new session key after a 401");
+        }
+        const auto pulse_s = std::chrono::duration_cast<std::chrono::seconds>(g_pulse_interval).count();
+        rf::console::print("  Pulse: {}s, trace {}", pulse_s, g_trace ? "on" : "off");
+    },
+    "Show the status of the FactionFiles stats event stream.",
+};
+
+ConsoleCommand2 sv_afstats_trace_cmd{
+    "sv_afstats_trace",
+    [](std::optional<int> enabled) {
+        if (enabled) {
+            g_trace = *enabled != 0;
+        }
+        rf::console::print("AF stats event batch tracing is {}.", g_trace ? "enabled" : "disabled");
+    },
+    "Log the full JSON of every built stats batch.",
+    "sv_afstats_trace <0|1>",
+};
+
+} // namespace
+
+// -------------------------------------------------------------------------
+// Emission API
+// -------------------------------------------------------------------------
+
+void on_player_join(rf::Player* player)
+{
+    if (!player || player->is_browser) {
+        return; // browsers never join and never appear in the stream
+    }
+    if (!ensure_session()) {
+        return;
+    }
+    if (!player->afstats_key.empty()) {
+        return; // a resend of the join request must not mint a second key
+    }
+
+    player->afstats_key = mint_upssk();
+    reset_round_counters(player);
+    player->afstats_leave_reason = -1;
+
+    EvPlayerJoin ev;
+    ev.upssk = player->afstats_key;
+    ev.name = sanitize_string(player->name.c_str(), k_max_name_len);
+    ev.kind = player->is_bot ? k_join_kind_bot : k_join_kind_human;
+    ev.client = client_string(player);
+
+    if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+        // VERIFICATION PHASE ONLY: logs the session key verbatim, by explicit request.
+        // A UPSSK is a server-minted throwaway for an untracked player, not a client
+        // credential, but it is the identity the remediate line below pairs against.
+        xlog::warn("[afstats-ev] minted UPSSK {} for {} ({})", ev.upssk, ev.name,
+                   player->is_bot ? "bot" : "human");
+    }
+    push_event(std::move(ev));
+
+    // A player joining mid-round is in no round_start roster until the next one, so
+    // without this FF derives team=none for them. Team is finalized by the
+    // join flow before this runs; fire only for team gametypes, once per join.
+    if (multi_is_team_game_type()) {
+        on_status(player,
+                  player->team == rf::TEAM_BLUE ? StatusKind::team_blue : StatusKind::team_red);
+    }
+}
+
+void on_pssk_received(rf::Player* player)
+{
+    if (!player || !player->afstats_pssk || !ensure_session()) {
+        return;
+    }
+    const std::string& pssk = *player->afstats_pssk;
+    // First-write-wins: once remediated to a real PSSK, never overwrite it. A
+    // second, different PSSK for the same connection must not rewrite identity or
+    // leak a live key into the archived upssk field.
+    if (!player->afstats_key.empty() && !player->afstats_key.starts_with("u-")) {
+        return;
+    }
+    if (player->afstats_key == pssk) {
+        return; // duplicate delivery of a key we already report under
+    }
+    if (player->afstats_key.empty()) {
+        // No UPSSK to fold in (join predates the module being active); just adopt it.
+        player->afstats_key = pssk;
+        if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+            // VERIFICATION PHASE ONLY: logs the session key verbatim, by explicit request.
+            xlog::warn("[afstats-ev] adopted PSSK {} for {} with no prior key", pssk, player->name);
+        }
+        return;
+    }
+
+    // Ship everything accumulated under the UPSSK keyed by the UPSSK before the
+    // swap, so pre-remediation damage/accuracy attaches to the untracked identity and
+    // only later activity ships under the PSSK. Ordering: flush, emit, swap.
+    flush_accumulators();
+
+    EvPlayerRemediate ev;
+    ev.upssk = player->afstats_key;
+    ev.pssk = pssk;
+    if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+        // VERIFICATION PHASE ONLY: logs the session key verbatim, by explicit request.
+        xlog::warn("[afstats-ev] remediating {} : UPSSK {} -> PSSK {}", player->name, ev.upssk, ev.pssk);
+    }
+    push_event(std::move(ev));
+    player->afstats_key = pssk;
+}
+
+void note_leave_reason(rf::Player* player, LeaveReason reason)
+{
+    if (!emitting_enabled()) {
+        return; // never write the latch on a stats-disabled server
+    }
+    if (!player || player->afstats_leave_reason >= 0) {
+        return;
+    }
+    player->afstats_leave_reason = static_cast<int8_t>(reason);
+}
+
+void on_player_leave(rf::Player* player)
+{
+    if (!player || player->afstats_key.empty() || !g_session_started) {
+        return;
+    }
+
+    EvPlayerLeave ev;
+    // Nothing local marked this player: they went away without a left_game packet
+    // and without a kick this build initiated, which is a connection timeout.
+    ev.reason = player->afstats_leave_reason >= 0
+        ? static_cast<uint8_t>(player->afstats_leave_reason)
+        : static_cast<uint8_t>(LeaveReason::timeout);
+    ev.stats = build_roster_entry(player, true);
+
+    if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+        // Redacted, not marked: the key is incidental to a leave record and this fires for
+        // every disconnect, so a live PSSK would end up in the log of every server forever.
+        xlog::warn("[afstats-ev] {} left (reason {}), key {}", ev.stats.name, ev.reason,
+                   key_suffix(ev.stats.player));
+    }
+    push_event(std::move(ev));
+    player->afstats_key.clear();
+}
+
+void on_player_rename(rf::Player* player, const char* name)
+{
+    if (!player || !ensure_session() || player->afstats_key.empty()) {
+        return;
+    }
+    EvPlayerRename ev;
+    ev.player = player->afstats_key;
+    ev.name = sanitize_string(name ? name : "", k_max_name_len);
+    if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+        // Redacted: the key is incidental here, the name change is the subject.
+        xlog::warn("[afstats-ev] rename {} -> '{}'", key_suffix(ev.player), ev.name);
+    }
+    push_event(std::move(ev));
+}
+
+void on_round_start()
+{
+    if (!ensure_session()) {
+        return;
+    }
+    if (g_round_open) {
+        // A round that never reported an end (level reload during limbo, etc.).
+        emit_round_end(g_pending_end_type.value_or(RoundEndType::map_change_manual));
+    }
+    flush_accumulators();
+    if (g_any_round_started) {
+        ++g_round;
+    }
+    g_any_round_started = true;
+    g_round_open = true;
+    g_pending_end_type.reset();
+
+    for (rf::Player& player : SinglyLinkedList{rf::player_list}) {
+        if (!player.is_browser) {
+            reset_round_counters(&player);
+        }
+    }
+
+    const auto game_type = rf::multi_get_game_type();
+
+    EvRoundStart ev;
+    ev.tc_mod = rf::mod_param.found() ? sanitize_string(rf::mod_param.get_arg(), k_max_string_len)
+                                      : std::string{};
+    ev.level_file = sanitize_string(rf::level.filename.c_str(), k_max_string_len);
+    ev.level_name = sanitize_string(rf::level.name.c_str(), k_max_string_len);
+    ev.gametype = static_cast<uint8_t>(game_type);
+    ev.time_limit_s = rf::multi_time_limit > 0.0f ? static_cast<uint32_t>(rf::multi_time_limit) : 0;
+    ev.win_condition = g_alpine_server_config_active_rules.get_score_limit(game_type).value_or(0);
+    ev.overtime_enabled = g_alpine_server_config_active_rules.overtime.enabled;
+    // Computed fresh from config/state rather than read back from the cached
+    // server-info static, which is 0 until the first server-info packet is built:
+    // a dedicated server's first round_start can precede any such packet.
+    ev.af_flags = af_compute_server_info_flags();
+    ev.rf_flags = build_rf_flags();
+    ev.gi_flags = server_get_game_info_flags().game_info_flags_to_uint32();
+    // Always stamped, so warmup and match rounds are separable even when the
+    // match_start / match_end pair was lost to a gap.
+    ev.match_state = af_match_state_for_stats();
+    ev.mutators = build_mutators();
+    ev.gametype_settings = build_gametype_settings(game_type);
+    ev.roster = build_roster(false);
+
+    if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+        xlog::warn("[afstats-ev] round {} started: {} (gametype {}), {} players, {} mutators", g_round,
+                   ev.level_file, ev.gametype, ev.roster.size(), ev.mutators.size());
+    }
+    push_event(std::move(ev));
+}
+
+void note_round_end_type(RoundEndType end_type)
+{
+    if (!emitting_enabled()) {
+        return; // never write the latch on a stats-disabled server
+    }
+    if (!g_pending_end_type) {
+        g_pending_end_type = end_type;
+    }
+}
+
+void on_round_end()
+{
+    if (!g_session_started || !g_round_open) {
+        return;
+    }
+    emit_round_end(g_pending_end_type.value_or(RoundEndType::map_change_manual));
+}
+
+void on_kill(rf::Player* victim, rf::Player* killer, int weapon_type, int damage_type, uint8_t kill_flags,
+             const std::vector<uint8_t>& assist_player_ids, const rf::Vector3& victim_pos,
+             const rf::Vector3* killer_pos)
+{
+    if (!victim || !ensure_session() || victim->afstats_key.empty()) {
+        return;
+    }
+
+    EvKill ev;
+    ev.victim = victim->afstats_key;
+    if (killer) {
+        ev.killer = killer->afstats_key;
+    }
+    ev.weapon = weapon_type;
+    // The registry is uint8; anything outside it would fail FF-side validation, so
+    // an out-of-range engine value is reported as the unknown-damage sentinel.
+    ev.damage_type = (damage_type >= 0 && damage_type <= 0xFF) ? static_cast<uint8_t>(damage_type) : 0;
+    ev.flags = kill_flags;
+    ev.victim_pos = Vec3{victim_pos.x, victim_pos.y, victim_pos.z};
+    if (killer_pos) {
+        ev.has_killer_pos = true;
+        ev.killer_pos = Vec3{killer_pos->x, killer_pos->y, killer_pos->z};
+    }
+
+    for (uint8_t assist_id : assist_player_ids) {
+        rf::Player* assister = rf::multi_find_player_by_id(assist_id);
+        if (assister && !assister->afstats_key.empty()) {
+            ev.assists.push_back(assister->afstats_key);
+            ++assister->afstats_round.assists;
+        }
+    }
+
+    ++victim->afstats_round.deaths;
+    victim->afstats_round.current_streak = 0;
+    if (killer && killer != victim) {
+        auto& c = killer->afstats_round;
+        ++c.kills;
+        ++c.current_streak;
+        c.highest_streak = std::max(c.highest_streak, c.current_streak);
+    }
+
+    push_event(std::move(ev));
+}
+
+void on_spawn(rf::Player* player, const rf::Vector3& pos)
+{
+    if (!player || !ensure_session() || player->afstats_key.empty()) {
+        return;
+    }
+    EvSpawn ev;
+    ev.player = player->afstats_key;
+    ev.pos = Vec3{pos.x, pos.y, pos.z};
+    push_event(std::move(ev));
+}
+
+void on_damage(rf::Player* attacker, rf::Player* victim, int weapon_type, int damage_type, float amount,
+               bool direct_hit, bool headshot)
+{
+    if (!victim || amount <= 0.0f || !ensure_session() || victim->afstats_key.empty()) {
+        return;
+    }
+
+    // An attacker with no key is environmental as far as the stream is concerned. A view,
+    // not a copy: this function runs on every damage application and the string it would
+    // copy is longer than the small-string buffer. Both players outlive this call.
+    const std::string_view attacker_key = (attacker && !attacker->afstats_key.empty())
+        ? std::string_view{attacker->afstats_key}
+        : std::string_view{};
+    const uint8_t dt = (damage_type >= 0 && damage_type <= 0xFF) ? static_cast<uint8_t>(damage_type) : 0;
+
+    DamageAccum& acc =
+        damage_bucket(DamageKeyView{attacker_key, victim->afstats_key, weapon_type, dt});
+    acc.amount += amount;
+    ++acc.hits;
+
+    victim->afstats_round.damage_taken += amount;
+    // Count self-splash toward damage_dealt too: the stream emits a damage
+    // event for attacker==victim, and FF folds that into damage_dealt, so the summary
+    // counter must match or it diverges from the stream by exactly the self-damage.
+    // Keyed on attacker_key rather than the pointer so this matches the shots_hit guard
+    // below and the victim-side guard above: a player with no stats key never appears in
+    // a roster, so accumulating a summary for them can only ever be dead work.
+    if (!attacker_key.empty()) {
+        attacker->afstats_round.damage_dealt += amount;
+    }
+
+    // Only a direct projectile hit is an accuracy hit. Splash still
+    // counts toward `damage`, which is why this is not the same condition. `hit`
+    // counts damage-applications, so a projectile that damages two players counts
+    // twice; that is definitional, accuracy is only compared within a weapon.
+    if (direct_hit && weapon_type >= 0 && !attacker_key.empty()) {
+        AccuracyAccum& shots = accuracy_bucket(AccuracyKeyView{attacker_key, weapon_type});
+        ++shots.hit;
+        if (headshot) {
+            ++shots.hit_head;
+        }
+        ++attacker->afstats_round.shots_hit;
+    }
+}
+
+void on_weapon_fired(rf::Player* player, int weapon_type, uint32_t projectiles)
+{
+    if (!player || weapon_type < 0 || projectiles == 0 || !ensure_session()
+        || player->afstats_key.empty()) {
+        return;
+    }
+    accuracy_bucket(AccuracyKeyView{player->afstats_key, weapon_type}).fired += projectiles;
+    player->afstats_round.shots_fired += projectiles;
+}
+
+void on_status(rf::Player* player, StatusKind kind, int value)
+{
+    if (!player || !ensure_session() || player->afstats_key.empty()) {
+        return;
+    }
+    EvStatus ev;
+    ev.player = player->afstats_key;
+    ev.kind = static_cast<uint8_t>(kind);
+    if (kind == StatusKind::handicap) {
+        ev.has_value = true;
+        ev.value = value;
+    }
+    if (g_trace) {
+        xlog::warn("[afstats-ev] status kind {} for {}", ev.kind, player->name);
+    }
+    push_event(std::move(ev));
+}
+
+void on_item_pickup(rf::Player* player, int item_type, const rf::Vector3& pos, int respawn_ms)
+{
+    if (!player || !ensure_session() || player->afstats_key.empty()) {
+        return;
+    }
+    EvItemPickup ev;
+    ev.player = player->afstats_key;
+    ev.item = item_type;
+    ev.pos = Vec3{pos.x, pos.y, pos.z};
+    ev.respawn_ms = respawn_ms > 0 ? static_cast<uint32_t>(respawn_ms) : 0;
+    push_event(std::move(ev));
+}
+
+void on_flag_event(FlagEventKind kind, uint8_t team, rf::Player* player, const rf::Vector3& pos)
+{
+    if (!ensure_session()) {
+        return;
+    }
+    EvFlagEvent ev;
+    ev.kind = static_cast<uint8_t>(kind);
+    ev.team = team;
+    if (player && !player->afstats_key.empty()) {
+        ev.player = player->afstats_key;
+    }
+    ev.pos = Vec3{pos.x, pos.y, pos.z};
+    if (g_trace) {
+        xlog::warn("[afstats-ev] flag_event kind {} team {}", ev.kind, ev.team);
+    }
+    push_event(std::move(ev));
+}
+
+void on_point_event(int hill_uid, PointEventKind kind, uint8_t owner,
+                    const std::vector<rf::Player*>& credited, bool locked)
+{
+    if (!ensure_session()) {
+        return;
+    }
+    EvPointEvent ev;
+    ev.hill = static_cast<uint8_t>(std::clamp(hill_uid, 0, 255));
+    ev.kind = static_cast<uint8_t>(kind);
+    ev.owner = owner;
+    ev.locked = locked;
+    for (rf::Player* player : credited) {
+        if (player && !player->afstats_key.empty()) {
+            ev.players.push_back(player->afstats_key);
+        }
+    }
+    if (g_trace) {
+        xlog::warn("[afstats-ev] point_event hill {} kind {} owner {}", ev.hill, ev.kind, ev.owner);
+    }
+    push_event(std::move(ev));
+}
+
+void on_bagman_event(BagmanEventKind kind, rf::Player* player, const rf::Vector3& pos)
+{
+    if (!ensure_session()) {
+        return;
+    }
+    EvBagmanEvent ev;
+    ev.kind = static_cast<uint8_t>(kind);
+    if (player && !player->afstats_key.empty()) {
+        ev.player = player->afstats_key;
+    }
+    ev.pos = Vec3{pos.x, pos.y, pos.z};
+    if (g_trace) {
+        xlog::warn("[afstats-ev] bagman_event kind {}", ev.kind);
+    }
+    push_event(std::move(ev));
+}
+
+void on_bagman_pickup(rf::Player* player, const rf::Vector3& pos, BagmanFrom from)
+{
+    if (!ensure_session()) {
+        return;
+    }
+    EvBagmanEvent ev;
+    ev.kind = static_cast<uint8_t>(BagmanEventKind::pickup);
+    if (player && !player->afstats_key.empty()) {
+        ev.player = player->afstats_key;
+    }
+    ev.has_from = true;
+    ev.from = static_cast<uint8_t>(from);
+    ev.pos = Vec3{pos.x, pos.y, pos.z};
+    if (g_trace) {
+        xlog::warn("[afstats-ev] bagman_event pickup from {}", ev.from);
+    }
+    push_event(std::move(ev));
+}
+
+void on_gg_levelup(rf::Player* player, int level, int weapon_type)
+{
+    if (!player || !ensure_session() || player->afstats_key.empty()) {
+        return;
+    }
+    EvGgLevelup ev;
+    ev.player = player->afstats_key;
+    ev.level = static_cast<uint32_t>(std::max(level, 0));
+    ev.weapon = weapon_type;
+    if (g_trace) {
+        xlog::warn("[afstats-ev] gg_levelup {} to level {}", player->name, ev.level);
+    }
+    push_event(std::move(ev));
+}
+
+void on_match_start(int team_size, const std::vector<rf::Player*>& participants)
+{
+    if (!ensure_session()) {
+        return;
+    }
+    EvMatchStart ev;
+    ev.team_size = static_cast<uint32_t>(std::max(team_size, 0));
+    for (rf::Player* player : participants) {
+        if (player && !player->afstats_key.empty()) {
+            ev.participants.push_back(player->afstats_key);
+        }
+    }
+    g_match_open = true;
+    if (g_trace) {
+        xlog::warn("[afstats-ev] match_start {}v{} with {} participants", ev.team_size, ev.team_size,
+                   ev.participants.size());
+    }
+    push_event(std::move(ev));
+}
+
+void on_match_end(MatchResult result, uint8_t winner_team, rf::Player* winner_player)
+{
+    if (!ensure_session() || !g_match_open) {
+        return; // a cancel and the limbo that follows it both reach this
+    }
+    g_match_open = false;
+
+    EvMatchEnd ev;
+    ev.result = static_cast<uint8_t>(result);
+    ev.winner_team = winner_team;
+    if (winner_player && !winner_player->afstats_key.empty()) {
+        ev.winner_player = winner_player->afstats_key;
+    }
+    if (g_trace) {
+        xlog::warn("[afstats-ev] match_end result {} winner_team {}", ev.result, ev.winner_team);
+    }
+    push_event(std::move(ev));
+}
+
+void on_match_end_derived(MatchResult result)
+{
+    if (!ensure_session() || !g_match_open) {
+        return;
+    }
+    uint8_t winner_team = team_none;
+    rf::Player* winner_player = nullptr;
+    derive_winner(winner_team, winner_player);
+    on_match_end(result, winner_team, winner_player);
+}
+
+void on_vote_called(uint8_t vote_type, rf::Player* initiator, rf::Player* target, const char* detail)
+{
+    if (!ensure_session()) {
+        return;
+    }
+    EvVoteCalled ev;
+    ev.vote_type = vote_type;
+    if (initiator && !initiator->afstats_key.empty()) {
+        ev.initiator = initiator->afstats_key;
+    }
+    if (target && !target->afstats_key.empty()) {
+        ev.target = target->afstats_key;
+    }
+    if (detail) {
+        ev.detail = sanitize_string(detail, k_max_string_len);
+    }
+    if (g_trace) {
+        xlog::warn("[afstats-ev] vote_called type {} detail '{}'", ev.vote_type, ev.detail);
+    }
+    push_event(std::move(ev));
+}
+
+void on_vote_ended(uint8_t vote_type, uint8_t result, int yes, int no, int eligible)
+{
+    if (!ensure_session()) {
+        return;
+    }
+    EvVoteEnded ev;
+    ev.vote_type = vote_type;
+    ev.result = result;
+    ev.yes = static_cast<uint32_t>(std::max(yes, 0));
+    ev.no = static_cast<uint32_t>(std::max(no, 0));
+    ev.eligible = static_cast<uint32_t>(std::max(eligible, 0));
+    if (g_trace) {
+        xlog::warn("[afstats-ev] vote_ended type {} result {} ({} yes / {} no / {} eligible)",
+                   ev.vote_type, ev.result, ev.yes, ev.no, ev.eligible);
+    }
+    push_event(std::move(ev));
+}
+
+void on_geomod(const rf::Vector3& pos, float scale, bool rf2_style, rf::Player* shooter,
+               int weapon_type)
+{
+    if (!ensure_session()) {
+        return;
+    }
+    EvGeomod ev;
+    ev.pos = Vec3{pos.x, pos.y, pos.z};
+    ev.scale = scale;
+    ev.rf2_style = rf2_style;
+    if (shooter && !shooter->afstats_key.empty()) {
+        ev.player = shooter->afstats_key;
+    }
+    // The weapon is reported only alongside a resolved shooter.
+    ev.weapon = ev.player.empty() ? -1 : weapon_type;
+    if (g_trace) {
+        xlog::warn("[afstats-ev] geomod scale {:.1f} rf2 {}", ev.scale, ev.rf2_style);
+    }
+    push_event(std::move(ev));
+}
+
+void on_clutter_destroyed(rf::Clutter* clutter, int killer_handle, int weapon_type, int damage_type)
+{
+    if (!clutter || !ensure_session()) {
+        return;
+    }
+    EvClutterDestroyed ev;
+    // info_index -1 is an alpine mesh with no clutter.tbl type; report that as null.
+    if (clutter->info_index >= 0) {
+        ev.has_clutter_type = true;
+        ev.clutter_type = static_cast<uint32_t>(clutter->info_index);
+    }
+    // A runtime-spawned clutter carries a negative uid; only report a placed object's uid.
+    if (clutter->uid >= 0) {
+        ev.has_uid = true;
+        ev.uid = clutter->uid;
+    }
+    if (rf::Player* attacker = rf::player_from_entity_handle(killer_handle)) {
+        if (!attacker->afstats_key.empty()) {
+            ev.player = attacker->afstats_key;
+        }
+    }
+    // The weapon is reported only alongside a resolved attacker.
+    ev.weapon = ev.player.empty() ? -1 : weapon_type;
+    ev.damage_type = (damage_type >= 0 && damage_type <= 0xFF) ? static_cast<uint8_t>(damage_type) : 0;
+    ev.pos = Vec3{clutter->pos.x, clutter->pos.y, clutter->pos.z};
+    if (g_trace) {
+        xlog::warn("[afstats-ev] clutter_destroyed info_index {} uid {}", clutter->info_index,
+                   clutter->uid);
+    }
+    push_event(std::move(ev));
+}
+
+void on_detail_brush_destroyed(uint8_t material, int room_uid, int killer_handle, int weapon_type,
+                               int damage_type, const rf::Vector3& pos)
+{
+    if (!ensure_session()) {
+        return;
+    }
+    EvDetailBrushDestroyed ev;
+    ev.material = material;
+    if (room_uid >= 0) {
+        ev.has_room_uid = true;
+        ev.room_uid = room_uid;
+    }
+    if (rf::Player* attacker = rf::player_from_entity_handle(killer_handle)) {
+        if (!attacker->afstats_key.empty()) {
+            ev.player = attacker->afstats_key;
+        }
+    }
+    // The weapon is reported only alongside a resolved attacker.
+    ev.weapon = ev.player.empty() ? -1 : weapon_type;
+    ev.damage_type = (damage_type >= 0 && damage_type <= 0xFF) ? static_cast<uint8_t>(damage_type) : 0;
+    ev.pos = Vec3{pos.x, pos.y, pos.z};
+    if (g_trace) {
+        xlog::warn("[afstats-ev] detail_brush_destroyed material {} room_uid {}", ev.material,
+                   room_uid);
+    }
+    push_event(std::move(ev));
+}
+
+void do_patch()
+{
+    sv_afstats_events_status_cmd.register_cmd();
+    sv_afstats_trace_cmd.register_cmd();
+}
+
+namespace {
+
+void do_frame_impl()
+{
+    if (!g_session_started) {
+        return;
+    }
+
+    for (rf::Player& player : SinglyLinkedList{rf::player_list}) {
+        if (!player.is_browser && !player.afstats_key.empty()) {
+            sample_player_state(&player);
+        }
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+    const bool pulse_due = now >= g_next_pulse;
+    if (pulse_due) {
+        g_next_pulse = now + g_pulse_interval;
+        // Move the damage/accuracy accumulators into the live queue every pulse,
+        // even while a batch is in flight or the stream is paused, so they can't grow
+        // for a whole round and then dump thousands of events in one frame at its end.
+        flush_accumulators();
+    }
+
+    if (g_paused_401) {
+        // Only re-check the session key on the pulse, not every frame, so a long
+        // pause is not a per-frame get_gssk() mutex + string copy.
+        if (!pulse_due) {
+            return;
+        }
+        // A revoked or malformed GSK never yields a new GSSK, so stop the stream
+        // cleanly instead of caching forever. A genuinely new GSSK later restarts a
+        // fresh session through ensure_session().
+        const auto status = fflink::snapshot_state().status;
+        if (status == fflink::SessionStatus::rejected_by_server
+            || status == fflink::SessionStatus::bad_gsk_format) {
+            xlog::warn("[afstats-ev] session key permanently rejected; stopping the event stream");
+            reset_module_state();
+            return;
+        }
+        const std::string gssk = fflink::get_gssk();
+        if (gssk.empty() || gssk == g_paused_gssk) {
+            return; // the cache keeps filling while we wait for a new key
+        }
+        xlog::warn("[afstats-ev] a new session key arrived; resuming the stream");
+        g_paused_401 = false;
+        g_paused_gssk.clear();
+        g_next_pulse = now;
+        return;
+    }
+
+    if (g_send_in_flight) {
+        return;
+    }
+    if (!pulse_due) {
+        return;
+    }
+    pump();
+}
+
+void on_shutdown_impl()
+{
+    if (!g_session_started) {
+        return;
+    }
+
+    if (g_round_open) {
+        note_round_end_type(RoundEndType::server_shutdown);
+        emit_round_end(RoundEndType::server_shutdown);
+    }
+
+    // Tell the worker to stop; the final attempt runs inline so its timeouts, not a
+    // thread handshake, bound how long shutdown can take. g_worker_stop stays set
+    // through the flush below so a worker caught mid-post exits when it loops back.
+    {
+        std::lock_guard lock(g_worker_mutex);
+        g_worker_stop = true;
+        g_worker_job.reset();
+    }
+    g_worker_cv.notify_all();
+
+    if (g_pending.empty()) {
+        build_batch_from_queue();
+    }
+
+    const std::string gssk = g_pending.empty() ? std::string{} : fflink::get_gssk();
+    if (g_pending.empty()) {
+        if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+            xlog::warn("[afstats-ev] shutdown with nothing left to send");
+        }
+    }
+    else if (gssk.empty()) {
+        xlog::warn("[afstats-ev] shutdown with {} unsent events and no session key; discarding",
+                   g_queue.size() + g_pending.front().events.size());
+    }
+    else {
+        // A hard wall on the flush so multi_stop (and a listen-server host
+        // returning to menu) can't block. Event loss here is acceptable.
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(2000);
+        while (!g_pending.empty() && std::chrono::steady_clock::now() < deadline) {
+            PendingBatch& front = g_pending.front();
+            SendJob job{build_envelope(front, gssk), front.batch, g_session_generation};
+            if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+                xlog::warn("[afstats-ev] shutdown flush: sending batch {} ({} events)", front.batch,
+                           front.events.size());
+            }
+            const SendResult result =
+                do_one_post(job, k_shutdown_connect_timeout_ms, k_shutdown_receive_timeout_ms);
+            if (result.status != 200 || !result.ack_ok || result.ack_batch != front.batch) {
+                xlog::warn("[afstats-ev] shutdown flush failed ({}); {} events lost", result.detail,
+                           front.events.size());
+                break;
+            }
+            if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+                xlog::warn("[afstats-ev] shutdown flush: batch {} acked", front.batch);
+            }
+            g_pending.pop_front();
+            if (g_pending.empty()) {
+                build_batch_from_queue();
+            }
+        }
+    }
+
+    // Full reset so a second session in this process starts clean, and let the
+    // worker respawn next session. g_worker_stop deliberately stays SET here: a worker
+    // blocked in a post can outlive the bounded flush window above, and clearing the
+    // flag now would let it loop back, see no stop, and park as a second live consumer.
+    // ensure_worker_started clears it under the mutex when it claims the next
+    // generation, which is also what retires any predecessor.
+    reset_module_state();
+    {
+        std::lock_guard lock(g_worker_mutex);
+        g_worker_job.reset();
+    }
+    g_worker_started = false;
+}
+
+} // namespace
+
+void do_frame()
+{
+    // The pulse runs inside the stock frame loop, so a stats exception is
+    // swallowed at the module boundary, never unwound into rf_do_frame_hook. This and
+    // on_shutdown are deliberately the module's only firewalls: they wrap the JSON
+    // serialization, which is the one part that genuinely throws. The emission entry
+    // points are held to the same no-throw-by-construction standard as the rest of the
+    // hook code rather than being blanketed in try/catch.
+    try {
+        do_frame_impl();
+    }
+    catch (const std::exception& e) {
+        xlog::warn("[afstats-ev] swallowed exception in do_frame: {}", e.what());
+    }
+    catch (...) {
+        xlog::warn("[afstats-ev] swallowed unknown exception in do_frame");
+    }
+}
+
+void on_shutdown()
+{
+    try {
+        on_shutdown_impl();
+    }
+    catch (const std::exception& e) {
+        xlog::warn("[afstats-ev] swallowed exception in on_shutdown: {}", e.what());
+    }
+    catch (...) {
+        xlog::warn("[afstats-ev] swallowed unknown exception in on_shutdown");
+    }
+}
+
+} // namespace afstats

--- a/game_patch/fflink/afstats_events.cpp
+++ b/game_patch/fflink/afstats_events.cpp
@@ -1485,7 +1485,11 @@ SendResult do_one_post(const SendJob& job, unsigned long connect_timeout_ms, uns
             if (j.contains("ok") && j["ok"].is_boolean() && j["ok"].get<bool>()
                 && j.contains("batch") && j["batch"].is_number_integer()) {
                 const auto acked = j["batch"].get<int64_t>();
-                if (acked >= 0) {
+                // Reject out-of-range batch numbers before the uint32 cast: a value above
+                // UINT32_MAX would wrap and could alias a live batch number, discarding that
+                // batch as acked. A well-formed ack always fits, so this only rejects
+                // malformed/hostile input.
+                if (acked >= 0 && acked <= static_cast<int64_t>(UINT32_MAX)) {
                     out.ack_ok = true;
                     out.ack_batch = static_cast<uint32_t>(acked);
                 }
@@ -2722,7 +2726,11 @@ void on_match_end_derived(MatchResult result)
 
 void on_subround_start(const std::vector<rf::Player*>& participants)
 {
-    if (!ensure_session()) {
+    // A subround only exists inside an open game round. If the game round is closed
+    // (e.g. the session was torn down and lazily restarted mid-game, so on_round_start
+    // has not run since), suppress it: otherwise this subround_start would never be
+    // paired with a close, since emit_round_end only fires while g_round_open is true.
+    if (!ensure_session() || !g_round_open) {
         return;
     }
     // A prior subround that never saw its end still holds the latch (a level change

--- a/game_patch/fflink/afstats_events.h
+++ b/game_patch/fflink/afstats_events.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string_view>
 #include <vector>
 
 namespace rf
@@ -131,8 +132,10 @@ void note_leave_reason(rf::Player* player, LeaveReason reason);
 void on_player_leave(rf::Player* player);
 
 // The server processed a name change for this player. Emits `player_rename` with
-// the finalized name; call after the stock handler has applied it.
-void on_player_rename(rf::Player* player, const char* name);
+// the finalized name; call after the stock handler has applied it. `prev_name` is the
+// name the player held before this change (what the stream last reported): an unchanged
+// name emits nothing, and successive changes are rate-floored.
+void on_player_rename(rf::Player* player, const char* name, std::string_view prev_name);
 
 // A level finished loading server-side. Emits `round_start`.
 void on_round_start();

--- a/game_patch/fflink/afstats_events.h
+++ b/game_patch/fflink/afstats_events.h
@@ -99,6 +99,14 @@ enum class MatchResult : uint8_t
     canceled = 1,
 };
 
+// Wire values from the subround_end `result` registry.
+enum class SubroundResult : uint8_t
+{
+    completed = 0, // decided (a winner_team or winner_player is set)
+    draw = 1,      // ran to completion with no winner (double wipe, timeout tie, mutual death)
+    canceled = 2,  // ended without a decided contest (level change, or abandoned before it could start)
+};
+
 // Wire values from the round_start `match_state` registry. Stamped on every
 // round_start so warmup play is distinguishable from match play at round
 // granularity, without depending on the (gap-lossy) match_start/match_end pair.
@@ -201,6 +209,13 @@ void on_match_end(MatchResult result, uint8_t winner_team, rf::Player* winner_pl
 // Same, for the ready-up match system, which stores no winner: the winning team or
 // top-scoring player is derived from the live scores at the call site.
 void on_match_end_derived(MatchResult result);
+
+// Subround system: a traditional round driven by rounds.cpp (a Pit duel, a Wipeout
+// round). Nested inside a game (round_*). Numbering is 1-based and restarts each game.
+void on_subround_start(const std::vector<rf::Player*>& participants);
+// `winner_team` is the team registry (team_none when not applicable) and
+// `winner_player` is set only for duel-style subrounds.
+void on_subround_end(SubroundResult result, uint8_t winner_team, rf::Player* winner_player);
 
 // Vote lifecycle. `vote_type` and `result` are the wire-frozen AfVoteType /
 // AfVoteResult values and go out verbatim. `vote_type` is repeated on `vote_ended`

--- a/game_patch/fflink/afstats_events.h
+++ b/game_patch/fflink/afstats_events.h
@@ -1,0 +1,248 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace rf
+{
+    struct Player;
+    struct Vector3;
+    struct Clutter;
+}
+
+// Server-side event reporting to FactionFiles.
+// Layer 1 (this header) is the emission API gameplay hooks call. Every entry
+// point is a no-op unless this process is a multiplayer server with FactionFiles
+// stats enabled, so call sites never need to gate themselves. Events may queue
+// before the GSK -> GSSK exchange completes; nothing transmits until a GSSK
+// exists.
+namespace afstats {
+
+// Wire values from the round_end `end_type` registry.
+enum class RoundEndType : uint8_t
+{
+    time_limit = 0,
+    score_limit = 1,
+    map_change_manual = 2,
+    map_change_vote = 3,
+    level_logic = 4,
+    server_shutdown = 5,
+};
+
+// Wire values from the player_leave `reason` registry.
+enum class LeaveReason : uint8_t
+{
+    quit = 0,
+    kicked = 1,
+    banned = 2,
+    timeout = 3,
+    vote_kicked = 4,
+};
+
+// Wire values from the status `kind` registry.
+enum class StatusKind : uint8_t
+{
+    team_red = 0,
+    team_blue = 1,
+    spec_start = 2,
+    spec_stop = 3,
+    idle_start = 4,
+    idle_stop = 5,
+    participate_start = 6,
+    participate_stop = 7,
+    handicap = 8, // carries the new percent as `value`
+};
+
+// Wire values from the flag_event `kind` registry.
+enum class FlagEventKind : uint8_t
+{
+    steal = 0,
+    pickup = 1,
+    capture = 2,
+    drop_death = 3,
+    drop_manual = 4,
+    return_touch = 5,
+    return_timeout = 6,
+    reset = 7,
+};
+
+// Wire values from the point_event `kind` registry.
+enum class PointEventKind : uint8_t
+{
+    owner_change = 0,
+    contest_start = 1,
+    contest_end = 2,
+    lock_change = 3,
+};
+
+// Wire values from the bagman_event `kind` registry.
+enum class BagmanEventKind : uint8_t
+{
+    available = 0,
+    pickup = 1,
+    drop = 2,
+    ret = 3, // "return" on the wire; the keyword is taken
+};
+
+// bagman_event `from`, pickup only.
+enum class BagmanFrom : uint8_t
+{
+    spawn = 0,
+    dropped = 1,
+};
+
+// Wire values from the match_end `result` registry.
+enum class MatchResult : uint8_t
+{
+    completed = 0,
+    canceled = 1,
+};
+
+// Wire values from the round_start `match_state` registry. Stamped on every
+// round_start so warmup play is distinguishable from match play at round
+// granularity, without depending on the (gap-lossy) match_start/match_end pair.
+enum class MatchState : uint8_t
+{
+    none = 0,
+    pre_match = 1,
+    match_active = 2,
+};
+
+// The `team` registry. 0 and 1 are the engine's own values.
+constexpr uint8_t team_red = 0;
+constexpr uint8_t team_blue = 1;
+constexpr uint8_t team_none = 2;
+
+// Server-side join is complete and the player's identity fields are populated.
+// Mints the player's UPSSK and emits `player_join`. Browsers are ignored; bots
+// are reported with kind "bot".
+void on_player_join(rf::Player* player);
+
+// The client delivered its real PSSK. Emits `player_remediate` and swaps the
+// player's stats key when the delivered key differs from the current one.
+void on_pssk_received(rf::Player* player);
+
+// Record why a player is about to leave. First writer wins, so tag the specific
+// reason before the generic kick path runs.
+void note_leave_reason(rf::Player* player, LeaveReason reason);
+
+// The player is being torn down. Must run while PlayerAdditionalData is still
+// alive; emits `player_leave` with the partial-round summary.
+void on_player_leave(rf::Player* player);
+
+// The server processed a name change for this player. Emits `player_rename` with
+// the finalized name; call after the stock handler has applied it.
+void on_player_rename(rf::Player* player, const char* name);
+
+// A level finished loading server-side. Emits `round_start`.
+void on_round_start();
+
+// Record why the current round is ending. First writer wins; consumed and reset
+// by on_round_end(). Without a call the round is reported as a manual change.
+void note_round_end_type(RoundEndType end_type);
+
+// The server entered limbo, i.e. the round is over. Emits `round_end`.
+void on_round_end();
+
+// A lethal blow landed. Arguments mirror what the af_kill_info path already
+// computed: `weapon_type` < 0 and a null `killer` are reported as JSON null,
+// `kill_flags` is the af_kill_info_flags bitfield and goes on the wire verbatim,
+// and `assist_player_ids` is the attribution list in most-recent-first order.
+void on_kill(rf::Player* victim, rf::Player* killer, int weapon_type, int damage_type,
+             uint8_t kill_flags, const std::vector<uint8_t>& assist_player_ids,
+             const rf::Vector3& victim_pos, const rf::Vector3* killer_pos);
+
+// A player spawned server-side.
+void on_spawn(rf::Player* player, const rf::Vector3& pos);
+
+// Damage was applied to a player. Feeds the windowed `damage` aggregate and, when
+// `direct_hit` is set, the `hit`/`hit_head` side of the `accuracy` aggregate --
+// splash contributes damage but is never a projectile hit. A null
+// `attacker` is environmental. `amount` is effective post-armor damage.
+void on_damage(rf::Player* attacker, rf::Player* victim, int weapon_type, int damage_type,
+               float amount, bool direct_hit, bool headshot);
+
+// A player pulled a trigger. `projectiles` is the shot's projectile count from the
+// weapon table, so pellet weapons account exactly.
+void on_weapon_fired(rf::Player* player, int weapon_type, uint32_t projectiles);
+
+// Out-of-band player state change. `value` is only read for
+// StatusKind::handicap.
+void on_status(rf::Player* player, StatusKind kind, int value = 0);
+
+// A player picked an item up server-side. `respawn_ms` is 0 when it never respawns.
+void on_item_pickup(rf::Player* player, int item_type, const rf::Vector3& pos, int respawn_ms);
+
+// CTF flag / Salvage object transition. `player` may be null (timeout, reset);
+// `team` is the flag's own team, or team_none for Salvage's neutral object.
+void on_flag_event(FlagEventKind kind, uint8_t team, rf::Player* player, const rf::Vector3& pos);
+
+// KOTH capture-point transition. `players` are the keys credited on an owner
+// change and empty otherwise.
+void on_point_event(int hill_uid, PointEventKind kind, uint8_t owner,
+                    const std::vector<rf::Player*>& credited, bool locked);
+
+// Bagman bag transition. `player` is the carrier for a pickup and the previous
+// carrier for a drop; null for available and return.
+void on_bagman_event(BagmanEventKind kind, rf::Player* player, const rf::Vector3& pos);
+void on_bagman_pickup(rf::Player* player, const rf::Vector3& pos, BagmanFrom from);
+
+// GunGame progression.
+void on_gg_levelup(rf::Player* player, int level, int weapon_type);
+
+// Ready-up match system, including Pit duels.
+void on_match_start(int team_size, const std::vector<rf::Player*>& participants);
+// `winner_team` is the team registry (team_none when not applicable) and
+// `winner_player` is set only for duel-style matches.
+void on_match_end(MatchResult result, uint8_t winner_team, rf::Player* winner_player);
+// Same, for the ready-up match system, which stores no winner: the winning team or
+// top-scoring player is derived from the live scores at the call site.
+void on_match_end_derived(MatchResult result);
+
+// Vote lifecycle. `vote_type` and `result` are the wire-frozen AfVoteType /
+// AfVoteResult values and go out verbatim. `vote_type` is repeated on `vote_ended`
+// so an outcome is typed without pairing to its call.
+void on_vote_called(uint8_t vote_type, rf::Player* initiator, rf::Player* target,
+                    const char* detail);
+void on_vote_ended(uint8_t vote_type, uint8_t result, int yes, int no, int eligible);
+
+// World / destruction events. Both are server-side only.
+
+// A terrain carve happened -- classic geomod or the Alpine 1.3 brush-based kind,
+// selected by `rf2_style`. `scale` is the carve radius in world units. `shooter` and
+// `weapon_type` are best-effort attribution: a null `shooter` (chain reaction, level
+// logic, environmental) and a `weapon_type` < 0 are reported as JSON null, and the
+// weapon is nulled whenever the shooter is.
+void on_geomod(const rf::Vector3& pos, float scale, bool rf2_style, rf::Player* shooter,
+               int weapon_type);
+
+// A destructible clutter prop was killed. `killer_handle` is the lethal blow's
+// responsible entity, resolved to the attacking player (null = world/environmental);
+// `weapon_type` < 0 and a null attacker are reported as JSON null. `damage_type` is the
+// registry value. clutter_type (the clutter.tbl info_index) and the level uid
+// are read off the object and reported as null when it carries none (info_index -1 for
+// an alpine mesh, a negative uid for a runtime-spawned object).
+void on_clutter_destroyed(rf::Clutter* clutter, int killer_handle, int weapon_type,
+                          int damage_type);
+
+// A breakable detail brush (level geometry -- stock RF's destructible glass, extended by
+// Alpine to several materials) shattered. `material` is the rf::DetailMaterial registry
+// value and is the point of the event. `room_uid` is the detail room's uid,
+// reported as null when negative. `killer_handle` is the lethal blow's responsible entity,
+// resolved to the attacking player (null = world/environmental); `weapon_type` < 0 and a
+// null attacker are reported as JSON null. `damage_type` is the registry value.
+void on_detail_brush_destroyed(uint8_t material, int room_uid, int killer_handle,
+                               int weapon_type, int damage_type, const rf::Vector3& pos);
+
+// Register console commands. Called from fflink::do_patch().
+void do_patch();
+
+// Sender pulse. Called from fflink::do_frame().
+void do_frame();
+
+// Clean shutdown: close any open round and make one bounded attempt to flush.
+// Never blocks for more than about two seconds, and there is no delivery
+// guarantee.
+void on_shutdown();
+
+} // namespace afstats

--- a/game_patch/fflink/fflink.cpp
+++ b/game_patch/fflink/fflink.cpp
@@ -1,3 +1,4 @@
+#include "afstats_client.h"
 #include "fflink.h"
 #include "fflink_session.h"
 #include "fflink_utils.h"
@@ -7,6 +8,7 @@ namespace fflink {
 void do_patch()
 {
     session_do_patch();
+    afstats_do_patch();
 }
 
 void do_frame()

--- a/game_patch/fflink/fflink.cpp
+++ b/game_patch/fflink/fflink.cpp
@@ -1,4 +1,5 @@
 #include "afstats_client.h"
+#include "afstats_events.h"
 #include "fflink.h"
 #include "fflink_session.h"
 #include "fflink_utils.h"
@@ -8,13 +9,15 @@ namespace fflink {
 void do_patch()
 {
     session_do_patch();
-    afstats_do_patch();
+    afstats_client_do_patch();  // client-side: PSSK handshake + afstats_status cmd
+    afstats::do_patch();        // server-side: event sender
 }
 
 void do_frame()
 {
     drain_pending_main_thread_tasks();
     drain_pending_console();
+    afstats::do_frame();
 }
 
 } // namespace fflink

--- a/game_patch/fflink/fflink_session.cpp
+++ b/game_patch/fflink/fflink_session.cpp
@@ -15,10 +15,13 @@
 #include <xlog/xlog.h>
 
 #include <common/HttpRequest.h>
+#include <common/utils/list-utils.h>
 #include <common/version/version.h>
 
 #include "../multi/server_internal.h"
 #include "../os/console.h"
+#include "../rf/multi.h"
+#include "../rf/player/player.h"
 #include "fflink_utils.h"
 
 namespace fflink {
@@ -39,41 +42,6 @@ std::mutex g_state_mutex;
 SessionState g_state;
 std::string g_gssk; // protected by g_state_mutex
 std::atomic<bool> g_exchange_in_flight{false};
-
-bool is_lower_hex_char(char c)
-{
-    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
-}
-
-bool is_valid_gsk_format(std::string_view gsk)
-{
-    if (gsk.size() != 32) {
-        return false;
-    }
-    for (char c : gsk) {
-        if (!is_lower_hex_char(c)) {
-            return false;
-        }
-    }
-    return true;
-}
-
-bool is_valid_gssk_format(std::string_view gssk)
-{
-    if (gssk.size() != 32) {
-        return false;
-    }
-    for (char c : gssk) {
-        const bool ok =
-            (c >= '0' && c <= '9') ||
-            (c >= 'a' && c <= 'z') ||
-            (c >= 'A' && c <= 'Z');
-        if (!ok) {
-            return false;
-        }
-    }
-    return true;
-}
 
 void set_state(SessionStatus status, int server_id, std::string_view error_msg, std::string_view gssk)
 {
@@ -174,7 +142,7 @@ ExchangeOutcome do_one_exchange(const std::string& gsk)
             auto j = nlohmann::json::parse(response);
             auto gssk = j.at("gssk").get<std::string>();
             const auto server_id = j.at("server_id").get<int>();
-            if (!is_valid_gssk_format(gssk)) {
+            if (!is_valid_stats_key_format(gssk)) {
                 throw std::runtime_error("gssk has invalid format");
             }
             out.kind = ExchangeOutcome::Kind::success;
@@ -227,8 +195,7 @@ void exchange_worker_impl(const std::string& gsk)
             xlog::info("[fflink] session established (server_id={})", outcome.server_id);
             set_state(SessionStatus::valid, outcome.server_id, "", outcome.gssk);
             enqueue_console_line(std::format(
-                "FactionFiles session established (server id {}, gssk={}).",
-                outcome.server_id, outcome.gssk));
+                "FactionFiles session established (server id {}).", outcome.server_id));
             g_exchange_in_flight.store(false, std::memory_order_release);
             return;
         }
@@ -350,6 +317,18 @@ std::string get_gssk()
     return g_gssk;
 }
 
+bool afstats_server_enabled()
+{
+    const auto& cfg = g_alpine_server_config;
+    if (cfg.fflink_gsk.empty() || !is_valid_gsk_format(cfg.fflink_gsk)) {
+        return false;
+    }
+    // Deliberately not "session valid": the exchange lands seconds after launch and
+    // may lapse during an FF outage, and a PSSK held across either is still useful.
+    const auto status = snapshot_state().status;
+    return status != SessionStatus::bad_gsk_format && status != SessionStatus::rejected_by_server;
+}
+
 namespace {
 
 const char* status_to_str(SessionStatus s)
@@ -375,6 +354,15 @@ ConsoleCommand2 sv_fflink_status_cmd{
         }
         if (!state.last_error.empty()) {
             rf::console::print("  Last error: {}", state.last_error);
+        }
+        if (rf::is_multi && rf::is_server) {
+            int with_pssk = 0;
+            for (const rf::Player& player : SinglyLinkedList{rf::player_list}) {
+                if (player.afstats_pssk) {
+                    ++with_pssk;
+                }
+            }
+            rf::console::print("  Connected players with a stats session key: {}", with_pssk);
         }
     },
     "Show the current FactionFiles server session link status.",

--- a/game_patch/fflink/fflink_session.cpp
+++ b/game_patch/fflink/fflink_session.cpp
@@ -38,6 +38,12 @@ constexpr unsigned long k_receive_timeout_ms = 3000;
 // Backoff schedule for transient failures (seconds). After the last entry, entries continue using the last delay.
 constexpr int k_backoff_schedule_s[] = {5, 30, 120};
 
+// The session response is a small JSON object; cap the read so a broken or hostile
+// endpoint can't stream unbounded data into memory. Mirrors the cap the events and
+// player-stats clients already enforce. Past the cap the read throws and is classified
+// as a transient error, so the exchange simply retries.
+constexpr size_t k_max_response_bytes = 256 * 1024;
+
 std::mutex g_state_mutex;
 SessionState g_state;
 std::string g_gssk; // protected by g_state_mutex
@@ -94,7 +100,14 @@ ExchangeOutcome do_one_exchange(const std::string& gsk)
 
         char buf[1024];
         std::ostringstream stream;
+        size_t total = 0;
         while (size_t n = req.read(buf, sizeof(buf))) {
+            total += n;
+            if (total > k_max_response_bytes) {
+                // The per-read receive timeout bounds how long any one read blocks; this
+                // byte cap bounds the total so a slow trickle can't grow unbounded either.
+                throw std::runtime_error("response exceeded size cap");
+            }
             stream.write(buf, n);
         }
         response = stream.str();
@@ -113,7 +126,8 @@ ExchangeOutcome do_one_exchange(const std::string& gsk)
         const std::string response_preview = sanitize_for_log(
             response.size() <= k_log_response_prefix
                 ? std::string_view{response}
-                : std::string_view{response}.substr(0, k_log_response_prefix));
+                : std::string_view{response}.substr(0, k_log_response_prefix),
+            k_log_response_prefix);
         const char* truncated = response.size() > k_log_response_prefix ? "...[truncated]" : "";
         xlog::info("[fflink] response body: {}{}", response_preview, truncated);
     };

--- a/game_patch/fflink/fflink_session.h
+++ b/game_patch/fflink/fflink_session.h
@@ -34,6 +34,10 @@ SessionState snapshot_state();
 // The returned string is a copy; the GSSK must never be persisted to disk.
 std::string get_gssk();
 
+// True when this server should advertise itself as stats-enabled and accept PSSKs:
+// a well-formed GSK is configured and FactionFiles has not hard-rejected it.
+bool afstats_server_enabled();
+
 // Register console commands and any other one-time setup for the session subsystem.
 // Called from fflink::do_patch().
 void session_do_patch();

--- a/game_patch/fflink/fflink_utils.cpp
+++ b/game_patch/fflink/fflink_utils.cpp
@@ -1,5 +1,6 @@
 #include "fflink_utils.h"
 
+#include <algorithm>
 #include <mutex>
 #include <utility>
 #include <vector>
@@ -72,16 +73,40 @@ void drain_pending_main_thread_tasks()
     }
 }
 
-std::string sanitize_for_log(std::string_view in)
+std::string sanitize_for_log(std::string_view in, size_t max_len)
 {
     std::string out;
-    out.reserve(in.size());
+    out.reserve(std::min(in.size(), max_len));
     for (unsigned char c : in) {
+        if (out.size() >= max_len) {
+            break;
+        }
         if (c < 0x20 || c == 0x7F) {
             out.push_back('.');
         }
         else {
             out.push_back(static_cast<char>(c));
+        }
+    }
+    // Only when the cap actually truncated the input: don't leave a partial UTF-8
+    // sequence dangling at the boundary. C0/DEL are the only bytes rewritten above and
+    // they are all single-byte, so high bytes survive verbatim and this walk is exact.
+    if (out.size() == max_len && in.size() > max_len) {
+        size_t i = out.size();
+        while (i > 0 && (static_cast<unsigned char>(out[i - 1]) & 0xC0) == 0x80) {
+            --i; // step back over continuation bytes (10xxxxxx)
+        }
+        if (i > 0) {
+            const unsigned char lead = static_cast<unsigned char>(out[i - 1]);
+            size_t seq_len = 0;
+            if (lead < 0x80) seq_len = 1;
+            else if ((lead & 0xE0) == 0xC0) seq_len = 2;
+            else if ((lead & 0xF0) == 0xE0) seq_len = 3;
+            else if ((lead & 0xF8) == 0xF0) seq_len = 4;
+            const size_t have = out.size() - (i - 1);
+            if (seq_len == 0 || have < seq_len) {
+                out.resize(i - 1); // drop the incomplete (or invalid) trailing sequence
+            }
         }
     }
     return out;

--- a/game_patch/fflink/fflink_utils.cpp
+++ b/game_patch/fflink/fflink_utils.cpp
@@ -18,6 +18,11 @@ std::vector<std::string> g_pending_console_lines;
 std::mutex g_pending_tasks_mutex;
 std::vector<std::function<void()>> g_pending_tasks;
 
+bool is_lower_hex_char(char c)
+{
+    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
+}
+
 } // namespace
 
 void enqueue_console_line(std::string line)
@@ -80,6 +85,36 @@ std::string sanitize_for_log(std::string_view in)
         }
     }
     return out;
+}
+
+bool is_valid_gsk_format(std::string_view gsk)
+{
+    if (gsk.size() != 32) {
+        return false;
+    }
+    for (char c : gsk) {
+        if (!is_lower_hex_char(c)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool is_valid_stats_key_format(std::string_view key)
+{
+    if (key.size() != 32) {
+        return false;
+    }
+    for (char c : key) {
+        const bool ok =
+            (c >= '0' && c <= '9') ||
+            (c >= 'a' && c <= 'z') ||
+            (c >= 'A' && c <= 'Z');
+        if (!ok) {
+            return false;
+        }
+    }
+    return true;
 }
 
 } // namespace fflink

--- a/game_patch/fflink/fflink_utils.h
+++ b/game_patch/fflink/fflink_utils.h
@@ -18,8 +18,11 @@ void enqueue_main_thread_task(std::function<void()> task);
 // Drain and run any pending main-thread tasks. MUST be called from the main thread.
 void drain_pending_main_thread_tasks();
 
-// Sanitize response strings before logging
-std::string sanitize_for_log(std::string_view in);
+// Sanitize response strings before logging. Replaces C0 controls and DEL, and hard
+// caps the result at max_len bytes so a network-sourced string can never be copied
+// unbounded into a log line or the fixed-size engine console ring. Truncation stops on
+// a UTF-8 sequence boundary so a multibyte codepoint is never left half-copied.
+std::string sanitize_for_log(std::string_view in, size_t max_len = 200);
 
 // GSK format: exactly 32 lowercase hex chars.
 bool is_valid_gsk_format(std::string_view gsk);

--- a/game_patch/fflink/fflink_utils.h
+++ b/game_patch/fflink/fflink_utils.h
@@ -21,4 +21,11 @@ void drain_pending_main_thread_tasks();
 // Sanitize response strings before logging
 std::string sanitize_for_log(std::string_view in);
 
+// GSK format: exactly 32 lowercase hex chars.
+bool is_valid_gsk_format(std::string_view gsk);
+
+// Session/stats key format: exactly 32 alphanumeric chars. Shared by the GSSK,
+// the player stats key (PSK) and the player stats session key (PSSK).
+bool is_valid_stats_key_format(std::string_view key);
+
 } // namespace fflink

--- a/game_patch/misc/destruction.cpp
+++ b/game_patch/misc/destruction.cpp
@@ -28,6 +28,8 @@
 #include "../rf/player/player.h"
 #include "../rf/player/camera.h"
 #include "../os/console.h"
+#include "../fflink/afstats_events.h"
+#include "../fflink/fflink_session.h"
 #include "destruction.h"
 #include "level.h"
 #include "../sound/sound_foley.h"
@@ -225,6 +227,35 @@ BreakableMaterialState* get_material_state(rf::DetailMaterial mat)
 static rf::DetailMaterial g_breaking_material = rf::DetailMaterial::Glass;
 static rf::GRoom* g_breaking_room = nullptr;
 static bool g_breaking_from_explosion = false;
+
+// Best-effort attribution for the current detail-brush break, for the stats stream.
+// Set at the damage entry points -- exactly where g_breaking_from_explosion is -- and
+// read once at the server-side break commit (glass_sound). A damage-driven break
+// is synchronous within the damage call tree, so `capture_tick` (GetTickCount64, the same
+// source s_last_vfx_tick uses) stamped at the damage entry equals the tick at the commit.
+// The commit only trusts the attribution when the ticks match: a break that is NOT
+// damage-driven this frame (level logic reaching glass_sound directly, or a stale capture
+// from an earlier near-miss whose validate_destroy failed) reads a mismatched tick and is
+// reported with null attribution -- wrong attribution is worse than null. Reset on level load.
+struct BreakAttribution
+{
+    int killer_handle = -1;   // responsible entity handle; resolved to a player, null if not
+    int weapon_type = -1;     // TC-mod weapon id, or -1 when not in scope (radius path)
+    int damage_type = -1;     // stats registry value, or -1 (unknown)
+    uint64_t capture_tick = 0; // GetTickCount64 at the damage entry; break commit must match
+};
+static BreakAttribution g_break_attr;
+
+// The single predicate for both the capture sites and the commit site. Keeping them
+// identical is what makes the capture side safe to skip: when this is false nothing is
+// stamped, but nothing reads it either, and if it flips to true later the stale
+// capture_tick can no longer match so the first break is simply reported anonymously.
+// Gating the captures keeps the feature a strict no-op on a stats-disabled host and in
+// single player, where apply_radius_damage runs on every explosion.
+static bool afstats_break_attr_enabled()
+{
+    return rf::is_server && fflink::afstats_server_enabled();
+}
 
 // Per-room dedup: prevents multiple projectiles from creating effects on the same room
 // in the same frame (e.g., pistol creating two weapon entities per shot).
@@ -848,6 +879,7 @@ void reset_breakable_material_state()
     g_breaking_material = rf::DetailMaterial::Glass;
     g_breaking_room = nullptr;
     g_breaking_from_explosion = false;
+    g_break_attr = BreakAttribution{};
     s_last_vfx_room = nullptr;
     s_last_vfx_tick = 0;
     g_current_radius_damage_type = -1;
@@ -932,11 +964,22 @@ CodeInjection validate_destroy_vertex_count_fix{
     },
 };
 
-// Capture damage_type at entry of apply_radius_damage (0x00488dc0).
+// Capture damage_type at entry of apply_radius_damage (0x00488dc0). Also stashes the
+// radius blow's killer_handle and damage_type for the stats stream: the room
+// break happens deeper in this call (room_apply_radius_damage -> glass_kill) with neither
+// in scope. Stack: SUB ESP,0x18 has run but the four register pushes at 0x00488ded have
+// not, so the cdecl args killer_handle (arg 4) and damage_type (arg 5) sit at esp+0x28 and
+// esp+0x2C. The radius path carries no weapon type, so that stays null.
 CodeInjection capture_damage_type_injection{
     0x00488ded,
     [](auto& regs) {
         g_current_radius_damage_type = *reinterpret_cast<int*>(regs.esp + 0x2C);
+        if (afstats_break_attr_enabled()) {
+            g_break_attr.killer_handle = *reinterpret_cast<int*>(regs.esp + 0x28);
+            g_break_attr.weapon_type = -1;
+            g_break_attr.damage_type = g_current_radius_damage_type;
+            g_break_attr.capture_tick = GetTickCount64();
+        }
     },
 };
 
@@ -1822,10 +1865,33 @@ CodeInjection glass_kill_material_injection{
 CodeInjection glass_sound_entry_injection{
     0x00490c00,
     [](auto& regs) {
+        auto* pos = *reinterpret_cast<rf::Vector3**>(regs.esp + 4);
+
+        // Stats stream: one detail_brush_destroyed per committed break, for
+        // EVERY material (glass included). glass_sound is the sole point both break paths
+        // reach, and only after validate_destroy has succeeded, so it fires exactly once
+        // per kill. Server-side only: a client applying a received glass_kill packet also
+        // runs glass_sound, so gating on the deciding server avoids emitting the broadcast
+        // twice. material is g_breaking_material; the room uid and best-effort attribution
+        // come from the globals finalized above. Read before the non-glass shatter below,
+        // which frees the room's faces. on_detail_brush_destroyed self-gates on a
+        // stats-enabled server.
+        if (afstats_break_attr_enabled() && g_breaking_room && pos) {
+            // Trust the stashed attribution only when its damage entry landed on THIS tick:
+            // a break not driven by damage this frame (level logic reaching glass_sound, or a
+            // stale capture from an earlier near-miss) would otherwise inherit whoever last
+            // damaged glass. Wrong attribution is worse than null, so a tick mismatch reports
+            // the break as anonymous. material and room_uid are always fresh, so they stand.
+            const bool fresh = g_break_attr.capture_tick == GetTickCount64();
+            afstats::on_detail_brush_destroyed(
+                static_cast<uint8_t>(g_breaking_material), g_breaking_room->uid,
+                fresh ? g_break_attr.killer_handle : -1, fresh ? g_break_attr.weapon_type : -1,
+                fresh ? g_break_attr.damage_type : -1, *pos);
+        }
+
         auto* mat_cfg = get_material_config(g_breaking_material);
         if (mat_cfg && g_breaking_room) {
             auto* mat_state = get_material_state(g_breaking_material);
-            auto* pos = *reinterpret_cast<rf::Vector3**>(regs.esp + 4);
 
             // Send glass_kill packet before face extraction frees the original faces
             if (rf::is_multi && rf::is_server) {
@@ -1868,6 +1934,16 @@ CodeInjection glass_decal_material_injection{
         // Check if the projectile's weapon type has a damage radius > 0.
         auto* weapon = reinterpret_cast<rf::Weapon*>(static_cast<void*>(regs.esi));
         g_breaking_from_explosion = (weapon && weapon->info && weapon->info->damage_radius > 0.0f);
+
+        // Stash direct-hit attribution for the stats stream: the shooter is the
+        // projectile's parent entity, and the weapon and its damage type come off the
+        // weapon info. Consumed at the server-side break commit (glass_sound).
+        if (weapon && afstats_break_attr_enabled()) {
+            g_break_attr.killer_handle = weapon->parent_handle;
+            g_break_attr.weapon_type = weapon->info_index;
+            g_break_attr.damage_type = weapon->info ? weapon->info->damage_type : -1;
+            g_break_attr.capture_tick = GetTickCount64();
+        }
 
         if (room->material_type != rf::DetailMaterial::Glass) {
             auto* proj = reinterpret_cast<uint8_t*>(static_cast<void*>(regs.esi));
@@ -2561,6 +2637,27 @@ FunHook<bool(float, int, rf::GRoom*, rf::Vector3*, rf::Vector3*, int, int)> geom
         g_rf2_suppress_geomod_create_effects = false;
         rf::g_geomod_emitter_default_idx = saved_default_emitter;
         rf::g_geomod_emitter_driller_idx = saved_driller_emitter;
+
+        // Stats stream: one geomod event per confirmed carve, on both the
+        // classic and rf2-brush paths. geomod_create is the sole caller of the queue and
+        // returns early for MP clients, so this is a server-side-only choke point with no
+        // double-emit against the geomod broadcast. Attribution is best-effort: the source
+        // handle is a weapon whose parent is the shooter entity and whose info_index is the
+        // weapon type; other callers (level logic, etc.) fall back to null.
+        if (result && pos) {
+            rf::Player* shooter = nullptr;
+            int weapon_type = -1;
+            if (rf::Object* src = rf::obj_from_handle(parent_handle)) {
+                if (src->type == rf::OT_WEAPON) {
+                    weapon_type = static_cast<rf::Weapon*>(src)->info_index;
+                    shooter = rf::player_from_entity_handle(src->parent_handle);
+                }
+                else {
+                    shooter = rf::player_from_entity_handle(parent_handle);
+                }
+            }
+            afstats::on_geomod(*pos, radius, is_rf2_geomod, shooter, weapon_type);
+        }
 
         if (is_rf2_geomod) {
             rf::g_num_geomods_this_level = saved_crater_count;

--- a/game_patch/misc/misc.cpp
+++ b/game_patch/misc/misc.cpp
@@ -234,7 +234,7 @@ FunHook<void()> multi_after_players_packet_hook{
         multi_after_players_packet_hook.call_target();
         g_in_mp_game = true;
         mp_send_handicap_request(false);
-        fflink::afstats_on_entered_game();
+        fflink::afstats_client_on_entered_game();
     },
 };
 

--- a/game_patch/misc/misc.cpp
+++ b/game_patch/misc/misc.cpp
@@ -34,6 +34,7 @@
 #include "../rf/level.h"
 #include "../rf/file/file.h"
 #include "../object/object.h"
+#include "../fflink/afstats_client.h"
 #include "waypoints.h"
 
 void achievements_apply_patch();
@@ -233,6 +234,7 @@ FunHook<void()> multi_after_players_packet_hook{
         multi_after_players_packet_hook.call_target();
         g_in_mp_game = true;
         mp_send_handicap_request(false);
+        fflink::afstats_on_entered_game();
     },
 };
 

--- a/game_patch/misc/player.cpp
+++ b/game_patch/misc/player.cpp
@@ -33,6 +33,7 @@
 #include "../hud/hud_internal.h"
 #include "../hud/hud.h"
 #include "../multi/alpine_packets.h"
+#include "../fflink/afstats_events.h"
 #include "../hud/hud_world.h"
 #include <common/utils/list-utils.h>
 #include <common/version/version.h>
@@ -269,6 +270,9 @@ FunHook<void(rf::Player*)> player_destroy_hook{
         pit_on_player_disconnect(player);
         gungame_on_player_disconnect(player);
         if (rf::is_server) {
+            // Must run while PlayerAdditionalData is still alive, since the leave
+            // event carries the player's partial-round summary.
+            afstats::on_player_leave(player);
             remove_ready_player_silent(player);
             server_vote_on_player_leave(player);
             if (player->is_bot) {

--- a/game_patch/multi/alpine_packets.cpp
+++ b/game_patch/multi/alpine_packets.cpp
@@ -47,6 +47,8 @@
 #include "../misc/misc.h"
 #include "../purefaction/pf_packets.h"
 #include "../os/os.h"
+#include "../fflink/fflink_session.h"
+#include "../fflink/fflink_utils.h"
 
 void af_send_packet(rf::Player* player, const void* data, int len, bool is_reliable)
 {
@@ -644,6 +646,13 @@ void serialize_payload(const JetpackStateReqPayload& payload, std::byte* buf, si
     buf[offset++] = static_cast<std::byte>(payload.on);
 }
 
+// af_req_stats_pssk
+void serialize_payload(const StatsPsskPayload& payload, std::byte* buf, size_t& offset)
+{
+    std::memcpy(buf + offset, payload.pssk, sizeof(payload.pssk));
+    offset += sizeof(payload.pssk);
+}
+
 // af_sreq_ready_prompt
 void serialize_payload(const ReadyPromptPayload& payload, std::byte* buf, size_t& offset)
 {
@@ -836,6 +845,29 @@ void af_send_jetpack_state_request(bool on)
     packet.header.size = sizeof(uint8_t) + sizeof(JetpackStateReqPayload);
     packet.req_type = af_client_req_type::af_req_jetpack_state;
     packet.payload = JetpackStateReqPayload{static_cast<uint8_t>(on ? 1 : 0)};
+
+    af_send_client_req_packet(packet, true); // reliable
+}
+
+// Hand the server the FactionFiles session key that authorizes it to report this
+// player's stats. Minted per join, so it is only ever sent once per connection.
+void af_send_stats_pssk(const std::string& pssk)
+{
+    if (!rf::is_multi || rf::is_server) {
+        return;
+    }
+
+    StatsPsskPayload payload{};
+    if (pssk.size() != sizeof(payload.pssk)) {
+        return;
+    }
+    std::memcpy(payload.pssk, pssk.data(), sizeof(payload.pssk));
+
+    af_client_req_packet packet{};
+    packet.header.type = static_cast<uint8_t>(af_packet_type::af_client_req);
+    packet.header.size = sizeof(uint8_t) + sizeof(StatsPsskPayload);
+    packet.req_type = af_client_req_type::af_req_stats_pssk;
+    packet.payload = payload;
 
     af_send_client_req_packet(packet, true); // reliable
 }
@@ -1597,6 +1629,33 @@ static void af_process_client_req_packet(const void* data, size_t len, const rf:
             if (gt_is_pit()) {
                 pit_handle_queue_request(player, action);
             }
+            break;
+        }
+        case af_client_req_type::af_req_stats_pssk: {
+            if (player->is_browser) {
+                xlog::warn("[afstats] dropping PSSK from a browser ({})", player->name);
+                return;
+            }
+            if (!fflink::afstats_server_enabled()) {
+                xlog::warn("[afstats] dropping PSSK from {}: stats are not enabled on this server",
+                           player->name);
+                return;
+            }
+            if (remaining < sizeof(StatsPsskPayload)) {
+                xlog::warn("[afstats] PSSK payload from {} too short ({} < {})", player->name, remaining,
+                           sizeof(StatsPsskPayload));
+                return;
+            }
+            const std::string_view pssk{reinterpret_cast<const char*>(bytes + offset), sizeof(StatsPsskPayload)};
+            if (!fflink::is_valid_stats_key_format(pssk)) {
+                xlog::warn("[afstats] malformed PSSK from {}", player->name);
+                return;
+            }
+            const bool replacing = player->afstats_pssk.has_value();
+            player->afstats_pssk = std::string{pssk};
+            // VERIFICATION PHASE ONLY: logs the session key verbatim, by explicit request.
+            xlog::warn("[afstats] received PSSK {} from {}{}", pssk, player->name,
+                       replacing ? " (replacing a previous one)" : "");
             break;
         }
         case af_client_req_type::af_req_vote_call: {

--- a/game_patch/multi/alpine_packets.cpp
+++ b/game_patch/multi/alpine_packets.cpp
@@ -47,6 +47,8 @@
 #include "../misc/misc.h"
 #include "../purefaction/pf_packets.h"
 #include "../os/os.h"
+#include "../fflink/afstats_client.h"
+#include "../fflink/afstats_events.h"
 #include "../fflink/fflink_session.h"
 #include "../fflink/fflink_utils.h"
 
@@ -1651,11 +1653,29 @@ static void af_process_client_req_packet(const void* data, size_t len, const rf:
                 xlog::warn("[afstats] malformed PSSK from {}", player->name);
                 return;
             }
-            const bool replacing = player->afstats_pssk.has_value();
+            // First-write-wins, ahead of everything else: a PSSK is minted per join and
+            // delivered once, so a second key on the same connection has no legitimate
+            // meaning. Rejecting before the store closes the identity-rewrite hole on
+            // afstats_pssk the same way on_pssk_received closes it on afstats_key, and
+            // rejecting before the log means a client cannot drive log volume at all.
+            // Dropped silently on purpose: a resend is normal and must not warn.
+            if (player->afstats_pssk.has_value()) {
+                break;
+            }
+            // Floor the delivery rate so a client cannot flood the pre-store window.
+            // Dropped silently: no per-packet warn.
+            constexpr int64_t k_pssk_min_interval_ms = 1000;
+            const int64_t now_ms = timer::get_i64(1000);
+            if (player->last_pssk_ms && now_ms - *player->last_pssk_ms < k_pssk_min_interval_ms) {
+                return;
+            }
+            player->last_pssk_ms = now_ms;
             player->afstats_pssk = std::string{pssk};
-            // VERIFICATION PHASE ONLY: logs the session key verbatim, by explicit request.
-            xlog::warn("[afstats] received PSSK {} from {}{}", pssk, player->name,
-                       replacing ? " (replacing a previous one)" : "");
+            if constexpr (AFSTATS_VERIFICATION_LOGGING) {
+                // VERIFICATION PHASE ONLY: logs the session key verbatim, by explicit request.
+                xlog::warn("[afstats] received PSSK {} from {}", pssk, player->name);
+            }
+            afstats::on_pssk_received(player);
             break;
         }
         case af_client_req_type::af_req_vote_call: {
@@ -3382,27 +3402,12 @@ void af_reset_session_overrides_snapshot()
     g_session_overrides_snapshot.clear();
 }
 
-static void build_af_server_info_packet(af_server_info_packet& pkt)
+// The stable server-info AF flags, computed fresh from config/state with no side
+// effects. build_af_server_info_packet ORs in the transient SIF_SERVER_CFG_CHANGED
+// signal separately; the stats round_start snapshot reads this pure value so its
+// af_flags never lag the cached-packet static.
+uint32_t af_compute_server_info_flags()
 {
-    pkt = {};
-    pkt.header.type = static_cast<uint8_t>(af_packet_type::af_server_info);
-    pkt.header.size = static_cast<uint16_t>(sizeof(af_server_info_packet) - sizeof(RF_GamePacketHeader));
-
-    // build rf_flags
-    uint32_t rf32 = 0;
-    if (rf::netgame.flags & rf::NetGameFlags::NG_FLAG_WEAPON_STAY)
-        rf32 |= static_cast<uint32_t>(rf_server_info_flags::RFSIF_WEAPON_STAY);
-    if (rf::netgame.flags & rf::NetGameFlags::NG_FLAG_FORCE_RESPAWN)
-        rf32 |= static_cast<uint32_t>(rf_server_info_flags::RFSIF_FORCE_RESPAWN);
-    if (rf::netgame.flags & rf::NetGameFlags::NG_FLAG_TEAM_DAMAGE)
-        rf32 |= static_cast<uint32_t>(rf_server_info_flags::RFSIF_TEAM_DAMAGE);
-    if (rf::netgame.flags & rf::NetGameFlags::NG_FLAG_FALL_DAMAGE)
-        rf32 |= static_cast<uint32_t>(rf_server_info_flags::RFSIF_FALL_DAMAGE);
-    if (rf::netgame.flags & rf::NetGameFlags::NG_FLAG_BALANCE_TEAMS)
-        rf32 |= static_cast<uint32_t>(rf_server_info_flags::RFSIF_BALANCE_TEAMS);
-    pkt.rf_flags = static_cast<uint8_t>(rf32);
-
-    // build af_flags
     uint32_t af = 0;
     if (g_alpine_server_config_active_rules.saving_enabled)
         af |= af_server_info_flags::SIF_POSITION_SAVING;
@@ -3457,6 +3462,32 @@ static void build_af_server_info_packet(af_server_info_packet& pkt)
         af |= af_server_info_flags::SIF_DODGING;
     if (g_alpine_server_config_active_rules.mutators.pogo_enabled)
         af |= af_server_info_flags::SIF_POGO;
+    return af;
+}
+
+static void build_af_server_info_packet(af_server_info_packet& pkt)
+{
+    pkt = {};
+    pkt.header.type = static_cast<uint8_t>(af_packet_type::af_server_info);
+    pkt.header.size = static_cast<uint16_t>(sizeof(af_server_info_packet) - sizeof(RF_GamePacketHeader));
+
+    // build rf_flags
+    uint32_t rf32 = 0;
+    if (rf::netgame.flags & rf::NetGameFlags::NG_FLAG_WEAPON_STAY)
+        rf32 |= static_cast<uint32_t>(rf_server_info_flags::RFSIF_WEAPON_STAY);
+    if (rf::netgame.flags & rf::NetGameFlags::NG_FLAG_FORCE_RESPAWN)
+        rf32 |= static_cast<uint32_t>(rf_server_info_flags::RFSIF_FORCE_RESPAWN);
+    if (rf::netgame.flags & rf::NetGameFlags::NG_FLAG_TEAM_DAMAGE)
+        rf32 |= static_cast<uint32_t>(rf_server_info_flags::RFSIF_TEAM_DAMAGE);
+    if (rf::netgame.flags & rf::NetGameFlags::NG_FLAG_FALL_DAMAGE)
+        rf32 |= static_cast<uint32_t>(rf_server_info_flags::RFSIF_FALL_DAMAGE);
+    if (rf::netgame.flags & rf::NetGameFlags::NG_FLAG_BALANCE_TEAMS)
+        rf32 |= static_cast<uint32_t>(rf_server_info_flags::RFSIF_BALANCE_TEAMS);
+    pkt.rf_flags = static_cast<uint8_t>(rf32);
+
+    // build af_flags (stable bits factored out so the stats snapshot can compute
+    // them fresh without the SIF_SERVER_CFG_CHANGED side effect below)
+    uint32_t af = af_compute_server_info_flags();
     // Must stay immediately ahead of the signal_cfg_changed check below, which
     // consumes the flag this sets.
     {
@@ -3784,6 +3815,7 @@ void af_process_spectate_start_packet(
     }
 
     spectator->spectatee = then_some(in_spectate, new_target);
+    const bool was_spectator = spectator->is_spectator;
     if (!spectator->is_spectator && in_spectate) {
         spectator->spectate_start_time = std::chrono::steady_clock::now();
     }
@@ -3791,6 +3823,11 @@ void af_process_spectate_start_packet(
         spectator->spectate_start_time = std::nullopt;
     }
     spectator->is_spectator = in_spectate;
+    // Only the edge: a spectator retargeting sends this packet too.
+    if (was_spectator != in_spectate) {
+        afstats::on_status(spectator, in_spectate ? afstats::StatusKind::spec_start
+                                                  : afstats::StatusKind::spec_stop);
+    }
 }
 
 void af_send_spectate_notify_packet(

--- a/game_patch/multi/alpine_packets.cpp
+++ b/game_patch/multi/alpine_packets.cpp
@@ -1634,23 +1634,47 @@ static void af_process_client_req_packet(const void* data, size_t len, const rf:
             break;
         }
         case af_client_req_type::af_req_stats_pssk: {
+            constexpr int64_t k_pssk_min_interval_ms = 1000;
+            const int64_t now_ms = timer::get_i64(1000);
+            // Every rejection below is reachable once per packet, so the warns get their
+            // own per-player floor: the first-write-wins check and the delivery rate floor
+            // further down are both too late to stop a client from driving log volume.
+            // A throttled warn still drops the packet, it just goes unlogged. The floor
+            // is tracked separately from last_pssk_ms so a rejected packet can never
+            // delay the one good PSSK a join is allowed to deliver.
+            const auto warn_throttle_open = [&]() {
+                if (player->last_pssk_warn_ms
+                    && now_ms - *player->last_pssk_warn_ms < k_pssk_min_interval_ms) {
+                    return false;
+                }
+                player->last_pssk_warn_ms = now_ms;
+                return true;
+            };
             if (player->is_browser) {
-                xlog::warn("[afstats] dropping PSSK from a browser ({})", player->name);
+                if (warn_throttle_open()) {
+                    xlog::warn("[afstats] dropping PSSK from a browser ({})", player->name);
+                }
                 return;
             }
             if (!fflink::afstats_server_enabled()) {
-                xlog::warn("[afstats] dropping PSSK from {}: stats are not enabled on this server",
-                           player->name);
+                if (warn_throttle_open()) {
+                    xlog::warn("[afstats] dropping PSSK from {}: stats are not enabled on this server",
+                               player->name);
+                }
                 return;
             }
             if (remaining < sizeof(StatsPsskPayload)) {
-                xlog::warn("[afstats] PSSK payload from {} too short ({} < {})", player->name, remaining,
-                           sizeof(StatsPsskPayload));
+                if (warn_throttle_open()) {
+                    xlog::warn("[afstats] PSSK payload from {} too short ({} < {})", player->name,
+                               remaining, sizeof(StatsPsskPayload));
+                }
                 return;
             }
             const std::string_view pssk{reinterpret_cast<const char*>(bytes + offset), sizeof(StatsPsskPayload)};
             if (!fflink::is_valid_stats_key_format(pssk)) {
-                xlog::warn("[afstats] malformed PSSK from {}", player->name);
+                if (warn_throttle_open()) {
+                    xlog::warn("[afstats] malformed PSSK from {}", player->name);
+                }
                 return;
             }
             // First-write-wins, ahead of everything else: a PSSK is minted per join and
@@ -1664,8 +1688,6 @@ static void af_process_client_req_packet(const void* data, size_t len, const rf:
             }
             // Floor the delivery rate so a client cannot flood the pre-store window.
             // Dropped silently: no per-packet warn.
-            constexpr int64_t k_pssk_min_interval_ms = 1000;
-            const int64_t now_ms = timer::get_i64(1000);
             if (player->last_pssk_ms && now_ms - *player->last_pssk_ms < k_pssk_min_interval_ms) {
                 return;
             }

--- a/game_patch/multi/alpine_packets.h
+++ b/game_patch/multi/alpine_packets.h
@@ -94,6 +94,7 @@ enum class af_client_req_type : uint8_t
     af_req_vote_cancel = 0x8,  // Alpine 1.4 (no additional data)
     af_req_vote_options = 0x9, // Alpine 1.4 (5 bytes: flags + known_generation)
     af_req_jetpack_state = 0xA, // Alpine 1.4 (1 byte: on 0/1)
+    af_req_stats_pssk = 0xB,    // Alpine 1.4 (32 bytes: player stats session key, no NUL)
 };
 
 // Frozen wire constants, values can NEVER be reordered or changed.
@@ -270,9 +271,18 @@ struct JetpackStateReqPayload
     uint8_t on = 0;
 };
 
+// The player stats session key minted by FactionFiles for this join, handed to the
+// server so it can report this player's stats. Raw, not NUL terminated.
+struct StatsPsskPayload
+{
+    char pssk[32] = {};
+};
+static_assert(sizeof(StatsPsskPayload) == 32);
+
 using af_client_payload = std::variant<HandicapPayload, SprayReqPayload, CharacterPayload,
                                        ReadyReqPayload, PitQueueReqPayload, VoteCastReqPayload,
-                                       VoteOptionsReqPayload, JetpackStateReqPayload, std::monostate>;
+                                       VoteOptionsReqPayload, JetpackStateReqPayload,
+                                       StatsPsskPayload, std::monostate>;
 
 struct af_client_req_packet
 {
@@ -843,6 +853,7 @@ void af_send_server_cfg_request();
 void af_send_spray_request(uint16_t texture_id, const rf::Vector3& pos, const rf::Vector3& normal);
 void af_send_ready_request(uint8_t action);      // 0 = unready, 1 = ready, 2 = toggle
 void af_send_pit_queue_request(uint8_t action);  // 0 = leave, 1 = join, 2 = toggle
+void af_send_stats_pssk(const std::string& pssk);
 
 // vote system (client -> server)
 void af_send_vote_call(const AfVoteCallParams& params);

--- a/game_patch/multi/alpine_packets.h
+++ b/game_patch/multi/alpine_packets.h
@@ -824,6 +824,7 @@ void af_send_just_died_info_packet(rf::Player* to_player, bool respawn_allowed, 
 static void af_process_just_died_info_packet(const void* data, size_t len, const rf::NetAddr& addr);
 void af_send_server_info_packet(rf::Player* player);
 void af_send_server_info_packet_to_all();
+uint32_t af_compute_server_info_flags();
 void af_reset_session_overrides_snapshot();
 static void af_process_server_info_packet(const void* data, size_t len, const rf::NetAddr&);
 void af_send_spectate_start_packet(const rf::Player* spectatee);

--- a/game_patch/multi/bagman.cpp
+++ b/game_patch/multi/bagman.cpp
@@ -17,6 +17,7 @@
 #include "server.h"
 #include "server_internal.h"
 #include "alpine_packets.h"
+#include "../fflink/afstats_events.h"
 #include "../rf/multi.h"
 #include "../rf/item.h"
 #include "../rf/entity.h"
@@ -315,7 +316,12 @@ void bagman_broadcast_state()
     af_send_bagman_state_packet_to_all();
 }
 
-int bagman_get_red_team_score() 
+int bagman_get_score_tick_ms()
+{
+    return kScoreTickMs;
+}
+
+int bagman_get_red_team_score()
 {
     return g_bagman_info.red_team_score;
 }
@@ -422,6 +428,7 @@ static rf::Player* find_player_with_bag_powerup()
 static void on_pickup(rf::Player* player)
 {
     rf::Entity* ep = alive_entity_for(player);
+    const BagState state_before = g_bagman_info.state;
 
     g_bagman_info.carrier = player;
     g_bagman_info.state = BagState::BS_Carried;
@@ -435,6 +442,9 @@ static void on_pickup(rf::Player* player)
     rf::multi_powerup_add(player, kPowerupTypeAmp, kCarrierAmpDurationMs);
 
     announce(std::format("{} has the bag!", player->name.c_str()));
+    afstats::on_bagman_pickup(player, g_bagman_info.bag_pos,
+        state_before == BagState::BS_Dropped ? afstats::BagmanFrom::dropped
+                                             : afstats::BagmanFrom::spawn);
     bagman_broadcast_state();
 }
 
@@ -445,6 +455,7 @@ static void drop_bag_at_position(rf::Player* prev_carrier, const rf::Vector3& dr
     g_bagman_info.state = BagState::BS_Dropped;
     g_bagman_info.bag_pos = drop_pos;
     g_bagman_info.return_timer.set(g_alpine_server_config_active_rules.bagman.bag_return_time_ms);
+    afstats::on_bagman_event(afstats::BagmanEventKind::drop, prev_carrier, drop_pos);
 
     if (prev_carrier) {
         rf::multi_powerup_remove(prev_carrier, kPowerupTypeAmp);
@@ -481,6 +492,7 @@ static void drop_bag_from_entity(rf::Player* prev_carrier, rf::Entity* ep)
     rf::Vector3 drop_pos = ep ? ep->pos : g_bagman_info.bag_pos;
     rf::Matrix3 drop_orient = ep ? ep->orient : g_bagman_info.spawn_orient;
     spawn_bag_item(drop_pos, drop_orient);
+    afstats::on_bagman_event(afstats::BagmanEventKind::drop, prev_carrier, drop_pos);
 
     if (prev_carrier) {
         announce(std::format("{} dropped the bag!", prev_carrier->name.c_str()));
@@ -498,6 +510,7 @@ void bagman_play_return_sound()
 
 static void on_return()
 {
+    afstats::on_bagman_event(afstats::BagmanEventKind::ret, nullptr, g_bagman_info.spawn_pos);
     g_bagman_info.state = BagState::BS_At_Spawn;
     g_bagman_info.return_timer.invalidate();
     g_bagman_info.bag_respawn_retry_timer.invalidate();
@@ -566,6 +579,8 @@ void bagman_do_frame()
                 g_bagman_info.state = BagState::BS_At_Spawn;
                 spawn_bag_item(g_bagman_info.spawn_pos, g_bagman_info.spawn_orient);
                 announce("The bag is now available!");
+                afstats::on_bagman_event(afstats::BagmanEventKind::available, nullptr,
+                                         g_bagman_info.spawn_pos);
                 bagman_broadcast_state();
             }
             return;

--- a/game_patch/multi/bagman.h
+++ b/game_patch/multi/bagman.h
@@ -53,6 +53,7 @@ void bagman_on_player_disconnect(rf::Player* player);
 void bagman_on_entity_will_die(rf::Entity* ep);
 int bagman_get_red_team_score();
 int bagman_get_blue_team_score();
+int bagman_get_score_tick_ms();
 void bagman_set_red_team_score(int v);
 void bagman_set_blue_team_score(int v);
 void bagman_force_state_sync_to(rf::Player* player);

--- a/game_patch/multi/commands.cpp
+++ b/game_patch/multi/commands.cpp
@@ -1,4 +1,5 @@
 #include "../os/console.h"
+#include "../fflink/afstats_events.h"
 #include "server_internal.h"
 #include "../rf/multi.h"
 #include "../rf/gameseq.h"
@@ -197,6 +198,9 @@ void process_delayed_kicks()
         for (int player_id : batch) {
             rf::Player* player = rf::multi_find_player_by_id(static_cast<uint8_t>(player_id));
             if (player) {
+                // Generic fallback: a ban or vote kick has already tagged its own
+                // reason, and note_leave_reason keeps the first writer.
+                afstats::note_leave_reason(player, afstats::LeaveReason::kicked);
                 rf::multi_kick_player(player);
             }
         }
@@ -213,6 +217,7 @@ void ban_cmd_handler_hook()
             if (player) {
                 if (player != rf::local_player) {
                     rf::console::printf(rf::strings::banning_player, player->name.c_str());
+                    afstats::note_leave_reason(player, afstats::LeaveReason::banned);
                     rf::multi_ban_ip(player->net_data->addr);
                     kick_player_delayed(player);
                 }

--- a/game_patch/multi/gametype.cpp
+++ b/game_patch/multi/gametype.cpp
@@ -17,6 +17,7 @@
 #include "multi.h"
 #include "mutators.h"
 #include "alpine_packets.h"
+#include "../fflink/afstats_events.h"
 #include "../hud/hud_internal.h"
 #include "../hud/multi_spectate.h"
 #include "../sound/sound.h"
@@ -1069,6 +1070,27 @@ static void esc_apply_initial_ownerships()
     }
 }
 
+static uint8_t afstats_team_for_owner(HillOwner owner)
+{
+    switch (owner) {
+        case HillOwner::HO_Red:  return afstats::team_red;
+        case HillOwner::HO_Blue: return afstats::team_blue;
+        default:                 return afstats::team_none;
+    }
+}
+
+static std::vector<rf::Player*> players_from_ids(const std::vector<uint8_t>& ids)
+{
+    std::vector<rf::Player*> players;
+    players.reserve(ids.size());
+    for (uint8_t id : ids) {
+        if (rf::Player* p = rf::multi_find_player_by_id(id)) {
+            players.push_back(p);
+        }
+    }
+    return players;
+}
+
 static void server_maybe_broadcast_state(HillInfo& h, const Presence& pres)
 {
     const uint8_t prog_bucket = static_cast<uint8_t>(h.capture_progress / 5);
@@ -1083,6 +1105,23 @@ static void server_maybe_broadcast_state(HillInfo& h, const Presence& pres)
 
     if (!changed)
         return;
+
+    // Contest is a per-tick derived condition with nothing latched to hook, so the
+    // edge is taken against the same snapshot the network dedup already keeps.
+    const bool was_contested = h.net_last_red > 0 && h.net_last_blue > 0;
+    const bool is_contested = pres.red > 0 && pres.blue > 0;
+    if (was_contested != is_contested) {
+        afstats::on_point_event(h.hill_uid,
+            is_contested ? afstats::PointEventKind::contest_start
+                         : afstats::PointEventKind::contest_end,
+            afstats_team_for_owner(h.ownership), {},
+            h.lock_status != HillLockStatus::HLS_Available);
+    }
+    if (h.net_last_lock_status != h.lock_status) {
+        afstats::on_point_event(h.hill_uid, afstats::PointEventKind::lock_change,
+            afstats_team_for_owner(h.ownership), {},
+            h.lock_status != HillLockStatus::HLS_Available);
+    }
 
     af_send_koth_hill_state_packet_to_all(h, pres);
 
@@ -1196,6 +1235,15 @@ static void koth_apply_ownership(HillInfo& h, HillOwner new_owner, bool announce
                 ids = on_capture_collect_player_ids_on_hill_for_team(h, reward_team);
             const uint8_t uid8 = static_cast<uint8_t>(std::clamp(h.hill_uid, 0, 255));
             af_send_koth_hill_captured_packet_to_all(uid8, new_owner, ids);
+            afstats::on_point_event(h.hill_uid, afstats::PointEventKind::owner_change,
+                afstats_team_for_owner(new_owner), players_from_ids(ids),
+                h.lock_status != HillLockStatus::HLS_Available);
+        }
+        else {
+            // A silent flip (script/event driven) still changes ownership.
+            afstats::on_point_event(h.hill_uid, afstats::PointEventKind::owner_change,
+                afstats_team_for_owner(new_owner), {},
+                h.lock_status != HillLockStatus::HLS_Available);
         }
     }
 }
@@ -2038,6 +2086,12 @@ void multi_level_init_post_gametypes()
     // Mutator pickup suppression runs last so its policy applies on top of any
     // gametype-specific item handling.
     mutators_level_init_post();
+
+    // After everything above, so the round_start snapshot sees the level, the
+    // game type, the active rules and every gametype's own state as final.
+    if (rf::is_multi && rf::is_server) {
+        afstats::on_round_start();
+    }
 }
 
 // pre level being loaded

--- a/game_patch/multi/gungame.cpp
+++ b/game_patch/multi/gungame.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <format>
+#include <iterator>
 #include <map>
 #include <optional>
 #include <random>
@@ -15,6 +16,7 @@
 #include "server.h"
 #include "server_internal.h"
 #include "alpine_packets.h"
+#include "../fflink/afstats_events.h"
 #include "../main/main.h"
 #include "../sound/sound.h"
 #include "../hud/hud.h"
@@ -735,6 +737,10 @@ void gungame_on_player_kill(rf::Player* killer, rf::Player* killed)
                 grant_rampage_reward(killer);
             }
         }
+        // There is no stored level counter: the level is the player's position in
+        // their own score-threshold -> weapon order map.
+        const int level = static_cast<int>(std::distance(order.begin(), order.upper_bound(score)));
+        afstats::on_gg_levelup(killer, level, weapon);
         grant_and_switch(killer, weapon);
     }
 

--- a/game_patch/multi/kill_attribution.cpp
+++ b/game_patch/multi/kill_attribution.cpp
@@ -5,12 +5,15 @@
 #include <utility>
 #include <vector>
 #include <patch_common/FunHook.h>
+#include "../rf/clutter.h"
 #include "../rf/entity.h"
 #include "../rf/item.h"
 #include "../rf/math/vector.h"
 #include "../rf/multi.h"
+#include "../rf/object.h"
 #include "../rf/player/player.h"
 #include "../rf/weapon.h"
+#include "../fflink/afstats_events.h"
 #include "alpine_packets.h"
 #include "kill_attribution.h"
 
@@ -118,10 +121,33 @@ FunHook<float(int, float, int, int, int, rf::Vector3*, int, char)> obj_damage_ho
             g_damage_ctx = {};
         }
 
+        // Stats stream: snapshot whether this blow is about to kill a live
+        // clutter prop, so the alive->dead transition can be detected after the damage
+        // lands. obj_damage is the lethal-blow context that carries killer/weapon/damage
+        // type. Already-dead / delayed-delete clutter is excluded so a repeat blow on a
+        // corpse cannot emit a second time.
+        const rf::Object* const victim_before = rf::obj_from_handle(victim_handle);
+        // Local, not a static: obj_damage recurses (chained deaths), and a shared flag
+        // would be clobbered by the inner call before the outer one reads it.
+        const bool clutter_alive_before = victim_before && victim_before->type == rf::OT_CLUTTER
+            && !(victim_before->obj_flags & rf::OF_DELAYED_DELETE) && victim_before->life > 0.0f;
+
         const float real_damage = obj_damage_hook.call_target(victim_handle, damage, killer_handle,
                                                               weapon_type, damage_type, pos,
                                                               killer_uid, flags);
         g_damage_ctx = prev_ctx;
+
+        // Re-resolve rather than reusing the pre-call pointer: RF handles carry a
+        // generation, so a victim freed inside the damage call yields null here instead of
+        // a dangling read. That removes the whole lifetime assumption -- whether clutter
+        // death defers deletion or not, this can only ever touch a live object.
+        if (clutter_alive_before) {
+            rf::Object* const after = rf::obj_from_handle(victim_handle);
+            if (after && after->type == rf::OT_CLUTTER && after->life <= 0.0f) {
+                afstats::on_clutter_destroyed(static_cast<rf::Clutter*>(after), killer_handle,
+                                              weapon_type, damage_type);
+            }
+        }
         return real_damage;
     },
 };

--- a/game_patch/multi/multi.cpp
+++ b/game_patch/multi/multi.cpp
@@ -22,6 +22,7 @@
 #include "salvage.h"
 #include "mutators.h"
 #include "bots/bot_chat_manager.h"
+#include "../fflink/afstats_events.h"
 #include "../hud/hud.h"
 #include "../hud/multi_spectate.h"
 #include "../rf/file/file.h"
@@ -287,6 +288,9 @@ FunHook<void()> multi_limbo_init{
 
             if (g_match_info.match_active) {
                 af_broadcast_automated_chat_msg("\xA6 Match complete!");
+                // Before reset(), which drops the roster, and while the scores the
+                // winner is derived from are still the finished match's.
+                afstats::on_match_end_derived(afstats::MatchResult::completed);
                 g_match_info.reset();
             }
             else if (g_match_info.pre_match_active && g_match_info.everyone_ready) {
@@ -849,6 +853,21 @@ FunHook<void(rf::Entity*, int, rf::Vector3&, rf::Matrix3&, bool)> multi_process_
             }
         }
         multi_process_remote_weapon_fire_hook.call_target(ep, weapon_type, pos, orient, alt_fire);
+
+        // One trigger pull. Counting projectiles rather than shots here is what makes
+        // pellet weapons comparable with single-projectile ones.
+        if (rf::is_server) {
+            if (rf::Player* pp = rf::player_from_entity_handle(ep->handle)) {
+                int projectiles = 1;
+                if (kill_attribution_is_valid_weapon_type(weapon_type)) {
+                    projectiles = std::max(rf::weapon_types[weapon_type].num_projectiles, 1);
+                }
+                if (ep->entity_flags2 & 0x1000) { // EF2_SHOTGUN_DOUBLE_BULLET_UNK
+                    projectiles *= 2;
+                }
+                afstats::on_weapon_fired(pp, weapon_type, static_cast<uint32_t>(projectiles));
+            }
+        }
 
         // Notify spectate system of weapon fire so the fpgun fire animation is triggered.
         // Skip thrown projectile weapons (grenade, C4, flamethrower canister alt-fire) because

--- a/game_patch/multi/network.cpp
+++ b/game_patch/multi/network.cpp
@@ -63,6 +63,8 @@
 #include "../purefaction/pf.h"
 #include "../sound/sound.h"
 #include "../misc/tlv.h"
+#include "../fflink/afstats_client.h"
+#include "../fflink/fflink_session.h"
 
 // NET_IFINDEX_UNSPECIFIED is not defined in MinGW headers
 #ifndef NET_IFINDEX_UNSPECIFIED
@@ -1402,6 +1404,10 @@ CallHook<int(const rf::NetAddr*, std::byte*, size_t)> send_game_info_packet_hook
             req_ver = it->second.ver;
         }
 
+        // Tracks the FactionFiles session, which settles after startup and can lapse,
+        // so it is refreshed here rather than only at server init.
+        g_game_info_server_flags.stats_enabled = fflink::afstats_server_enabled();
+
         // level filename (null-terminated, used by AF extensions)
         uint8_t fname[64] = {0};
         size_t fname_len = 0;
@@ -1567,6 +1573,7 @@ CallHook<int(const rf::NetAddr*, std::byte*, size_t)> send_join_req_packet_hook{
                 show_unsupported_game_type_popup();
                 return 0;
             }
+            fflink::afstats_on_join_req(*addr, extra && (extra->af_flags & AF_GI_FLAG_STATS_ENABLED));
         }
 
         const bool session_client_bot_mode = client_bot_launch_enabled();
@@ -1755,6 +1762,12 @@ CallHook<int(const rf::NetAddr*, std::byte*, size_t)> send_join_accept_packet_ho
         if (g_alpine_server_config_active_rules.mutators.pogo_enabled) {
             ext_data.flags |= AlpineFactionJoinAcceptPacketExt::Flags::pogo;
         }
+        // Direct connects have no browser game_info entry, so this is the only
+        // point at which they learn to run the stats key exchange.
+        if (fflink::afstats_server_enabled()) {
+            ext_data.flags |= AlpineFactionJoinAcceptPacketExt::Flags::stats_enabled;
+            xlog::warn("[afstats] advertising stats-enabled in join_accept");
+        }
         // AF 1.3+ clients: use footer-based format for forward compatibility
         // Older clients: use legacy raw struct (they don't know about the footer)
         bool use_footer = g_joining_client_version == ClientSoftware::AlpineFaction
@@ -1900,6 +1913,9 @@ CodeInjection process_join_accept_injection{
             server_info.dodging = !!(ext_data.flags & AlpineFactionJoinAcceptPacketExt::Flags::dodging);
             server_info.pogo = !!(ext_data.flags & AlpineFactionJoinAcceptPacketExt::Flags::pogo);
             // featured_no_clip is intentionally not stored here, it's consumed inline below via mutators_set_no_clip_weapon.
+
+            fflink::afstats_on_join_accept(
+                !!(ext_data.flags & AlpineFactionJoinAcceptPacketExt::Flags::stats_enabled));
 
             constexpr float default_fov = 90.0f;
             if (!!(ext_data.flags & AlpineFactionJoinAcceptPacketExt::Flags::max_fov) && ext_data.max_fov >= default_fov) {
@@ -2608,6 +2624,7 @@ FunHook<void()> multi_stop_hook{
         gungame_on_multi_shutdown(); // put the Jeep Gun mesh + damage back to weapons.tbl
         mutators_on_multi_shutdown(); // put the level's own gravity back
         riot_shield_on_multi_level_init(); // drop any pending riot shield break suppressions
+        fflink::afstats_reset(); // a stats session key is only ever valid for the join it was minted for
         if (rf::local_player) {
             PlayerAdditionalData* const player_add_data =
                 static_cast<PlayerAdditionalData*>(rf::local_player);

--- a/game_patch/multi/network.cpp
+++ b/game_patch/multi/network.cpp
@@ -64,6 +64,7 @@
 #include "../sound/sound.h"
 #include "../misc/tlv.h"
 #include "../fflink/afstats_client.h"
+#include "../fflink/afstats_events.h"
 #include "../fflink/fflink_session.h"
 
 // NET_IFINDEX_UNSPECIFIED is not defined in MinGW headers
@@ -791,6 +792,13 @@ FunHook<MultiIoPacketHandler> process_left_game_packet_hook{
                 build_local_player_spectators_strings();
             }
         }
+        else if (rf::Player* const player = rf::multi_find_player_by_id(data[0])) {
+            // A left_game packet means the client announced its own departure, so
+            // this is a quit rather than a timeout the server had to notice.
+            afstats::note_leave_reason(player, data[1] == RF_LeftReason::RF_LR_KICKED
+                ? afstats::LeaveReason::kicked
+                : afstats::LeaveReason::quit);
+        }
 
         process_left_game_packet_hook.call_target(data, addr);
     },
@@ -931,6 +939,15 @@ FunHook<MultiIoPacketHandler> process_name_change_packet_hook{
         // server-side and client-side
         verify_player_id_in_packet(&data[0], addr, "name_change");
         process_name_change_packet_hook.call_target(data, addr);
+
+        if (rf::is_server) {
+            // call_target applied the rename server-side (and rebroadcast it); read
+            // the finalized name back for the stats stream. data[0] is the player id,
+            // corrected by verify_player_id_in_packet above.
+            if (rf::Player* const player = rf::multi_find_player_by_id(data[0])) {
+                afstats::on_player_rename(player, player->name.c_str());
+            }
+        }
     },
 };
 
@@ -965,7 +982,16 @@ FunHook<MultiIoPacketHandler> process_team_change_packet_hook{
                 }
             }
         }
+        // The stock handler owns the write, and it no-ops on a same-team request, so
+        // the transition is only observable by comparing across the call.
+        rf::Player* const changing = rf::is_server ? rf::multi_find_player_by_id(data[0]) : nullptr;
+        const rf::ubyte team_before = changing ? changing->team : rf::ubyte{};
         process_team_change_packet_hook.call_target(data, addr);
+        if (changing && changing->team != team_before) {
+            afstats::on_status(changing, changing->team == rf::TEAM_BLUE
+                ? afstats::StatusKind::team_blue
+                : afstats::StatusKind::team_red);
+        }
     },
 };
 
@@ -1573,7 +1599,7 @@ CallHook<int(const rf::NetAddr*, std::byte*, size_t)> send_join_req_packet_hook{
                 show_unsupported_game_type_popup();
                 return 0;
             }
-            fflink::afstats_on_join_req(*addr, extra && (extra->af_flags & AF_GI_FLAG_STATS_ENABLED));
+            fflink::afstats_client_on_join_req(*addr, extra && (extra->af_flags & AF_GI_FLAG_STATS_ENABLED));
         }
 
         const bool session_client_bot_mode = client_bot_launch_enabled();
@@ -1766,7 +1792,7 @@ CallHook<int(const rf::NetAddr*, std::byte*, size_t)> send_join_accept_packet_ho
         // point at which they learn to run the stats key exchange.
         if (fflink::afstats_server_enabled()) {
             ext_data.flags |= AlpineFactionJoinAcceptPacketExt::Flags::stats_enabled;
-            xlog::warn("[afstats] advertising stats-enabled in join_accept");
+            xlog::debug("[afstats] advertising stats-enabled in join_accept");
         }
         // AF 1.3+ clients: use footer-based format for forward compatibility
         // Older clients: use legacy raw struct (they don't know about the footer)
@@ -1914,7 +1940,7 @@ CodeInjection process_join_accept_injection{
             server_info.pogo = !!(ext_data.flags & AlpineFactionJoinAcceptPacketExt::Flags::pogo);
             // featured_no_clip is intentionally not stored here, it's consumed inline below via mutators_set_no_clip_weapon.
 
-            fflink::afstats_on_join_accept(
+            fflink::afstats_client_on_join_accept(
                 !!(ext_data.flags & AlpineFactionJoinAcceptPacketExt::Flags::stats_enabled));
 
             constexpr float default_fov = 90.0f;
@@ -2290,6 +2316,10 @@ FunHook<void(int, rf::NetAddr*)> process_join_req_packet_hook{
             if (g_dedicated_launched_from_ads) {
                 print_player_info(valid_player, true);
             }
+
+            // Last thing in the join: is_bot / is_browser / version_info are only
+            // correct now, and the anti-fake-bot path above already returned.
+            afstats::on_player_join(valid_player);
         }
     },
 };
@@ -2624,7 +2654,8 @@ FunHook<void()> multi_stop_hook{
         gungame_on_multi_shutdown(); // put the Jeep Gun mesh + damage back to weapons.tbl
         mutators_on_multi_shutdown(); // put the level's own gravity back
         riot_shield_on_multi_level_init(); // drop any pending riot shield break suppressions
-        fflink::afstats_reset(); // a stats session key is only ever valid for the join it was minted for
+        afstats::on_shutdown(); // best-effort final flush of the stats event stream
+        fflink::afstats_client_reset(); // a stats session key is only ever valid for the join it was minted for
         if (rf::local_player) {
             PlayerAdditionalData* const player_add_data =
                 static_cast<PlayerAdditionalData*>(rf::local_player);

--- a/game_patch/multi/network.cpp
+++ b/game_patch/multi/network.cpp
@@ -938,6 +938,17 @@ FunHook<MultiIoPacketHandler> process_name_change_packet_hook{
     [](char* data, const rf::NetAddr& addr) {
         // server-side and client-side
         verify_player_id_in_packet(&data[0], addr, "name_change");
+
+        // Snapshot the current name before the stock handler overwrites it in place, so
+        // the stats emission can fire only on an actual change (clients can re-send the
+        // same name) — the pre-change name is exactly what the stream last reported.
+        std::string prev_name;
+        if (rf::is_server) {
+            if (const rf::Player* const player = rf::multi_find_player_by_id(data[0])) {
+                prev_name = player->name.c_str();
+            }
+        }
+
         process_name_change_packet_hook.call_target(data, addr);
 
         if (rf::is_server) {
@@ -945,7 +956,7 @@ FunHook<MultiIoPacketHandler> process_name_change_packet_hook{
             // the finalized name back for the stats stream. data[0] is the player id,
             // corrected by verify_player_id_in_packet above.
             if (rf::Player* const player = rf::multi_find_player_by_id(data[0])) {
-                afstats::on_player_rename(player, player->name.c_str());
+                afstats::on_player_rename(player, player->name.c_str(), prev_name);
             }
         }
     },
@@ -1806,19 +1817,46 @@ CallHook<int(const rf::NetAddr*, std::byte*, size_t)> send_join_accept_packet_ho
     },
 };
 
+// How much of the AF join_accept extension could be read. This trichotomy is
+// load-bearing for the stats flag:
+//   absent      - no AF extension at all (stock/DF/legacy non-AF). The ONLY state
+//                 permitted to clear a browser-derived stats flag to false.
+//   unparseable - AF-ish but the stats flag can't be trusted (footer magic without our
+//                 signature, or the signature read but the flags field was truncated
+//                 before it). Leave the browser-derived flag as-is; never downgrade a
+//                 real stats server's player to untracked on a short/corrupt accept.
+//   parsed_full - the flags field was positively read; the stats flag is authoritative.
+enum class JoinAcceptAf
+{
+    absent,
+    unparseable,
+    parsed_full,
+};
+
 // Parse AF extension from join_accept payload.
 // payload: points to start of payload (past 3-byte RF_GamePacketHeader)
 // payload_len: header.size field from the packet header
 // ext_offset: offset within payload where AF extension is expected (from stock field parsing)
-// Handles both footer-based (AF 1.3+) and legacy (pre-1.3) formats.
-static bool parse_join_accept_af_ext(const uint8_t* payload, size_t payload_len, size_t ext_offset,
+// Handles both footer-based (AF 1.3+) and legacy (pre-1.3) formats. `out` is populated
+// (and af_signature validated) for the parsed_* results.
+static JoinAcceptAf parse_join_accept_af_ext(const uint8_t* payload, size_t payload_len, size_t ext_offset,
     AlpineFactionJoinAcceptPacketExt& out)
 {
     std::memset(&out, 0, sizeof(out));
     if (!payload || payload_len == 0)
-        return false;
+        return JoinAcceptAf::unparseable; // no usable payload: not a positive non-AF signal
 
     const uint8_t* end = payload + payload_len;
+
+    // The stats flag lives past the signature; count the flag as read only when the copied
+    // span reached the end of the flags field. Real AF servers always send the full struct,
+    // so a signature-but-flags-truncated accept is a defensive path for a corrupted/short
+    // packet, never a normal one — it falls under `unparseable` (flag can't be trusted).
+    const size_t flags_end = offsetof(AlpineFactionJoinAcceptPacketExt, flags)
+        + sizeof(AlpineFactionJoinAcceptPacketExt::Flags);
+    const auto classify = [flags_end](size_t copy_len) {
+        return copy_len >= flags_end ? JoinAcceptAf::parsed_full : JoinAcceptAf::unparseable;
+    };
 
     // Try footer-based parsing first (AF 1.3+ server)
     if (payload_len >= sizeof(AFFooter)) {
@@ -1831,22 +1869,29 @@ static bool parse_join_accept_af_ext(const uint8_t* payload, size_t payload_len,
                 if (core >= payload) {
                     size_t copy_len = std::min(sizeof(out), core_len);
                     std::memcpy(&out, core, copy_len);
-                    return out.af_signature == ALPINE_FACTION_SIGNATURE;
+                    if (out.af_signature == ALPINE_FACTION_SIGNATURE) {
+                        return classify(copy_len);
+                    }
                 }
             }
-            return false; // footer present but malformed
+            // Footer magic present but the core did not yield our signature: an AF
+            // extension is here, just not one we can read — not a stock/DF server.
+            return JoinAcceptAf::unparseable;
         }
     }
 
     // Fallback: legacy format (pre-1.3 server) — extension appended raw after stock fields
-    if (ext_offset >= payload_len) return false;
+    if (ext_offset >= payload_len) return JoinAcceptAf::absent;
     const uint8_t* p = payload + ext_offset;
     size_t tail_len = end - p;
-    if (tail_len == 0) return false;
+    if (tail_len == 0) return JoinAcceptAf::absent;
 
     size_t copy_len = std::min(sizeof(out), tail_len);
     std::memcpy(&out, p, copy_len);
-    return out.af_signature == ALPINE_FACTION_SIGNATURE;
+    if (out.af_signature != ALPINE_FACTION_SIGNATURE) {
+        return JoinAcceptAf::absent; // stock/DF/other: no AF extension present
+    }
+    return classify(copy_len);
 }
 
 // Gate process_join_accept_packet so the engine never assigns an unknown
@@ -1902,7 +1947,11 @@ CodeInjection process_join_accept_injection{
         size_t payload_len = hdr.size;
         size_t ext_offset = static_cast<size_t>(regs.esi) + 5;
 
-        bool parsed = parse_join_accept_af_ext(payload, payload_len, ext_offset, ext_data);
+        JoinAcceptAf af_result = parse_join_accept_af_ext(payload, payload_len, ext_offset, ext_data);
+        // Only a fully-read extension drives server_info: a truncated/corrupt accept is
+        // untrustworthy, so it is treated like the no-extension case for server_info and
+        // handled separately for the stats flag below.
+        bool parsed = af_result == JoinAcceptAf::parsed_full;
 
         xlog::debug("Checking for join_accept AF extension: {:08X} (parsed: {})", ext_data.af_signature, parsed);
         if (parsed) {
@@ -1940,6 +1989,8 @@ CodeInjection process_join_accept_injection{
             server_info.pogo = !!(ext_data.flags & AlpineFactionJoinAcceptPacketExt::Flags::pogo);
             // featured_no_clip is intentionally not stored here, it's consumed inline below via mutators_set_no_clip_weapon.
 
+            // parsed_full is the only state reaching this branch, so the stats flag was
+            // positively read and is authoritative for settling the session.
             fflink::afstats_client_on_join_accept(
                 !!(ext_data.flags & AlpineFactionJoinAcceptPacketExt::Flags::stats_enabled));
 
@@ -1970,6 +2021,19 @@ CodeInjection process_join_accept_injection{
             mutators_set_no_clip_weapon(-1); // non-AF server: ensure no stale override
             mutators_update_low_gravity();   // no stale gravity override
             evaluate_footsteps();
+            // Only a confidently non-AF accept clears the browser-derived stats flag: a
+            // server with no AF extension at all cannot host stats, and the browser entry
+            // we may have latched from is not the server speaking. An AF extension that is
+            // present but unreadable is deliberately left alone — hard-clearing it here
+            // silently downgrades a real stats server's player to untracked for the whole
+            // session..
+            if (af_result == JoinAcceptAf::absent) {
+                fflink::afstats_client_on_join_accept(false);
+            }
+            else {
+                xlog::debug("[afstats] join_accept AF extension present but unparseable; "
+                            "leaving the stats flag as the browser reported it");
+            }
         }
     },
 };

--- a/game_patch/multi/network.h
+++ b/game_patch/multi/network.h
@@ -197,6 +197,7 @@ struct AlpineFactionJoinAcceptPacketExt
         skiing              = 1u << 24,
         pogo                = 1u << 25,
         dodging             = 1u << 26,
+        stats_enabled       = 1u << 27,
     } flags = Flags::none;
 
     float max_fov = 0.0f;
@@ -260,6 +261,9 @@ struct AlpineFactionJoinReqPacketExt // used for stashed data during join proces
 };
 template<>
 struct EnableEnumBitwiseOperators<AlpineFactionJoinReqPacketExt::Flags> : std::true_type {};
+
+// Bits of AFGameInfoExtra::af_flags, produced by AFGameInfoFlags::game_info_flags_to_uint32().
+constexpr uint32_t AF_GI_FLAG_STATS_ENABLED = 1u << 9;
 
 // Per-server extra data parsed from the AF game_info v2 extension
 struct AFGameInfoExtra

--- a/game_patch/multi/pit.cpp
+++ b/game_patch/multi/pit.cpp
@@ -15,6 +15,7 @@
 #include "server.h"
 #include "server_internal.h"
 #include "alpine_packets.h"
+#include "../fflink/afstats_events.h"
 #include "../hud/hud.h"
 #include "../sound/sound.h"
 #include "../rf/multi.h"
@@ -151,9 +152,13 @@ void clear_spectator_fields(rf::Player* p)
     if (old_target && rf::is_server) {
         af_send_spectate_notify_packet(old_target, p, false);
     }
+    const bool was_spectator = p->is_spectator;
     p->is_spectator = false;
     p->spectatee = std::nullopt;
     p->spectate_start_time = std::nullopt;
+    if (was_spectator) {
+        afstats::on_status(p, afstats::StatusKind::spec_stop);
+    }
 }
 
 // Validate/fill both dueler slots. Slot 0 is the "champion seat" by convention
@@ -213,6 +218,10 @@ void pit_on_round_begin()
     }
 
     pit_broadcast_queue_states();
+
+    // A Pit duel is reported as a 1v1 match: it is the unit that has participants
+    // and a winner, which is what the match events describe.
+    afstats::on_match_start(1, {g_pit.dueler[0], g_pit.dueler[1]});
 
     // Match point: if either dueler is one duel win away from the score limit,
     // play the "one kill remaining" announcer cue for everyone in the server.
@@ -305,6 +314,10 @@ rf::Player* pit_resolve_timeout_winner()
 void pit_on_round_end(rf::Player* winner, RoundEndReason reason)
 {
     if (!rf::is_server) return;
+
+    // A draw (timeout, or both duelers gone) reports no winner rather than a cancel:
+    // the duel ran to completion, it simply decided nothing.
+    afstats::on_match_end(afstats::MatchResult::completed, afstats::team_none, winner);
 
     rf::Player* d0 = g_pit.dueler[0];
     rf::Player* d1 = g_pit.dueler[1];

--- a/game_patch/multi/pit.cpp
+++ b/game_patch/multi/pit.cpp
@@ -192,9 +192,9 @@ void prepare_dueler(rf::Player* p)
 // The duel counts as started once both duelers have live entities, which is also the
 // point where the pairing stops being provisional: until then pit_should_end_round
 // may still swap a slot (or abandon the round outright) while it waits for both
-// players. Reporting the 1v1 match here rather than at round begin means the
+// players. Reporting the subround here rather than at round begin means the
 // participants are the two players who actually fought, and a pairing that never got
-// off the ground reports nothing at all — on_match_end is a no-op without a match
+// off the ground reports nothing at all — on_subround_end is a no-op without a subround
 // start, so an abandoned round stays silent on both ends.
 void latch_duel_started()
 {
@@ -203,9 +203,9 @@ void latch_duel_started()
 
     g_pit.duel_started = true;
 
-    // A Pit duel is reported as a 1v1 match: it is the unit that has participants
-    // and a winner, which is what the match events describe.
-    afstats::on_match_start(1, {g_pit.dueler[0], g_pit.dueler[1]});
+    // A Pit duel is reported as a subround: it is the unit that has participants
+    // and a winner, which is what the subround events describe.
+    afstats::on_subround_start({g_pit.dueler[0], g_pit.dueler[1]});
 }
 
 // === Round callbacks ============================================
@@ -329,8 +329,14 @@ void pit_on_round_end(rf::Player* winner, RoundEndReason reason)
     if (!rf::is_server) return;
 
     // A draw (timeout, or both duelers gone) reports no winner rather than a cancel:
-    // the duel ran to completion, it simply decided nothing.
-    afstats::on_match_end(afstats::MatchResult::completed, afstats::team_none, winner);
+    // the duel ran to completion, it simply decided nothing. A level change ends the
+    // subround without a decided contest.
+    afstats::SubroundResult result =
+        (reason == RoundEndReason::LevelChange) ? afstats::SubroundResult::canceled
+        : (winner != nullptr)                   ? afstats::SubroundResult::completed
+                                                : afstats::SubroundResult::draw;
+    // Pit is FFA: no winning team, the winner (if any) is the surviving dueler.
+    afstats::on_subround_end(result, afstats::team_none, winner);
 
     rf::Player* d0 = g_pit.dueler[0];
     rf::Player* d1 = g_pit.dueler[1];

--- a/game_patch/multi/pit.cpp
+++ b/game_patch/multi/pit.cpp
@@ -189,6 +189,25 @@ void prepare_dueler(rf::Player* p)
     clear_spectator_fields(p);
 }
 
+// The duel counts as started once both duelers have live entities, which is also the
+// point where the pairing stops being provisional: until then pit_should_end_round
+// may still swap a slot (or abandon the round outright) while it waits for both
+// players. Reporting the 1v1 match here rather than at round begin means the
+// participants are the two players who actually fought, and a pairing that never got
+// off the ground reports nothing at all — on_match_end is a no-op without a match
+// start, so an abandoned round stays silent on both ends.
+void latch_duel_started()
+{
+    if (g_pit.duel_started) return;
+    if (!player_has_alive_entity(g_pit.dueler[0]) || !player_has_alive_entity(g_pit.dueler[1])) return;
+
+    g_pit.duel_started = true;
+
+    // A Pit duel is reported as a 1v1 match: it is the unit that has participants
+    // and a winner, which is what the match events describe.
+    afstats::on_match_start(1, {g_pit.dueler[0], g_pit.dueler[1]});
+}
+
 // === Round callbacks ============================================
 
 void pit_on_round_begin()
@@ -218,10 +237,6 @@ void pit_on_round_begin()
     }
 
     pit_broadcast_queue_states();
-
-    // A Pit duel is reported as a 1v1 match: it is the unit that has participants
-    // and a winner, which is what the match events describe.
-    afstats::on_match_start(1, {g_pit.dueler[0], g_pit.dueler[1]});
 
     // Match point: if either dueler is one duel win away from the score limit,
     // play the "one kill remaining" announcer cue for everyone in the server.
@@ -281,9 +296,7 @@ bool pit_should_end_round(rf::Player** out_winner)
         if (changed) pit_broadcast_queue_states();
 
         // Latch once both duelers actually have live entities.
-        if (player_has_alive_entity(g_pit.dueler[0]) && player_has_alive_entity(g_pit.dueler[1])) {
-            g_pit.duel_started = true;
-        }
+        latch_duel_started();
         return false;
     }
 
@@ -557,11 +570,7 @@ void pit_do_frame()
         }
         g_internal_spawn_in_progress = false;
 
-        if (!g_pit.duel_started
-            && player_has_alive_entity(g_pit.dueler[0])
-            && player_has_alive_entity(g_pit.dueler[1])) {
-            g_pit.duel_started = true;
-        }
+        latch_duel_started();
     }
 }
 

--- a/game_patch/multi/rounds.cpp
+++ b/game_patch/multi/rounds.cpp
@@ -11,6 +11,7 @@
 #include "server.h"
 #include "server_internal.h"
 #include "alpine_packets.h"
+#include "../fflink/afstats_events.h"
 #include "../hud/hud.h"
 #include "../rf/multi.h"
 #include "../rf/entity.h"
@@ -226,6 +227,7 @@ void rotate_to_next_level()
     g_rounds_runtime.pending_level_change = true; // gate Inactive→start until level actually loads
     // Advance the rotation. multi_change_level is async; the latch above
     // keeps rounds_do_frame from restarting a round-set on the doomed level.
+    afstats::note_round_end_type(afstats::RoundEndType::level_logic);
     set_manually_loaded_level(false);
     rf::multi_change_level(nullptr);
 }

--- a/game_patch/multi/salvage.cpp
+++ b/game_patch/multi/salvage.cpp
@@ -16,6 +16,8 @@
 #include "gametype.h"
 #include "server_internal.h"
 #include "alpine_packets.h"
+#include "../fflink/afstats_events.h"
+#include "../fflink/fflink_session.h"
 #include "../hud/multi_spectate.h"
 #include "../misc/waypoints.h"
 #include "../rf/entity.h"
@@ -580,8 +582,18 @@ void spawn_flag_at_home()
     }
 }
 
+// Set for exactly one drop_flag_at call by salvage_handle_drop_flag_request; every
+// other drop (death, disconnect, forced) is a death drop.
+static bool g_drop_is_manual = false;
+
 void drop_flag_at(rf::Player* prev_carrier, const rf::Vector3& drop_pos)
 {
+    // Salvage's object is neutral, so its team is always the "none" sentinel.
+    afstats::on_flag_event(g_drop_is_manual ? afstats::FlagEventKind::drop_manual
+                                            : afstats::FlagEventKind::drop_death,
+                           afstats::team_none, prev_carrier, drop_pos);
+    g_drop_is_manual = false;
+
     set_carrier(nullptr);
     g_salvage_info.state = SalFlagState::Dropped;
     g_salvage_info.spawn_delay_timer.invalidate();
@@ -1178,6 +1190,11 @@ void salvage_on_flag_touch(rf::Player* player, rf::Item* item)
     // attachment just computed. CTF clears the same bit when a flag is taken.
     set_flag_item_class_spin(false);
 
+    const bool from_base = g_salvage_info.state == SalFlagState::AtSpawn;
+    afstats::on_flag_event(from_base ? afstats::FlagEventKind::steal
+                                     : afstats::FlagEventKind::pickup,
+                           afstats::team_none, player, ep->pos);
+
     set_carrier(player);
     g_salvage_info.state = SalFlagState::Carried;
     g_salvage_info.last_carrier_pos = ep->pos;
@@ -1210,6 +1227,8 @@ void salvage_on_base_touch(rf::Player* player, rf::Item* item)
     else {
         ++g_salvage_info.blue_caps;
     }
+
+    afstats::on_flag_event(afstats::FlagEventKind::capture, afstats::team_none, player, item->pos);
 
     rf::player_add_score(player, 4);
     if (player->stats) {
@@ -1257,6 +1276,7 @@ void salvage_handle_drop_flag_request(rf::Player* player)
     if (g_salvage_info.carrier != player) return;
 
     rf::Entity* ep = alive_entity_for(player);
+    g_drop_is_manual = true;
     drop_flag_at(player, ep ? ep->pos : g_salvage_info.last_carrier_pos);
 }
 
@@ -1299,6 +1319,8 @@ void salvage_do_frame()
     if (g_salvage_info.state == SalFlagState::Delayed) {
         if (g_salvage_info.spawn_delay_timer.valid() && g_salvage_info.spawn_delay_timer.elapsed()) {
             spawn_flag_at_home();
+            afstats::on_flag_event(afstats::FlagEventKind::reset, afstats::team_none, nullptr,
+                                   g_salvage_info.spawn_pos);
             announce("The flag is now available!");
             play_local_transition_sound(stock_sound_id::flag_respawn);
             salvage_broadcast_state();
@@ -1308,6 +1330,8 @@ void salvage_do_frame()
     else if (g_salvage_info.state == SalFlagState::Dropped) {
         if (g_salvage_info.return_timer.valid() && g_salvage_info.return_timer.elapsed()) {
             spawn_flag_at_home();
+            afstats::on_flag_event(afstats::FlagEventKind::return_timeout, afstats::team_none,
+                                   nullptr, g_salvage_info.spawn_pos);
             announce("The flag has returned.");
             play_local_transition_sound(stock_sound_id::flag_respawn);
             salvage_broadcast_state();
@@ -1356,7 +1380,32 @@ FunHook<void(rf::Player*, rf::Item*)> multi_ctf_apply_flag_hook{
     0x004738D0,
     [](rf::Player* pp, rf::Item* item) {
         if (!gt_is_salvage()) {
+            // The engine's own dispatch point for a CTF flag touch, and the only
+            // place that sees the pre-touch state a steal is distinguished by.
+            const bool red_flag = item && (item->item_flags & rf::IF_RED_FLAG) != 0;
+            const bool in_base_before = item && (item->item_flags & rf::IF_CTF_FLAG) != 0;
+            const rf::Vector3 touch_pos = item ? item->pos : rf::Vector3{};
+            rf::Player* const carrier_before =
+                red_flag ? rf::multi_ctf_get_red_flag_player() : rf::multi_ctf_get_blue_flag_player();
+
             multi_ctf_apply_flag_hook.call_target(pp, item);
+
+            if (rf::is_server && fflink::afstats_server_enabled() && pp && item) {
+                const uint8_t flag_team = red_flag ? afstats::team_red : afstats::team_blue;
+                rf::Player* const carrier_after = red_flag ? rf::multi_ctf_get_red_flag_player()
+                                                           : rf::multi_ctf_get_blue_flag_player();
+                const bool in_base_after =
+                    red_flag ? rf::multi_ctf_is_red_flag_in_base() : rf::multi_ctf_is_blue_flag_in_base();
+                if (carrier_after == pp && carrier_before != pp) {
+                    afstats::on_flag_event(in_base_before ? afstats::FlagEventKind::steal
+                                                          : afstats::FlagEventKind::pickup,
+                                           flag_team, pp, touch_pos);
+                }
+                else if (!in_base_before && in_base_after) {
+                    afstats::on_flag_event(afstats::FlagEventKind::return_touch, flag_team, pp,
+                                           touch_pos);
+                }
+            }
             return;
         }
         salvage_on_flag_touch(pp, item);
@@ -1368,7 +1417,24 @@ FunHook<void(rf::Player*, rf::Item*)> multi_ctf_apply_item_hook{
     0x00473BA0,
     [](rf::Player* pp, rf::Item* item) {
         if (!gt_is_salvage()) {
+            // A base touch only scores when the toucher was carrying the enemy flag,
+            // which the team score moving is the reliable evidence of.
+            const int red_before = rf::multi_ctf_get_red_team_score();
+            const int blue_before = rf::multi_ctf_get_blue_team_score();
+            const rf::Vector3 base_pos = item ? item->pos : rf::Vector3{};
+
             multi_ctf_apply_item_hook.call_target(pp, item);
+
+            if (rf::is_server && fflink::afstats_server_enabled() && pp && item) {
+                const bool red_capped = rf::multi_ctf_get_red_team_score() != red_before;
+                const bool blue_capped = rf::multi_ctf_get_blue_team_score() != blue_before;
+                if (red_capped || blue_capped) {
+                    // The flag that was captured is the enemy's, not the capper's.
+                    afstats::on_flag_event(afstats::FlagEventKind::capture,
+                                           red_capped ? afstats::team_blue : afstats::team_red, pp,
+                                           base_pos);
+                }
+            }
             return;
         }
         salvage_on_base_touch(pp, item);

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -59,6 +59,7 @@
 #include "../rf/os/timer.h"
 #include "../rf/level.h"
 #include "../rf/collide.h"
+#include "../fflink/fflink_session.h"
 
 // all commands that can be used by any rcon profiles
 // full_admin gives access to this entire list
@@ -4720,4 +4721,5 @@ void initialize_game_info_server_flags()
     g_game_info_server_flags.saving_enabled = server_is_saving_enabled();
     g_game_info_server_flags.gaussian_spread = server_gaussian_spread();
     g_game_info_server_flags.damage_notifications = server_has_damage_notifications();
+    g_game_info_server_flags.stats_enabled = fflink::afstats_server_enabled();
 }

--- a/game_patch/multi/server.cpp
+++ b/game_patch/multi/server.cpp
@@ -59,6 +59,7 @@
 #include "../rf/os/timer.h"
 #include "../rf/level.h"
 #include "../rf/collide.h"
+#include "../fflink/afstats_events.h"
 #include "../fflink/fflink_session.h"
 
 // all commands that can be used by any rcon profiles
@@ -559,7 +560,11 @@ void handle_load_command(rf::Player* player, std::string_view save_name)
 void handle_player_set_handicap(rf::Player* player, uint8_t amount)
 {
     const uint8_t applied = static_cast<uint8_t>(std::clamp<int>(amount, 0, 99));
+    const bool changed = player->damage_handicap != applied;
     player->damage_handicap = applied;
+    if (changed) {
+        afstats::on_status(player, afstats::StatusKind::handicap, applied);
+    }
     rf::console::print("At their request, {} has been given a {}% damage reduction handicap.", player->name, applied);
     auto msg = std::format("At your request, you have been given a {}% damage reduction handicap.", applied);
     af_send_automated_chat_msg(msg, player);
@@ -633,6 +638,10 @@ void handle_whosready_command(rf::Player* player)
     }
 }
 
+// Set for exactly one multi_ctf_drop_flag call by handle_drop_flag_request. Every
+// other caller of that function (death, disconnect, kick) is a death drop.
+static bool g_ctf_drop_is_manual = false;
+
 static void handle_drop_flag_request(rf::Player* player)
 {
     const bool is_salvage = gt_is_salvage();
@@ -652,6 +661,7 @@ static void handle_drop_flag_request(rf::Player* player)
 
     // drop flag if held
     if (rf::multi_ctf_get_red_flag_player() == player || rf::multi_ctf_get_blue_flag_player() == player) {
+        g_ctf_drop_is_manual = true;
         rf::multi_ctf_drop_flag(player);
         rf::ctf_flag_cooldown_timestamp.set(750);
     }
@@ -1315,6 +1325,9 @@ FunHook<float(rf::Entity*, float, int, int, int)> entity_damage_hook{
         float life_before = damaged_ep->life;
         float armor_before = damaged_ep->armor;
         int damaged_ep_handle = damaged_ep->handle;
+        // A gib destroys the entity, so the death position has to be taken before
+        // damage is applied to still be available afterwards.
+        rf::Vector3 victim_pos_before_damage = damaged_ep->pos;
 
         float real_damage = entity_damage_hook.call_target(damaged_ep, damage, killer_handle, damage_type, killer_uid);
 
@@ -1359,6 +1372,13 @@ FunHook<float(rf::Entity*, float, int, int, int)> entity_damage_hook{
 
         bool is_dead = damaged_ep ? damaged_ep->life <= 0.0f : true;
 
+        // Hoisted out of the lethal-blow block below: the stats stream needs the same
+        // weapon attribution for every damage application, not just the last one.
+        const DamageWeaponContext damage_ctx = kill_attribution_get_damage_context();
+        // A weapon type on the obj_damage call itself means a direct hit; splash damage
+        // only ever gets its weapon from the enclosing detonation context.
+        const bool direct_weapon_hit = damage_ctx.weapon_type >= 0 && !damage_ctx.splash;
+
         // Feed the combat chain that assists are computed from. Must run before the record
         // step below so the killing hit itself keeps the chain alive. Friendly fire in team
         // games never earns an assist.
@@ -1374,10 +1394,6 @@ FunHook<float(rf::Entity*, float, int, int, int)> entity_damage_hook{
         // lethal transition: post-death corpse damage must not overwrite it.
         if (rf::is_multi && rf::is_server && damaged_player && damaged_player->net_data
             && is_dead && life_before > 0.0f) {
-            const DamageWeaponContext damage_ctx = kill_attribution_get_damage_context();
-            // A weapon type on the obj_damage call itself means a direct hit; splash damage
-            // only ever gets its weapon from the enclosing detonation context.
-            const bool direct_weapon_hit = damage_ctx.weapon_type >= 0 && !damage_ctx.splash;
             int weapon = damage_ctx.weapon_type;
             uint8_t kill_flags = damage_ctx.splash ? AF_KILL_FLAG_SPLASH : 0;
             if (weapon < 0 && killer_player && killer_player != damaged_player) {
@@ -1424,6 +1440,13 @@ FunHook<float(rf::Entity*, float, int, int, int)> entity_damage_hook{
                 }
             }
 
+            // Same flags and assist list the af_kill_info packet is built from, so
+            // the stats stream and the in-game attribution can never disagree.
+            const rf::Vector3 victim_pos = damaged_ep ? damaged_ep->pos : victim_pos_before_damage;
+            const rf::Entity* killer_ep_for_pos = rf::entity_from_handle(killer_handle);
+            afstats::on_kill(damaged_player, killer_player, weapon, damage_type, kill_flags, assists,
+                             victim_pos, killer_ep_for_pos ? &killer_ep_for_pos->pos : nullptr);
+
             kill_attribution_record(killed_id, killer_id, weapon, kill_flags, damage_type,
                                     std::move(assists));
         }
@@ -1438,6 +1461,25 @@ FunHook<float(rf::Entity*, float, int, int, int)> entity_damage_hook{
             } else {
                 effective_damage = std::min(real_damage, std::max(life_before, 0.0f) + std::max(armor_before, 0.0f) * 2.0f);
             }
+        }
+
+        // Feeds the windowed damage/accuracy aggregates. Deliberately wider than the
+        // PvP block below: environmental deaths and self-damage are real damage the
+        // stream reports, with a null attacker where there is no player behind it.
+        if (rf::is_server && damaged_player && real_damage > 0.0f) {
+            int stats_weapon = damage_ctx.weapon_type;
+            if (stats_weapon < 0 && killer_player && killer_player != damaged_player) {
+                if (rf::Entity* killer_ep = rf::entity_from_handle(killer_handle)) {
+                    stats_weapon = killer_ep->ai.current_primary_weapon;
+                }
+            }
+            bool stats_headshot = false;
+            if (direct_weapon_hit && !kill_attribution_is_melee_weapon(stats_weapon)) {
+                stats_headshot = kill_attribution_get_hit_region(damaged_ep_handle)
+                    == kill_attribution_hit_region_head;
+            }
+            afstats::on_damage(killer_player, damaged_player, stats_weapon, damage_type,
+                               effective_damage, direct_weapon_hit, stats_headshot);
         }
 
         if (rf::is_server && is_pvp_damage && real_damage > 0.0f) {
@@ -1776,6 +1818,10 @@ void start_match()
                                              g_match_info.ready_players_blue.end());
     g_match_info.ready_players_blue.clear();
 
+    afstats::on_match_start(g_match_info.team_size,
+        std::vector<rf::Player*>(g_match_info.active_match_players.begin(),
+                                 g_match_info.active_match_players.end()));
+
     for (rf::Player* player : get_clients(false, false)) {
         af_send_ready_prompt(player, 0); // match starting — pre-match no longer active
     }
@@ -1789,6 +1835,9 @@ void start_match()
 void cancel_match()
 {
     rf::console::print("Canceling match");
+    // Before load_next_level: the limbo it drives reaches the match-completed path
+    // with match_active still set, and the stream must report this as a cancel.
+    afstats::on_match_end(afstats::MatchResult::canceled, afstats::team_none, nullptr);
     if (g_match_info.match_active) {
         load_next_level(); // end the round if active match is canceled
     }
@@ -1859,6 +1908,22 @@ void start_pre_match()
             update_pre_match_powerups(player);
         }
     }
+}
+
+uint8_t af_match_state_for_stats()
+{
+    if (g_match_info.match_active) {
+        return static_cast<uint8_t>(afstats::MatchState::match_active);
+    }
+    // pre_match_queued counts as pre-match because of when this is read. The
+    // round_start stamp is taken from multi_level_init_post_gametypes, which the
+    // level-init injection runs BEFORE its own start_pre_match() call — so a
+    // pre-match that a match vote queued for this level load is still merely
+    // queued at stamp time, even though the round about to begin is ready-up play.
+    if (g_match_info.pre_match_active || g_match_info.pre_match_queued) {
+        return static_cast<uint8_t>(afstats::MatchState::pre_match);
+    }
+    return static_cast<uint8_t>(afstats::MatchState::none);
 }
 
 void add_ready_player(rf::Player* player)
@@ -2328,6 +2393,8 @@ static void assign_player_to_team(rf::Player* player, rf::ubyte new_team)
     }
 
     player->team = new_team;
+    afstats::on_status(player, new_team == rf::TEAM_BLUE ? afstats::StatusKind::team_blue
+                                                         : afstats::StatusKind::team_red);
 
     if (player->net_data) {
         rf::multi_send_team_change_packet(nullptr, player->net_data->player_id, new_team);
@@ -2423,6 +2490,7 @@ FunHook<void(rf::Player*)> multi_spawn_player_server_side_hook{
                 // Fresh entity, so any riot shield break suppression from the life
                 // that just ended can never apply to them again.
                 riot_shield_on_player_spawn(player);
+                afstats::on_spawn(player, ep->pos);
             }
 
             // inform newly spawned players of their loadout
@@ -3551,6 +3619,10 @@ FunHook<void()> multi_check_for_round_end_hook{
                 af_broadcast_automated_chat_msg(msg);
             }
             else {
+                // time_up is a local, so the stats stream has to be told which
+                // limit fired before the level change unwinds it.
+                afstats::note_round_end_type(time_up ? afstats::RoundEndType::time_limit
+                                                     : afstats::RoundEndType::score_limit);
                 set_manually_loaded_level(false);
                 rf::multi_change_level(nullptr);
             }
@@ -4175,6 +4247,76 @@ CodeInjection dropped_red_flag_return_time_patch{
     },
 };
 
+// Every drop cause funnels through here: death, manual request, disconnect, kick.
+FunHook<void(rf::Player*)> multi_ctf_drop_flag_hook{
+    0x00473F40,
+    [](rf::Player* player) {
+        // get_*_flag_player() returns null when no one carries the flag, so without
+        // the player!=null guard a null drop would false-match and sample a phantom.
+        const bool had_red = player != nullptr && rf::multi_ctf_get_red_flag_player() == player;
+        const bool had_blue = player != nullptr && rf::multi_ctf_get_blue_flag_player() == player;
+        rf::Vector3 drop_pos{};
+        if (had_red) {
+            rf::multi_ctf_get_red_flag_pos(&drop_pos);
+        }
+        else if (had_blue) {
+            rf::multi_ctf_get_blue_flag_pos(&drop_pos);
+        }
+
+        multi_ctf_drop_flag_hook.call_target(player);
+
+        if (rf::is_server && (had_red || had_blue)) {
+            afstats::on_flag_event(g_ctf_drop_is_manual ? afstats::FlagEventKind::drop_manual
+                                                        : afstats::FlagEventKind::drop_death,
+                                   had_red ? afstats::team_red : afstats::team_blue, player,
+                                   drop_pos);
+        }
+        g_ctf_drop_is_manual = false;
+    },
+};
+
+// The stolen-flag return timers are only checked here, and the return they drive
+// is the one flag transition with no player behind it.
+FunHook<void()> multi_ctf_do_frame_hook{
+    0x00472ED0,
+    []() {
+        // Pure observer: nothing here runs when stats are off. The position getters
+        // copy from globals (they do not dereference the flag items), and the
+        // in-base getters are null-guarded; still, only sample a side whose flag item
+        // exists so a one-flag level can never reach a getter with a null item.
+        // Salvage reports its own returns from salvage_do_frame.
+        const bool sampling = rf::is_server && fflink::afstats_server_enabled()
+            && rf::multi_get_game_type() == rf::NG_TYPE_CTF;
+        const bool sample_red = sampling && rf::ctf_red_flag_item != nullptr;
+        const bool sample_blue = sampling && rf::ctf_blue_flag_item != nullptr;
+        bool red_home_before = false;
+        bool blue_home_before = false;
+        rf::Vector3 red_pos{};
+        rf::Vector3 blue_pos{};
+        if (sample_red) {
+            red_home_before = rf::multi_ctf_is_red_flag_in_base();
+            rf::multi_ctf_get_red_flag_pos(&red_pos);
+        }
+        if (sample_blue) {
+            blue_home_before = rf::multi_ctf_is_blue_flag_in_base();
+            rf::multi_ctf_get_blue_flag_pos(&blue_pos);
+        }
+
+        multi_ctf_do_frame_hook.call_target();
+
+        // A touch return is reported from the touch dispatch, which runs outside this
+        // frame function, so anything that came home in here was the timer.
+        if (sample_red && !red_home_before && rf::multi_ctf_is_red_flag_in_base()) {
+            afstats::on_flag_event(afstats::FlagEventKind::return_timeout, afstats::team_red,
+                                   nullptr, red_pos);
+        }
+        if (sample_blue && !blue_home_before && rf::multi_ctf_is_blue_flag_in_base()) {
+            afstats::on_flag_event(afstats::FlagEventKind::return_timeout, afstats::team_blue,
+                                   nullptr, blue_pos);
+        }
+    },
+};
+
 CodeInjection sp_damage_calculation_patch{
     0x0041A373,
     [](auto& regs) {
@@ -4204,6 +4346,8 @@ void server_init()
 
     // Set CTF flag return time
     dropped_blue_flag_return_time_patch.install();
+    multi_ctf_drop_flag_hook.install();
+    multi_ctf_do_frame_hook.install();
     dropped_red_flag_return_time_patch.install();
 
     // SP-style damage calculations (ie. armour doesnt fully protect health)
@@ -4464,6 +4608,10 @@ void server_do_frame()
 
 void server_on_limbo_state_enter()
 {
+    // First, while g_is_overtime, the level info and the scores still describe the
+    // round that just finished.
+    afstats::on_round_end();
+
     g_is_overtime = false;
     g_prev_level = rf::level.filename.c_str();
     server_vote_on_limbo_state_enter();

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -38,6 +38,7 @@ struct AFGameInfoFlags
     bool saving_enabled         = false;
     bool gaussian_spread        = false;
     bool damage_notifications   = false;
+    bool stats_enabled          = false;
 
     uint32_t game_info_flags_to_uint32() const
     {
@@ -49,7 +50,8 @@ struct AFGameInfoFlags
                (static_cast<uint32_t>(match_mode)               << 5) |
                (static_cast<uint32_t>(saving_enabled)           << 6) |
                (static_cast<uint32_t>(gaussian_spread)          << 7) |
-               (static_cast<uint32_t>(damage_notifications)     << 8);
+               (static_cast<uint32_t>(damage_notifications)     << 8) |
+               (static_cast<uint32_t>(stats_enabled)            << 9);
     }
 };
 

--- a/game_patch/multi/server_internal.h
+++ b/game_patch/multi/server_internal.h
@@ -1066,6 +1066,7 @@ extern bool g_manually_loaded_level;
 extern std::string g_ads_config_name;
 extern AFGameInfoFlags g_game_info_server_flags;
 extern std::string g_prev_level;
+extern bool g_is_overtime;
 extern MatchInfo g_match_info;
 
 enum class UpcomingGameTypeSelection {
@@ -1120,6 +1121,9 @@ void update_pre_match_powerups(rf::Player* player);
 void start_match();
 void cancel_match();
 void start_pre_match();
+// The afstats::MatchState value describing the ready-up match system right now,
+// as a raw uint8 so this header stays free of the stats API. Read at round_start.
+uint8_t af_match_state_for_stats();
 void set_ready_status(rf::Player* player, bool is_ready);
 void remove_ready_player_silent(rf::Player* player);
 void toggle_ready_status(rf::Player* player);

--- a/game_patch/multi/votes.cpp
+++ b/game_patch/multi/votes.cpp
@@ -24,6 +24,7 @@
 #include <common/utils/string-utils.h>
 #include <xlog/xlog.h>
 #include "server_internal.h"
+#include "../fflink/afstats_events.h"
 #include "multi.h"
 #include "gametype.h"
 #include "mutators.h"
@@ -179,6 +180,14 @@ public:
         announced = true;
         send_vote_starting_msg(source);
 
+        // After validate(), so a level vote's detail is the resolved filename rather
+        // than the raw client string.
+        afstats::on_vote_called(static_cast<uint8_t>(vote_type_to_wire(get_type())), source,
+            get_target_player_id() >= 0
+                ? rf::multi_find_player_by_id(static_cast<uint8_t>(get_target_player_id()))
+                : nullptr,
+            get_detail().c_str());
+
         early_finish_check_timer.set(1000);
 
         return check_for_early_vote_finish();
@@ -316,6 +325,13 @@ public:
         }
         end_event_sent = true;
 
+        // Raw ballots, not the timeout path's adjusted tally: the stream reports what
+        // players actually cast and lets FactionFiles apply its own interpretation.
+        const VoteTally stats_tally = compute_tally();
+        afstats::on_vote_ended(static_cast<uint8_t>(vote_type_to_wire(get_type())),
+                               static_cast<uint8_t>(result), stats_tally.yes, stats_tally.no,
+                               stats_tally.yes + stats_tally.no + stats_tally.remaining);
+
         for (rf::Player& player : SinglyLinkedList{rf::player_list}) {
             // Same filter as the start event: a client that never got a start
             // event must not get updates or an end event either.
@@ -334,6 +350,12 @@ public:
 protected:
     [[nodiscard]] virtual std::string get_title() const = 0;
     [[nodiscard]] virtual const VoteConfig& get_config() const = 0;
+
+    // Stats-stream only: the bare subject of the vote (a level filename, a minute
+    // count), not the decorated title. Empty when the vote has no subject.
+    [[nodiscard]] virtual std::string get_detail() const { return {}; }
+    // Stats-stream only: -1 for every vote that has no target player.
+    [[nodiscard]] virtual int get_target_player_id() const { return -1; }
 
     // The one line that describes the outcome. Broadcast as chat to legacy clients
     // and carried in the structured end event, so both see identical wording.
@@ -910,6 +932,7 @@ struct VoteMatch : public Vote
                 clear_manual_rules_override();
             if (m_gametype)
                 set_upcoming_game_type(*m_gametype, UpcomingGameTypeSelection::ExplicitRequest);
+            afstats::note_round_end_type(afstats::RoundEndType::map_change_vote);
             multi_change_level_alpine(m_level_name.c_str());
             if (m_manual_rules_override) {
                 set_manual_rules_override(std::move(*m_manual_rules_override));
@@ -917,6 +940,8 @@ struct VoteMatch : public Vote
             }
         }
     }
+
+    [[nodiscard]] std::string get_detail() const override { return m_level_name; }
 
     [[nodiscard]] const VoteConfig& get_config() const override
     {
@@ -953,6 +978,8 @@ struct VoteCancelMatch : public Vote
 
     void on_accepted() override
     {
+        // cancel_match() ends the round via load_next_level() when a match is live.
+        afstats::note_round_end_type(afstats::RoundEndType::map_change_vote);
         cancel_match();
     }
 
@@ -970,6 +997,8 @@ struct VoteKick : public Vote
     // kick itself: the outcome runs a frame later, by which time the pointer could
     // name a destroyed player. -1 means "never resolvable".
     int m_target_player_id = -1;
+
+    [[nodiscard]] int get_target_player_id() const override { return m_target_player_id; }
 
     explicit VoteKick(rf::Player* target)
         : m_target_player(target),
@@ -1039,6 +1068,7 @@ struct VoteKick : public Vote
             return;
         }
         if (rf::Player* target = rf::multi_find_player_by_id(static_cast<uint8_t>(m_target_player_id))) {
+            afstats::note_leave_reason(target, afstats::LeaveReason::vote_kicked);
             kick_player_delayed(target);
         }
     }
@@ -1093,6 +1123,8 @@ struct VoteExtend : public Vote
         // extend_round_time takes MINUTES.
         extend_round_time(m_minutes);
     }
+
+    [[nodiscard]] std::string get_detail() const override { return std::to_string(m_minutes); }
 
     [[nodiscard]] const VoteConfig& get_config() const override
     {
@@ -1168,6 +1200,7 @@ struct VoteLevel : public Vote
             set_upcoming_game_type(*m_gametype, UpcomingGameTypeSelection::ExplicitRequest);
         }
 
+        afstats::note_round_end_type(afstats::RoundEndType::map_change_vote);
         multi_change_level_alpine(m_level_name.c_str());
 
         if (m_manual_rules_override) {
@@ -1175,6 +1208,8 @@ struct VoteLevel : public Vote
             m_manual_rules_override.reset();
         }
     }
+
+    [[nodiscard]] std::string get_detail() const override { return m_level_name; }
 
     [[nodiscard]] const VoteConfig& get_config() const override
     {
@@ -1272,6 +1307,7 @@ struct VoteRestart : public VoteRotation
     {
         // restart_current_level() round-trips the session override itself, so the
         // stash is not needed here — only the configured-rules reload is new.
+        afstats::note_round_end_type(afstats::RoundEndType::map_change_vote);
         if (m_preserve) {
             restart_current_level();
         }
@@ -1311,6 +1347,7 @@ struct VoteNext : public VoteRotation
     void on_accepted() override
     {
         stash_carry();
+        afstats::note_round_end_type(afstats::RoundEndType::map_change_vote);
         load_next_level();
     }
 
@@ -1345,6 +1382,7 @@ struct VoteRandom : public VoteRotation
     void on_accepted() override
     {
         stash_carry();
+        afstats::note_round_end_type(afstats::RoundEndType::map_change_vote);
         // if dynamic rotation is on, just load the next level
         g_alpine_server_config.dynamic_rotation ? load_next_level() : load_rand_level();
     }
@@ -1380,6 +1418,7 @@ struct VotePrevious : public VoteRotation
     void on_accepted() override
     {
         stash_carry();
+        afstats::note_round_end_type(afstats::RoundEndType::map_change_vote);
         load_prev_level();
     }
 

--- a/game_patch/multi/wipeout.cpp
+++ b/game_patch/multi/wipeout.cpp
@@ -10,6 +10,7 @@
 #include "server.h"
 #include "server_internal.h"
 #include "alpine_packets.h"
+#include "../fflink/afstats_events.h"
 #include "../hud/hud.h"
 #include "../sound/sound.h"
 #include "../rf/multi.h"
@@ -176,6 +177,10 @@ void wipeout_on_round_begin()
 
     xlog::info("Wipeout: round {} begin, {} spawned (R {} - B {})",
                g_info.rounds_completed + 1, spawned, g_info.red_team_score, g_info.blue_team_score);
+
+    // Report the subround. Wipeout has no fixed contestant set, so empty participants
+    // means "all active players in the game".
+    afstats::on_subround_start({});
 }
 
 bool wipeout_should_end_round(rf::Player** out_winner)
@@ -223,13 +228,35 @@ void announce_round_sounds(int winner_team)
     }
 }
 
-void wipeout_on_round_end(rf::Player* /*winner*/, RoundEndReason /*reason*/)
+void wipeout_on_round_end(rf::Player* /*winner*/, RoundEndReason reason)
 {
     if (!rf::is_server) return;
 
     ++g_info.rounds_completed;
     const int winner_team = g_pending_winner_team;
     g_pending_winner_team = -1;
+
+    // Report the subround end. Wipeout is team-decided (no winner_player); a level
+    // change cancels, a real winning team completes, and -1 is a double-wipe draw.
+    afstats::SubroundResult sr_result;
+    uint8_t sr_team;
+    if (reason == RoundEndReason::LevelChange) {
+        sr_result = afstats::SubroundResult::canceled;
+        sr_team = afstats::team_none;
+    }
+    else if (winner_team == rf::TEAM_RED) {
+        sr_result = afstats::SubroundResult::completed;
+        sr_team = afstats::team_red;
+    }
+    else if (winner_team == rf::TEAM_BLUE) {
+        sr_result = afstats::SubroundResult::completed;
+        sr_team = afstats::team_blue;
+    }
+    else { // -1: double wipe
+        sr_result = afstats::SubroundResult::draw;
+        sr_team = afstats::team_none;
+    }
+    afstats::on_subround_end(sr_result, sr_team, nullptr);
 
     if (winner_team == rf::TEAM_RED) ++g_info.red_team_score;
     else if (winner_team == rf::TEAM_BLUE) ++g_info.blue_team_score;

--- a/game_patch/object/item.cpp
+++ b/game_patch/object/item.cpp
@@ -5,6 +5,7 @@
 #include <xlog/xlog.h>
 #include <algorithm>
 #include <string_view>
+#include "../fflink/afstats_events.h"
 #include "../rf/event.h"
 #include "../rf/item.h"
 #include "../rf/misc.h"
@@ -117,6 +118,11 @@ static void on_item_picked_up(rf::Item* item, rf::Entity* entity)
     }
     else {
         mutators_on_item_picked_up(item, entity);
+        if (rf::is_server) {
+            // respawn_time_ms is the per-instance value and already reflects any
+            // server-config or mutator override; negative means it never respawns.
+            afstats::on_item_pickup(rf::player_from_entity_handle(entity->handle), item->info_index, item->pos, item->respawn_time_ms);
+        }
     }
 }
 

--- a/game_patch/os/console.cpp
+++ b/game_patch/os/console.cpp
@@ -151,6 +151,66 @@ void console_register_command(rf::console::Command* cmd)
         assert(false);
 }
 
+// The stock console writer (rf::console::output at 0x00509EC0) splits `text` on
+// '\n' and strncpy's each segment into a fixed 0x105-byte ring slot with no length
+// check: bytes [0, 0x101) hold the segment text plus its NUL and [0x101, 0x105) hold
+// the color dword, across 500 slots based at 0x01754730. A single newline-delimited
+// segment longer than the slot runs past its entry and corrupts adjacent .data
+// globals (the same hazard noted at game_patch/multi/mutators.cpp:44). Clamp each
+// segment defensively before it reaches the stock writer.
+constexpr size_t k_console_slot_size = 0x105;   // ring slot stride (261 bytes)
+constexpr size_t k_console_max_segment = 255;   // conservative cap on text bytes before the NUL
+static_assert(k_console_max_segment + 1 <= k_console_slot_size - 4,
+              "clamped segment + NUL must fit before the color dword in a ring slot");
+
+// True if any '\n'-delimited segment of `text` exceeds the slot cap. `text` must be non-null.
+static bool console_line_exceeds_slot(const char* text)
+{
+    size_t seg_len = 0;
+    for (const char* p = text; *p; ++p) {
+        if (*p == '\n') {
+            seg_len = 0;
+        }
+        else if (++seg_len > k_console_max_segment) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Rebuild `text` with every '\n'-delimited segment capped at k_console_max_segment
+// bytes, backing off to a UTF-8 code-point boundary so a multibyte sequence is never
+// split (same boundary rule as fflink::sanitize_for_log). Line structure is preserved:
+// each segment is capped independently and the '\n' separators are kept.
+static std::string console_clamp_segments(const char* text)
+{
+    std::string out;
+    const char* seg = text;
+    for (;;) {
+        const char* nl = seg;
+        while (*nl && *nl != '\n') {
+            ++nl;
+        }
+        size_t seg_len = static_cast<size_t>(nl - seg);
+        if (seg_len > k_console_max_segment) {
+            size_t cut = k_console_max_segment;
+            // If the cap lands in the middle of a UTF-8 sequence, step back over the
+            // continuation bytes (10xxxxxx) so the partial code point is dropped whole.
+            while (cut > 0 && (static_cast<unsigned char>(seg[cut]) & 0xC0) == 0x80) {
+                --cut;
+            }
+            seg_len = cut;
+        }
+        out.append(seg, seg_len);
+        if (*nl == '\0') {
+            break;
+        }
+        out.push_back('\n');
+        seg = nl + 1;
+    }
+    return out;
+}
+
 static FunHook<void(const char*, const rf::Color*)> console_output_hook{
     &rf::console::output,
     [](const char* text, const rf::Color* color) {
@@ -158,7 +218,17 @@ static FunHook<void(const char*, const rf::Color*)> console_output_hook{
             win32_console_output(text, color);
         }
         else {
-            console_output_hook.call_target(text, color);
+            // Clamp over-long lines before they reach the stock ring-buffer writer,
+            // which has no length check (see console_clamp_segments). Inert on the
+            // happy path: with no over-long segment we pass the original pointer
+            // through unchanged with zero allocation. Null text delegates as-is.
+            const char* out_text = text;
+            std::string clamped;
+            if (text && console_line_exceeds_slot(text)) {
+                clamped = console_clamp_segments(text);
+                out_text = clamped.c_str();
+            }
+            console_output_hook.call_target(out_text, color);
         }
         std::string_view text_view{text};
         console_log_write(text_view);

--- a/game_patch/os/console.cpp
+++ b/game_patch/os/console.cpp
@@ -230,7 +230,7 @@ static FunHook<void(const char*, const rf::Color*)> console_output_hook{
             }
             console_output_hook.call_target(out_text, color);
         }
-        std::string_view text_view{text};
+        std::string_view text_view = text ? std::string_view{text} : std::string_view{};
         console_log_write(text_view);
         if (g_console_log.is_open() && (text_view.empty() || (text_view.back() != '\n' && text_view.back() != '\r'))) {
             g_console_log.put('\n');

--- a/game_patch/rf/player/player.h
+++ b/game_patch/rf/player/player.h
@@ -100,6 +100,12 @@ struct PlayerAdditionalData {
     std::optional<int64_t> last_spray_ms{};
     // Floor rate limit for af_req_stats_pssk so a client cannot flood the handler.
     std::optional<int64_t> last_pssk_ms{};
+    // Separate floor for the af_req_stats_pssk rejection warns, so a rejected packet
+    // never eats the delivery budget above.
+    std::optional<int64_t> last_pssk_warn_ms{};
+    // Floor rate limit for stats player_rename emission so a client cannot turn a rename
+    // flood into an event flood. Uses the afstats uptime clock (resets per session).
+    std::optional<int64_t> last_rename_ms{};
 
     struct {
         std::map<std::string, PlayerNetGameSaveData> saves{};

--- a/game_patch/rf/player/player.h
+++ b/game_patch/rf/player/player.h
@@ -43,6 +43,39 @@ struct ClientVersionInfoProfile {
     bool is_d3d11 = false;
 };
 
+// Per-round, per-player counters for the FactionFiles event stream. Reset at
+// every round start; serialized whole into the round_end / player_leave summary
+// block. Score and caps are read live from the engine at summary time instead of
+// being duplicated here.
+struct AfstatsRoundCounters {
+    uint32_t kills = 0;
+    uint32_t deaths = 0;
+    uint32_t assists = 0;
+    uint32_t caps = 0;
+    uint32_t shots_fired = 0;
+    uint32_t shots_hit = 0;
+    float damage_dealt = 0.0f;
+    float damage_taken = 0.0f;
+    uint32_t highest_streak = 0;
+    uint32_t current_streak = 0;
+    int64_t time_played_ms = 0;
+    int64_t time_spectating_ms = 0;
+    int64_t time_idle_ms = 0;
+    int64_t ping_sum = 0;
+    uint32_t ping_samples = 0;
+
+    // Bookkeeping. The time accumulators above are advanced by sampling the
+    // player's state on the sender pulse, so these mark where the last sample
+    // landed rather than when a state was entered.
+    int64_t present_since_ms = 0;
+    int64_t last_sample_ms = 0;
+    int64_t last_ping_sample_ms = 0;
+
+    // Idle is a computed predicate with no stored engine state, so the sampler
+    // edge-detects it against this.
+    bool was_idle = false;
+};
+
 struct PlayerAdditionalData {
     // Shared variables.
     bool is_bot = false;
@@ -65,6 +98,8 @@ struct PlayerAdditionalData {
     std::optional<int64_t> last_hit_sound_ms{};
     std::optional<int64_t> last_critical_sound_ms{};
     std::optional<int64_t> last_spray_ms{};
+    // Floor rate limit for af_req_stats_pssk so a client cannot flood the handler.
+    std::optional<int64_t> last_pssk_ms{};
 
     struct {
         std::map<std::string, PlayerNetGameSaveData> saves{};
@@ -132,6 +167,17 @@ struct PlayerAdditionalData {
     // FactionFiles player stats session key delivered by the client on join.
     // Never persisted, unique per join.
     std::optional<std::string> afstats_pssk{};
+
+    // How the event stream refers to this player: a UPSSK minted by this server at
+    // join, replaced by the PSSK above once the client delivers one. Empty for
+    // browsers and whenever stats reporting is off.
+    std::string afstats_key{};
+    AfstatsRoundCounters afstats_round{};
+
+    // Value from the stats stream's leave-reason registry. First writer wins, so a
+    // specific reason (banned, vote_kicked) survives the generic kick that follows
+    // it; -1 means the player vanished without any local notice, i.e. a timeout.
+    int8_t afstats_leave_reason = -1;
 };
 static_assert(alignof(PlayerAdditionalData) == 0x8);
 #endif

--- a/game_patch/rf/player/player.h
+++ b/game_patch/rf/player/player.h
@@ -128,6 +128,10 @@ struct PlayerAdditionalData {
     // Throttles the spawn-decline notices in multi_spawn_player_server_side
     // (Alpine restriction, anti-cheat, match in progress, bot, respawn delay).
     rf::Timestamp spawn_decline_msg_timer{};
+
+    // FactionFiles player stats session key delivered by the client on join.
+    // Never persisted, unique per join.
+    std::optional<std::string> afstats_pssk{};
 };
 static_assert(alignof(PlayerAdditionalData) == 0x8);
 #endif

--- a/launcher/LauncherApp.cpp
+++ b/launcher/LauncherApp.cpp
@@ -222,6 +222,10 @@ bool LauncherApp::ValidateAFLinkToken(const std::string& fflink_token)
             xlog::warn("Invalid FactionFiles link token detected.");
             game_config.fflink_token = "";
             game_config.fflink_username = "";
+            // The token is no longer valid (account unlinked or token revoked FactionFiles-side),
+            // so reset the stats identity as well: the next stats-server join mints a fresh,
+            // unlinked PSK rather than reusing the one tied to the now-detached account.
+            game_config.afstats_psk = "";
             game_config.save();
             fflink_token_is_invalid = true;
             return 0;

--- a/launcher/OptionsDlg.cpp
+++ b/launcher/OptionsDlg.cpp
@@ -220,6 +220,11 @@ void OptionsDlg::OnBnClickedFFLinkAction()
         if (result == IDYES) {
             m_conf.fflink_username = "";
             m_conf.fflink_token = "";
+            // Reset the stats identity too: unlinking means the next stats-server join
+            // mints a fresh, unlinked PSK instead of continuing to present the one that
+            // FactionFiles associated with this account. It only becomes account-linked
+            // again if the player deliberately re-links later.
+            m_conf.afstats_psk = "";
             m_conf.save();
             UpdateFFLinkStatus();
 


### PR DESCRIPTION
- Add FactionFiles-supported multiplayer statistics tracking
  - Dedicated servers with a configured `fflink_gsk` report a gameplay event stream to FactionFiles
  - Clients joining a stats-enabled server obtain a stats session key from FactionFiles and deliver it to the server, attributing their stats to their linked FactionFiles account (or anonymously to their game installation when unlinked)
  - Players on legacy clients can still join and play normally, and are tracked per-connection without cross-session identity
  - `afstats_status` console command shows the local stats session state
  - `sv_afstats_trace` console command logs outgoing report batches (with session keys redacted) on dedicated servers