### PR TITLE
Particle emitter fixes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -193,6 +193,8 @@ Version 1.4.0 (Lupin): Not yet released
 - Fix plankton bunching into a small drifting cluster instead of distributing around the camera in some liquids
 - Fix links targeting Alpine objects breaking when a group containing them is imported in the level editor
 - Fix several multiplayer accuracy calculation issues
+- Fix `Active Distance` on level-placed particle emitters being ignored when hosting a listen server
+- Fix particle emitters created from `emitters.tbl` templates inheriting uninitialized UID and `Active Distance` values that could make their particles silently fail to spawn in rare cases
 
 [@is-this-c](https://github.com/is-this-c)
 - Clear cached server config output after a shuffle of a server's rotation

--- a/game_patch/multi/jetpack.cpp
+++ b/game_patch/multi/jetpack.cpp
@@ -186,13 +186,6 @@ bool jetpack_exhaust_emitter_type(rf::ParticleEmitterType* out)
     // The steam is decoration only; it must never damage an entity that flies
     // through it. Everything else the table asks for is kept.
     out->particle_flags2 &= ~PARTICLE_FLAG2_DAMAGES;
-
-    // The emitters.tbl parser leaves uid and active_distance untouched, so tbl
-    // templates carry whatever the allocation happened to contain. Both are
-    // copied into the emitter and a stray pair would let the AF active distance
-    // cull silently drop the exhaust.
-    out->uid = 0;
-    out->active_distance = 0.0f;
     return true;
 }
 

--- a/game_patch/object/particle.cpp
+++ b/game_patch/object/particle.cpp
@@ -60,7 +60,7 @@ CallHook<void(int, rf::ParticleCreateInfo&, rf::GRoom*, rf::Vector3*, int, rf::P
     [](int pool_id, rf::ParticleCreateInfo& pci, rf::GRoom* room, rf::Vector3 *a4, int parent_obj, rf::Particle** result, rf::ParticleEmitter* emitter) {
         // On AF levels, create particles only within the active distance
         // Applies to particle emitters placed in level file
-        if (!rf::is_server && !rf::is_dedicated_server && af_rfl_version(rf::level.version) && parent_obj == 0 && emitter->uid > 0) {
+        if (!rf::is_dedicated_server && af_rfl_version(rf::level.version) && parent_obj == 0 && emitter->uid > 0) {
             rf::Vector3 camera_pos = rf::camera_get_pos(rf::local_player->cam);
             float dist = camera_pos.distance_to(emitter->pos);
             if (emitter->active_distance != 0.0f && emitter->active_distance <= dist) {
@@ -135,6 +135,19 @@ CallHook<void(rf::ParticleEmitter*, const rf::Vector3*, const rf::Vector3*, floa
     },
 };
 
+FunHook<void()> particle_emitter_types_load_hook{
+    0x00496DF0,
+    []() {
+        particle_emitter_types_load_hook.call_target();
+        // The tbl parser never writes uid or active_distance, so templates keep
+        // heap garbage that the level-emitter checks can mistake for real values
+        for (int i = 0; i < rf::g_num_particle_emitter_types; ++i) {
+            rf::g_particle_emitter_types[i]->uid = 0;
+            rf::g_particle_emitter_types[i]->active_distance = 0.0f;
+        }
+    },
+};
+
 void particle_do_patch()
 {
     // Make particle emitters placed in AF level files respect the Active Distance param
@@ -164,4 +177,7 @@ void particle_do_patch()
 
     // Improve sorting in respect to the liquid surface
     particle_emitter_g_portal_object_add_hook.install();
+
+    // Zero garbage uid/active_distance left in emitters.tbl templates by the parser
+    particle_emitter_types_load_hook.install();
 }

--- a/game_patch/rf/particle_emitter.h
+++ b/game_patch/rf/particle_emitter.h
@@ -237,9 +237,9 @@ static auto& particle_create = addr_as_ref<void(int pool_id, ParticleCreateInfo&
     GRoom* room, Vector3* a4, int parent_obj, Particle** result,
     ParticleEmitter* emitter)>(0x00496840);
 
-// Array of particle emitter type template pointers loaded from emitters.tbl
-// (64 slots; live count is at 0x007BD99C, checked by particle_emitter_type_lookup)
+// Array of particle emitter type template pointers loaded from emitters.tbl (64 slots)
 static auto& g_particle_emitter_types = addr_as_ref<ParticleEmitterType*[64]>(0x007B2770);
+static auto& g_num_particle_emitter_types = addr_as_ref<int>(0x007BD99C);
 static auto& particle_emitter_type_lookup = addr_as_ref<int(const char* name)>(0x00497550);
 
 static auto& particle_emitter_create = addr_as_ref<ParticleEmitter*(


### PR DESCRIPTION
- Fix `Active Distance` on level-placed particle emitters being ignored when hosting a listen server
- Fix particle emitters created from `emitters.tbl` templates inheriting uninitialized UID and `Active Distance` values that could make their particles silently fail to spawn in rare cases

Fixes #248